### PR TITLE
V0.5

### DIFF
--- a/API_TESTS/API_TESTS.cpp
+++ b/API_TESTS/API_TESTS.cpp
@@ -1,0 +1,16 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace APITESTS
+{
+	TEST_CLASS(APITESTS)
+	{
+	public:
+		
+		TEST_METHOD(TestMethod1)
+		{
+		}
+	};
+}

--- a/API_TESTS/API_TESTS.vcxproj
+++ b/API_TESTS/API_TESTS.vcxproj
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>18.0</VCProjectVersion>
+    <ProjectGuid>{A6886362-A0EE-4A35-8582-85B34E4D5248}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>APITESTS</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="API_TESTS.cpp" />
+    <ClCompile Include="CompileTest.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TypedD3D\TypedD3D12.vcxproj">
+      <Project>{4c07b140-d4bd-40d4-be41-18e6aa4d78ef}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/API_TESTS/API_TESTS.vcxproj.filters
+++ b/API_TESTS/API_TESTS.vcxproj.filters
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="API_TESTS.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CompileTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/API_TESTS/CompileTest.cpp
+++ b/API_TESTS/CompileTest.cpp
@@ -11,33 +11,32 @@ using namespace TypedD3D;
 
 static void ContainersTest()
 {
-	static_assert(IUnknownWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<WeakWrapper<Untagged<ID3D11Device>>>);
+	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<Untagged<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<Untagged<ID3D11Device>>, true>>);
 
-	static_assert(IUnknownWeakWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWeakWrapper<WeakWrapper<Untagged<ID3D11Device>>>);
+	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<Untagged<ID3D11Device>>, false>>);
+	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<Untagged<ID3D11Device>>, true>>);
 
-	static_assert(IUnknownWrapper<StrongWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<StrongWrapper<Untagged<ID3D11Device>>>);
+	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<Untagged<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<Untagged<ID3D11Device>>, true>>);
 
-	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(std::constructible_from<StrongWrapper<Untagged<ID3D11Device>>, WeakWrapper<Untagged<ID3D11Device>>>);
+	static_assert(std::constructible_from<WeakWrapper<Untagged<ID3D11Device>>, StrongWrapper<Untagged<ID3D11Device>>>);
 
-	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device5>>>);
-	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device5>>>);
+	static_assert(std::constructible_from<StrongWrapper<Untagged<ID3D11Device>>, WeakWrapper<Untagged<ID3D11Device5>>>);
+	static_assert(std::constructible_from<WeakWrapper<Untagged<ID3D11Device>>, StrongWrapper<Untagged<ID3D11Device5>>>);
 
 
 	ID3D11Device5* raw;
-
-	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak = raw;
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak2 = weak;
+	WeakWrapper<Untagged<ID3D11Device5>> weak = raw;
+	WeakWrapper<Untagged<ID3D11Device>> weak2 = weak;
 	weak2 = weak;
 	weak = Cast<ID3D11Device5>(weak2);
-	const WeakWrapper<UntaggedTraits<ID3D11Device>>& weak3 = weak;
-	const WeakWrapper<UntaggedTraits<ID3D11Device>>& weak4 = weak2;
+	const WeakWrapper<Untagged<ID3D11Device>>& weak3 = weak;
+	const WeakWrapper<Untagged<ID3D11Device>>& weak4 = weak2;
 	weak = raw;
 	weak = Cast<ID3D11Device5>(raw);
 	weak2 = raw;
@@ -81,12 +80,12 @@ static void ContainersTest()
 	weak3->CheckCounterInfo();
 	(*weak3).CheckCounterInfo();
 
-	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong = raw;
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong2 = strong;
+	StrongWrapper<Untagged<ID3D11Device5>> strong = raw;
+	StrongWrapper<Untagged<ID3D11Device>> strong2 = strong;
 	strong2 = strong;
 	strong = Cast<ID3D11Device5>(strong2);
-	const StrongWrapper<UntaggedTraits<ID3D11Device>>& strong3 = strong;
-	const StrongWrapper<UntaggedTraits<ID3D11Device>>& strong4 = strong2;
+	const StrongWrapper<Untagged<ID3D11Device>>& strong3 = strong;
+	const StrongWrapper<Untagged<ID3D11Device>>& strong4 = strong2;
 	strong = raw;
 	strong = Cast<ID3D11Device5>(raw);
 	strong2 = raw;
@@ -132,16 +131,16 @@ static void ContainersTest()
 	strong2 = weak;
 	strong2 = weak2;
 
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak5 = strong;
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak6 = strong2;
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong5 = weak;
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong6 = weak2;
+	WeakWrapper<Untagged<ID3D11Device>> weak5 = strong;
+	WeakWrapper<Untagged<ID3D11Device>> weak6 = strong2;
+	StrongWrapper<Untagged<ID3D11Device>> strong5 = weak;
+	StrongWrapper<Untagged<ID3D11Device>> strong6 = weak2;
 
-	Array<WeakWrapper<UntaggedTraits<ID3D11Device5>>, 2> weakArr = { raw, raw };
-	Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2> weakArr2 = { weakArr[0], raw };
+	Array<WeakWrapper<Untagged<ID3D11Device5>>, 2> weakArr = { raw, raw };
+	Array<WeakWrapper<Untagged<ID3D11Device>>, 2> weakArr2 = { weakArr[0], raw };
 	weakArr[0] = Cast<ID3D11Device5>(weakArr[1]);
-	const Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr3 = weak;
-	Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr4 = weakArr2;
+	const Array<WeakWrapper<Untagged<ID3D11Device>>, 2>& weakArr3 = weak;
+	Array<WeakWrapper<Untagged<ID3D11Device>>, 2>& weakArr4 = weakArr2;
 	weakArr[0] = raw;
 	weakArr[0] = Cast<ID3D11Device5>(raw);
 	weakArr2[0] = raw;
@@ -191,11 +190,11 @@ static void ContainersTest()
 	weakArr3[0]->CheckCounterInfo();
 	(*weakArr3[0]).CheckCounterInfo();
 
-	Array<StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> strongArr = { raw, raw };
-	Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2> strongArr2 = { strongArr[0], strongArr[1] };
+	Array<StrongWrapper<Untagged<ID3D11Device5>>, 2> strongArr = { raw, raw };
+	Array<StrongWrapper<Untagged<ID3D11Device>>, 2> strongArr2 = { strongArr[0], strongArr[1] };
 	strongArr[0] = Cast<ID3D11Device5>(strongArr[1]);
-	const Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr3 = strong;
-	Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr4 = strongArr2;
+	const Array<StrongWrapper<Untagged<ID3D11Device>>, 2>& strongArr3 = strong;
+	Array<StrongWrapper<Untagged<ID3D11Device>>, 2>& strongArr4 = strongArr2;
 	Array strongArr5{ strong, strong };
 	Array strongArr6{ strongArr[0], strong };
 	strongArr[0] = raw;
@@ -252,12 +251,12 @@ static void ContainersTest()
 	weak2 = std::move(weakArr)[0];
 	weakArr[0] = Cast<ID3D11Device5>(weak2);
 	weakArr[0] = std::move(Cast<ID3D11Device5>(weak2));
-	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak7 = weakArr[0];
-	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak8 = std::move(weakArr)[0];
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak9 = weakArr[0];
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak10 = std::move(weakArr)[0];
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak11 = weakArr2[0];
-	WeakWrapper<UntaggedTraits<ID3D11Device>> weak12 = std::move(weakArr2)[0];
+	WeakWrapper<Untagged<ID3D11Device5>> weak7 = weakArr[0];
+	WeakWrapper<Untagged<ID3D11Device5>> weak8 = std::move(weakArr)[0];
+	WeakWrapper<Untagged<ID3D11Device>> weak9 = weakArr[0];
+	WeakWrapper<Untagged<ID3D11Device>> weak10 = std::move(weakArr)[0];
+	WeakWrapper<Untagged<ID3D11Device>> weak11 = weakArr2[0];
+	WeakWrapper<Untagged<ID3D11Device>> weak12 = std::move(weakArr2)[0];
 
 	strong = strongArr[0];
 	strong = std::move(strongArr)[0];
@@ -268,12 +267,12 @@ static void ContainersTest()
 	strong2 = std::move(strongArr)[0];
 	strongArr[0] = Cast<ID3D11Device5>(strong2);
 	strongArr[0] = std::move(Cast<ID3D11Device5>(strong2));
-	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong7 = strongArr[0];
-	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong8 = std::move(strongArr)[0];
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong9 = strongArr[0];
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong10 = std::move(strongArr)[0];
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong11 = strongArr2[0];
-	StrongWrapper<UntaggedTraits<ID3D11Device>> strong12 = std::move(strongArr2)[0];
+	StrongWrapper<Untagged<ID3D11Device5>> strong7 = strongArr[0];
+	StrongWrapper<Untagged<ID3D11Device5>> strong8 = std::move(strongArr)[0];
+	StrongWrapper<Untagged<ID3D11Device>> strong9 = strongArr[0];
+	StrongWrapper<Untagged<ID3D11Device>> strong10 = std::move(strongArr)[0];
+	StrongWrapper<Untagged<ID3D11Device>> strong11 = strongArr2[0];
+	StrongWrapper<Untagged<ID3D11Device>> strong12 = std::move(strongArr2)[0];
 
 	strongArr[0] = weakArr[0];
 	weakArr[0] = strongArr[0];
@@ -284,7 +283,7 @@ static void ContainersTest()
 	strong == weak;
 	weak == strong;
 
-	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : strongArr)
+	for(StrongWrapper<Untagged<ID3D11Device5>> values : strongArr)
 	{
 
 	}
@@ -296,8 +295,8 @@ static void ContainersTest()
 
 	Span s = strongArr;
 	Span s2 = s;
-	Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s3 = strongArr;
-	Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s4 = s2;
+	Span<const StrongWrapper<Untagged<ID3D11Device5>>, 2> s3 = strongArr;
+	Span<const StrongWrapper<Untagged<ID3D11Device5>>, 2> s4 = s2;
 	Span s5{ s2.begin(), s2.end() };
 	Span s6{ s2.begin(), s2.size() };
 	s = s2;
@@ -306,9 +305,9 @@ static void ContainersTest()
 	s3 = s4;
 	s3 = strongArr;
 
-	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s7 = strongArr;
-	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s8 = s7;
-	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s9 = s2;
+	Span<StrongWrapper<Untagged<ID3D11Device5>>> s7 = strongArr;
+	Span<StrongWrapper<Untagged<ID3D11Device5>>> s8 = s7;
+	Span<StrongWrapper<Untagged<ID3D11Device5>>> s9 = s2;
 
 	Vector v{ strong, strong };
 	Vector v2{ strongArr[0], strong };
@@ -321,7 +320,7 @@ static void ContainersTest()
 	v.pop_back();
 
 
-	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : s)
+	for(StrongWrapper<Untagged<ID3D11Device5>> values : s)
 	{
 
 	}
@@ -331,7 +330,7 @@ static void ContainersTest()
 
 	}
 
-	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : v)
+	for(StrongWrapper<Untagged<ID3D11Device5>> values : v)
 	{
 
 	}
@@ -341,8 +340,8 @@ static void ContainersTest()
 
 	}
 
-	auto SpanInput = [](Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>>) {};
-	auto SpanInput2 = [](Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>>) {};
+	auto SpanInput = [](Span<StrongWrapper<Untagged<ID3D11Device5>>>) {};
+	auto SpanInput2 = [](Span<const StrongWrapper<Untagged<ID3D11Device5>>>) {};
 	SpanInput(strongArr);
 	SpanInput2(strongArr);
 	SpanInput(s);

--- a/API_TESTS/CompileTest.cpp
+++ b/API_TESTS/CompileTest.cpp
@@ -1,0 +1,281 @@
+#include "pch.h"
+#include <d3d11_4.h>
+#include <concepts>
+import TypedD3D.Containers;
+import TypedD3D11;
+
+using namespace TypedD3D;
+
+static void ContainersTest()
+{
+	static_assert(IUnknownWrapperTest<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(IUnknownWrapperTest<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapperTest<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+
+	static_assert(IUnknownWeakWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+
+	static_assert(IUnknownWrapperTest<StrongWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(IUnknownWrapperTest<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapperTest<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+
+	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device>>>);
+
+	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device5>>>);
+	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device5>>>);
+
+
+	ID3D11Device5* raw;
+
+	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak = raw;
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak2 = weak;
+	weak2 = weak;
+	weak = Cast<ID3D11Device5>(weak2);
+	const WeakWrapper<UntaggedTraits<ID3D11Device>>& weak3 = weak;
+	const WeakWrapper<UntaggedTraits<ID3D11Device>>& weak4 = weak2;
+	weak = raw;
+	weak = Cast<ID3D11Device5>(raw);
+	weak2 = raw;
+
+	///Shouldn't compile
+	//weak3 = raw;
+	//weak4 = raw;
+
+	weak == weak2;
+	weak3 == weak4;
+	weak == raw;
+	weak2 == raw;
+	weak2 == weak;
+	raw == weak;
+	raw == weak2;
+	weak == nullptr;
+	nullptr == weak;
+	weak2 == nullptr;
+	nullptr == weak;
+
+	weak.Get();
+	weak.Acquire();
+	weak.Release();
+
+	weak.Attach(nullptr);
+	weak.Attach(raw);
+	weak.Detach();
+	weak2.Attach(raw);
+
+	weak3.Get();
+	weak3.Acquire();
+	weak3.Release();
+
+	///Shouldn't compile
+	//weak3.Attach(nullptr);
+	//weak3.Attach(raw);
+	//weak3.Detach();
+
+	weak2->CheckCounterInfo();
+	(*weak2).CheckCounterInfo();
+	weak3->CheckCounterInfo();
+	(*weak3).CheckCounterInfo();
+
+	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong = raw;
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong2 = strong;
+	strong2 = strong;
+	strong = Cast<ID3D11Device5>(strong2);
+	const StrongWrapper<UntaggedTraits<ID3D11Device>>& strong3 = strong;
+	const StrongWrapper<UntaggedTraits<ID3D11Device>>& strong4 = strong2;
+	strong = raw;
+	strong = Cast<ID3D11Device5>(raw);
+	strong2 = raw;
+
+	///Shouldn't compile
+	//strong3 = raw;
+	//strong3 = strong2;
+	//strong4 = raw;
+
+	strong == strong2;
+	strong3 == strong4;
+	strong == raw;
+	strong2 == raw;
+	strong2 == strong;
+	raw == strong;
+	raw == strong2;
+	strong == nullptr;
+	nullptr == strong;
+	strong2 == nullptr;
+	nullptr == strong;
+
+	strong.Get();
+
+	strong.Attach(nullptr);
+	strong.Attach(raw);
+	strong.Detach();
+	strong2.Attach(raw);
+
+	strong3.Get();
+
+	///Shouldn't compile
+	//strong3.Attach(nullptr);
+	//strong3.Attach(raw);
+	//strong3.Detach();
+
+	strong2->CheckCounterInfo();
+	(*strong2).CheckCounterInfo();
+	strong3->CheckCounterInfo();
+	(*strong3).CheckCounterInfo();
+
+	weak2 = strong;
+	weak2 = strong2;
+	strong2 = weak;
+	strong2 = weak2;
+
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak5 = strong;
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak6 = strong2;
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong5 = weak;
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong6 = weak2;
+
+	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device5>>, 2> weakArr = { raw, raw };
+	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2> weakArr2 = { weakArr[0], raw };
+	weakArr[0] = Cast<ID3D11Device5>(weakArr[1]);
+	const TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr3 = weak;
+	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr4 = weakArr2;
+	weakArr[0] = raw;
+	weakArr[0] = Cast<ID3D11Device5>(raw);
+	weakArr2[0] = raw;
+
+	///Shouldn't compile
+	//weakArr3[0] = raw;
+	//weakArr3[0] = weakArr2[0];
+
+	weakArr[0] == weakArr2[0];
+	weakArr[0] == raw;
+	weakArr2[0] == raw;
+	weakArr2[0] == weakArr[0];
+	raw == weakArr[0];
+	raw == weakArr2[0];
+	weakArr[0] == nullptr;
+	nullptr == weakArr[0];
+	weakArr2[0] == nullptr;
+	nullptr == weakArr[0];
+
+	weakArr3[0] == weakArr[0];
+	weakArr3[0] == raw;
+	weakArr3[0] == nullptr;
+	weakArr[0] == weakArr3[0];
+	raw == weakArr3[0];
+	nullptr == weakArr3[0];
+
+	weakArr[0].Get();
+	weakArr[0].Acquire();
+	weakArr[0].Release();
+
+	weakArr[0].Attach(nullptr);
+	weakArr[0].Attach(raw);
+	weakArr[0].Detach();
+	weakArr2[0].Attach(raw);
+
+	weakArr3[0].Get();
+	weakArr3[0].Acquire();
+	weakArr3[0].Release();
+
+	///Shouldn't compile
+	//weakArr3[0].Attach(nullptr);
+	//weakArr3[0].Attach(raw);
+	//weakArr3[0].Detach();
+
+	weakArr2[0]->CheckCounterInfo();
+	(*weakArr2[0]).CheckCounterInfo();
+	weakArr3[0]->CheckCounterInfo();
+	(*weakArr3[0]).CheckCounterInfo();
+
+	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> strongArr = { raw, raw };
+	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2> strongArr2 = { strongArr[0], strongArr[1] };
+	strongArr[0] = Cast<ID3D11Device5>(strongArr[1]);
+	const TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr3 = strong;
+	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr4 = strongArr2;
+	strongArr[0] = raw;
+	strongArr[0] = Cast<ID3D11Device5>(raw);
+	strongArr2[0] = raw;
+
+	///Shouldn't compile
+	//strongArr3[0] = raw;
+	//strongArr3[0] = strongArr2[0];
+
+	strongArr[0] == strongArr2[0];
+	strongArr[0] == raw;
+	strongArr2[0] == raw;
+	strongArr2[0] == strongArr[0];
+	raw == strongArr[0];
+	raw == strongArr2[0];
+	strongArr[0] == nullptr;
+	nullptr == strongArr[0];
+	strongArr2[0] == nullptr;
+	nullptr == strongArr[0];
+
+	strongArr3[0] == strongArr[0];
+	strongArr3[0] == raw;
+	strongArr3[0] == nullptr;
+	strongArr[0] == strongArr3[0];
+	raw == strongArr3[0];
+	nullptr == strongArr3[0];
+
+	strongArr[0].Get();
+
+	strongArr[0].Attach(nullptr);
+	strongArr[0].Attach(raw);
+	strongArr[0].Detach();
+	strongArr2[0].Attach(raw);
+
+	strongArr3[0].Get();
+
+	///Shouldn't compile
+	//strongArr3[0].Attach(nullptr);
+	//strongArr3[0].Attach(raw);
+	//strongArr3[0].Detach();
+
+	strongArr2[0]->CheckCounterInfo();
+	(*strongArr2[0]).CheckCounterInfo();
+	strongArr3[0]->CheckCounterInfo();
+	(*strongArr3[0]).CheckCounterInfo();
+
+	weak = weakArr[0];
+	weak = std::move(weakArr)[0];
+	weakArr[0] = weak;
+	weakArr[0] = std::move(weak);
+
+	weak2 = weakArr[0];
+	weak2 = std::move(weakArr)[0];
+	weakArr[0] = Cast<ID3D11Device5>(weak2);
+	weakArr[0] = std::move(Cast<ID3D11Device5>(weak2));
+	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak7 = weakArr[0];
+	WeakWrapper<UntaggedTraits<ID3D11Device5>> weak8 = std::move(weakArr)[0];
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak9 = weakArr[0];
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak10 = std::move(weakArr)[0];
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak11 = weakArr2[0];
+	WeakWrapper<UntaggedTraits<ID3D11Device>> weak12 = std::move(weakArr2)[0];
+
+	strong = strongArr[0];
+	strong = std::move(strongArr)[0];
+	strongArr[0] = strong;
+	strongArr[0] = std::move(strong);
+
+	strong2 = strongArr[0];
+	strong2 = std::move(strongArr)[0];
+	strongArr[0] = Cast<ID3D11Device5>(strong2);
+	strongArr[0] = std::move(Cast<ID3D11Device5>(strong2));
+	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong7 = strongArr[0];
+	StrongWrapper<UntaggedTraits<ID3D11Device5>> strong8 = std::move(strongArr)[0];
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong9 = strongArr[0];
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong10 = std::move(strongArr)[0];
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong11 = strongArr2[0];
+	StrongWrapper<UntaggedTraits<ID3D11Device>> strong12 = std::move(strongArr2)[0];
+
+	strongArr[0] = weakArr[0];
+	weakArr[0] = strongArr[0];
+	strongArr[0] = std::move(weakArr)[0];
+	weakArr[0] = std::move(strongArr)[0];
+	weakArr[0] == strongArr[0];
+
+	strong == weak;
+	weak == strong;
+}

--- a/API_TESTS/CompileTest.cpp
+++ b/API_TESTS/CompileTest.cpp
@@ -1,24 +1,27 @@
 #include "pch.h"
 #include <d3d11_4.h>
 #include <concepts>
+#include <d3d12.h>
+
 import TypedD3D.Shared;
 import TypedD3D11;
+import TypedD3D12;
 
 using namespace TypedD3D;
 
 static void ContainersTest()
 {
 	static_assert(IUnknownWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
 	static_assert(IUnknownWeakWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWeakWrapper<ElementReference<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
 	static_assert(IUnknownWrapper<StrongWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapper<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapper<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReference<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
 	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device>>>);
 	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device>>>);
@@ -337,4 +340,26 @@ static void ContainersTest()
 	{
 
 	}
+
+	auto SpanInput = [](Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>>) {};
+	auto SpanInput2 = [](Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>>) {};
+	SpanInput(strongArr);
+	SpanInput2(strongArr);
+	SpanInput(s);
+	SpanInput2(s);
+	//SpanInput(s3); //Shouldn't compile
+	SpanInput2(s3);
+	SpanInput(s5);
+	SpanInput2(s5);
+
+	Array<RTV<D3D12_CPU_DESCRIPTOR_HANDLE>, 2> cpuHandle;
+	const Array<RTV<D3D12_CPU_DESCRIPTOR_HANDLE>, 2> cpuHandle2;
+
+	auto SpanInput3 = [](Span<RTV<D3D12_CPU_DESCRIPTOR_HANDLE>>) {};
+	auto SpanInput4 = [](Span<const RTV<D3D12_CPU_DESCRIPTOR_HANDLE>>) {};
+	SpanInput3(cpuHandle);
+	SpanInput4(cpuHandle);
+
+	//SpanInput3(cpuHandle2); //shouldn't compile
+	SpanInput4(cpuHandle2);
 }

--- a/API_TESTS/CompileTest.cpp
+++ b/API_TESTS/CompileTest.cpp
@@ -1,24 +1,24 @@
 #include "pch.h"
 #include <d3d11_4.h>
 #include <concepts>
-import TypedD3D.Containers;
+import TypedD3D.Shared;
 import TypedD3D11;
 
 using namespace TypedD3D;
 
 static void ContainersTest()
 {
-	static_assert(IUnknownWrapperTest<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapperTest<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapperTest<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(IUnknownWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
 	static_assert(IUnknownWeakWrapper<WeakWrapper<UntaggedTraits<ID3D11Device>>>);
 	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, false>>);
 	static_assert(IUnknownWeakWrapper<ElementReferenceTest<WeakWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
-	static_assert(IUnknownWrapperTest<StrongWrapper<UntaggedTraits<ID3D11Device>>>);
-	static_assert(IUnknownWrapperTest<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
-	static_assert(IUnknownWrapperTest<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
+	static_assert(IUnknownWrapper<StrongWrapper<UntaggedTraits<ID3D11Device>>>);
+	static_assert(IUnknownWrapper<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, false>>);
+	static_assert(IUnknownWrapper<ElementReferenceTest<StrongWrapper<UntaggedTraits<ID3D11Device>>, true>>);
 
 	static_assert(std::constructible_from<StrongWrapper<UntaggedTraits<ID3D11Device>>, WeakWrapper<UntaggedTraits<ID3D11Device>>>);
 	static_assert(std::constructible_from<WeakWrapper<UntaggedTraits<ID3D11Device>>, StrongWrapper<UntaggedTraits<ID3D11Device>>>);
@@ -134,11 +134,11 @@ static void ContainersTest()
 	StrongWrapper<UntaggedTraits<ID3D11Device>> strong5 = weak;
 	StrongWrapper<UntaggedTraits<ID3D11Device>> strong6 = weak2;
 
-	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device5>>, 2> weakArr = { raw, raw };
-	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2> weakArr2 = { weakArr[0], raw };
+	Array<WeakWrapper<UntaggedTraits<ID3D11Device5>>, 2> weakArr = { raw, raw };
+	Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2> weakArr2 = { weakArr[0], raw };
 	weakArr[0] = Cast<ID3D11Device5>(weakArr[1]);
-	const TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr3 = weak;
-	TestArray<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr4 = weakArr2;
+	const Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr3 = weak;
+	Array<WeakWrapper<UntaggedTraits<ID3D11Device>>, 2>& weakArr4 = weakArr2;
 	weakArr[0] = raw;
 	weakArr[0] = Cast<ID3D11Device5>(raw);
 	weakArr2[0] = raw;
@@ -188,13 +188,13 @@ static void ContainersTest()
 	weakArr3[0]->CheckCounterInfo();
 	(*weakArr3[0]).CheckCounterInfo();
 
-	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> strongArr = { raw, raw };
-	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2> strongArr2 = { strongArr[0], strongArr[1] };
+	Array<StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> strongArr = { raw, raw };
+	Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2> strongArr2 = { strongArr[0], strongArr[1] };
 	strongArr[0] = Cast<ID3D11Device5>(strongArr[1]);
-	const TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr3 = strong;
-	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr4 = strongArr2;
-	TestArray strongArr5{ strong, strong };
-	TestArray strongArr6{ strongArr[0], strong };
+	const Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr3 = strong;
+	Array<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr4 = strongArr2;
+	Array strongArr5{ strong, strong };
+	Array strongArr6{ strongArr[0], strong };
 	strongArr[0] = raw;
 	strongArr[0] = Cast<ID3D11Device5>(raw);
 	strongArr2[0] = raw;
@@ -291,25 +291,25 @@ static void ContainersTest()
 
 	}
 
-	TestSpan s = strongArr;
-	TestSpan s2 = s;
-	TestSpan<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s3 = strongArr;
-	TestSpan<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s4 = s2;
-	TestSpan s5{ s2.begin(), s2.end() };
-	TestSpan s6{ s2.begin(), s2.size() };
+	Span s = strongArr;
+	Span s2 = s;
+	Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s3 = strongArr;
+	Span<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s4 = s2;
+	Span s5{ s2.begin(), s2.end() };
+	Span s6{ s2.begin(), s2.size() };
 	s = s2;
 	s = strongArr;
 	s3 = s;
 	s3 = s4;
 	s3 = strongArr;
 
-	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s7 = strongArr;
-	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s8 = s7;
-	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s9 = s2;
+	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s7 = strongArr;
+	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s8 = s7;
+	Span<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s9 = s2;
 
-	TestVector v{ strong, strong };
-	TestVector v2{ strongArr[0], strong };
-	TestVector v3{ strong, strongArr[0] };
+	Vector v{ strong, strong };
+	Vector v2{ strongArr[0], strong };
+	Vector v3{ strong, strongArr[0] };
 
 	v.empty();
 	v.size();

--- a/API_TESTS/CompileTest.cpp
+++ b/API_TESTS/CompileTest.cpp
@@ -193,6 +193,8 @@ static void ContainersTest()
 	strongArr[0] = Cast<ID3D11Device5>(strongArr[1]);
 	const TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr3 = strong;
 	TestArray<StrongWrapper<UntaggedTraits<ID3D11Device>>, 2>& strongArr4 = strongArr2;
+	TestArray strongArr5{ strong, strong };
+	TestArray strongArr6{ strongArr[0], strong };
 	strongArr[0] = raw;
 	strongArr[0] = Cast<ID3D11Device5>(raw);
 	strongArr2[0] = raw;
@@ -278,4 +280,61 @@ static void ContainersTest()
 
 	strong == weak;
 	weak == strong;
+
+	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : strongArr)
+	{
+
+	}
+
+	for(auto values : strongArr)
+	{
+
+	}
+
+	TestSpan s = strongArr;
+	TestSpan s2 = s;
+	TestSpan<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s3 = strongArr;
+	TestSpan<const StrongWrapper<UntaggedTraits<ID3D11Device5>>, 2> s4 = s2;
+	TestSpan s5{ s2.begin(), s2.end() };
+	TestSpan s6{ s2.begin(), s2.size() };
+	s = s2;
+	s = strongArr;
+	s3 = s;
+	s3 = s4;
+	s3 = strongArr;
+
+	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s7 = strongArr;
+	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s8 = s7;
+	TestSpan<StrongWrapper<UntaggedTraits<ID3D11Device5>>> s9 = s2;
+
+	TestVector v{ strong, strong };
+	TestVector v2{ strongArr[0], strong };
+	TestVector v3{ strong, strongArr[0] };
+
+	v.empty();
+	v.size();
+	s.size();
+	v.push_back(nullptr);
+	v.pop_back();
+
+
+	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : s)
+	{
+
+	}
+
+	for(auto values : s)
+	{
+
+	}
+
+	for(StrongWrapper<UntaggedTraits<ID3D11Device5>> values : v)
+	{
+
+	}
+
+	for(auto values : v)
+	{
+
+	}
 }

--- a/API_TESTS/pch.cpp
+++ b/API_TESTS/pch.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to the pre-compiled header
+
+#include "pch.h"
+
+// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/API_TESTS/pch.h
+++ b/API_TESTS/pch.h
@@ -1,0 +1,12 @@
+// pch.h: This is a precompiled header file.
+// Files listed below are compiled only once, improving build performance for future builds.
+// This also affects IntelliSense performance, including code completion and many code browsing features.
+// However, files listed here are ALL re-compiled if any one of them is updated between builds.
+// Do not add files here that you will be updating frequently as this negates the performance advantage.
+
+#ifndef PCH_H
+#define PCH_H
+
+// add headers that you want to pre-compile here
+
+#endif //PCH_H

--- a/README.md
+++ b/README.md
@@ -6,74 +6,77 @@
 In order to build, you must pull with submodules included.
 
 # TypedD3D
-TypedD3D is a C++ wrapper library for DirectX family related of APIs that is meant to provide stronger typing (D3D12), and a API the reflects more modern practices. This means removing out params, make non-optional pointer params be references etc. 
+TypedD3D is a C++ wrapper library for DirectX family related of APIs that is meant to provide stronger typing (D3D12), and a API the reflects more modern practices. This means removing out params, make non-optional pointer params be marked as such etc. 
 
 The aim is to put no extra memory overhead for each class and introduce little to no performance overhead to each function so it is as if you are writing raw DirectX code with extra type safety and modern practices. 
 
-All wrapper classes whose class inherits from IUnknown is wrapped around a ComPtr and acts as closely as to one, meaning you can using .Get() to get the pointer to the underlying object, while operator->() has been overloaded to expose the libraries' modern API instead of the old.
+All wrapper classes whose class inherits from IUnknown is wrapped around a smart pointer which exposes the libraries' modern API through `operator->()` and `operator*()`, while still being able to access the classic library's API through getting the raw pointer through `.Get()`.
 
 # API Usage
-The libraries' wrapper interface are exposed in a very simple way, by replacing ComPtr\<> with TypedD3D::Wrapper\<>. You might get some broken code as I delibrately don't expose operator&() and GetAddressOf() related functions as the library should work fine without them when updating your codebase. 
+The libraries' wrapper interface are exposed in a very simple way, by replacing ComPtr\<> with TypedD3D::Wrapper\<>. You might get some broken code as I delibrately don't expose operator&() and GetAddressOf() related functions as the library should work fine without them when updating your codebase. Where you do require those operations, I've provided a `OutPtr` type which can slot in anywhere a `T**` takes place
 
-There are however, 3 ways to refer to the same class:  
-- TypedD3D::Wrapper\<ID3D12Device> *(Suggested)*
-- TypedD3D::D3D12::Device_t\<ID3D12Device> *(Maybe for template programming)*
-- TypedD3D::D3D12::Device *(Old way, explicit to the library's names)*
-  
+I provide 2 smart pointers:
+- TypedD3D::Wrapper: Takes strong ownership, which will call `AddRef()` and `Release()`
+- TypedD3D::WrapperView: Takes weak ownership, which doesn't call `AddRef()` and `Release()`
+
 Casting to more derived versions of a class becomes more familiar too with TypedD3D::Cast\<ID3D12Device5>(device).
-  
+
+The library also provides a specialized `Span`, `Array` and `Vector` containers so that the object representation is compatible with the raw APIs, meaning calling `Vector.data()` will return a `T**` and not a `Wrapper<T>*` while providing proxy types so that you can still access them as if they were wrappers. They only accept wrapper types as their parameters which is used to provide type safe APIs where `span` types were expected.
+
 ## DX12 specific API
 DX12 has extra wrapper interfaces to help tag their specific types. They are:
 
-### Direct\<>
+### Direct\<> \\ DirectView\<>
 Compatible with any class that takes with D3D12_COMMAND_LIST_TYPE to initialize</br>
 **Eg:** Direct\<ID3D12CommandList>
 
-### Compute\<>
+### Compute\<> \\ ComputeView\<>
 Compatible with any class that takes with D3D12_COMMAND_LIST_TYPE to initialize and ID3D12PipelineState</br>
 **Eg:** Compute\<ID3D12PipelineState>
 
-### Bundle\<>
+### Bundle\<> \\ BundleView\<>
 Compatible ID3D12CommandList and it's derived classes and ID3D12CommandAllocator </br>
 **Eg:** Bundle\<ID3D12CommandList>
 
-### Copy\<>
+### Copy\<> \\ CopyView\<>
 Compatible with any class that takes with D3D12_COMMAND_LIST_TYPE to initialize </br>
 **Eg:** Copy\<ID3D12CommandList>
 ### CBV_SRV_UAV\<>
 Compatible with ID3D12DescriptorHeap, D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE </br>
 **Eg:** CBV_SRV_UAV\<ID3D12DescriptorHeap>
 
-### Sampler\<>
+### Sampler\<> \\ SamplerView\<>
 Compatible with ID3D12DescriptorHeap, D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE </br>
 **Eg:** Sampler\<ID3D12DescriptorHeap>
 
-### RTV\<>
+### RTV\<> \\ RTVView\<>
 Compatible with ID3D12DescriptorHeap, D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE </br>
 **Eg:** RTV\<ID3D12DescriptorHeap>
 
-### DSV\<>
+### DSV\<> \\ DSVView\<>
 Compatible with ID3D12DescriptorHeap, D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE </br>
 **Eg:** DSV\<ID3D12DescriptorHeap>
 
-### Graphics\<>
+### Graphics\<> \\ GraphicsView\<>
 Compatible with ID3D12PipelineState </br>
 **Eg:** Graphics\<ID3D12PipelineState>
 
-### ShaderVisible\<>
+### ShaderVisible\<> \\ ShaderVisibleView\<>
 Compatible with CBV_SRV_UAV and Sampler compatible classes </br>
 **Eg:** ShaderVisible\<Sampler\<ID3D12DescriptorHeap>>
 
 Various interfaces like the command lists and command queues only work when they have the same type, so I provide tagged wrappers for interfaces like those. Command lists also have their interfaces restricted based on what kind of command list was created based on [microsoft's document](https://docs.microsoft.com/en-us/windows/win32/direct3d12/recording-command-lists-and-bundles#command-list-api-restrictions), so they no longer have to constantly be referred which commands are available for what type of list.
+
+View type wrappers doesn't work on types which don't derived by IUnknown, so D3D12_CPU_DESCRIPTOR_HANDLE and D3D12_GPU_DESCRIPTOR_HANDLE does not apply
   
 ## DX12 Implemented Types
 - ID3D12Device up to ID3D12Device10
 - ID3D12CommandList up to ID3D12GraphicsCommandList7
 - ID3D12CommandAllocator
 - ID3D12CommandQueue
-- ID3D12DescriptorHeap*
-- D3D12_CPU_DESCRIPTOR_HANDLE*
-- D3D12_GPU_DESCRIPTOR_HANDLE*
+- ID3D12DescriptorHeap
+- D3D12_CPU_DESCRIPTOR_HANDLE
+- D3D12_GPU_DESCRIPTOR_HANDLE
 - ID3D12PipelineState
 
 ## DX11 Implemented Types
@@ -92,3 +95,5 @@ Various interfaces like the command lists and command queues only work when they
 - IDXGIFactory up to IDXGIFactory2
 - IDXGISwapChain up to IDXGISwapChain3
 - IDXGIAdapter
+
+If a type is not implemented, you can still update types which derive from IDXGIObject, ID3D12Object, or D3D11DeviceChild, and the smart pointers will act just like ComPtr, where `operator->()` will continue to expose the classic API.

--- a/TESTS/APICompileTest.cpp
+++ b/TESTS/APICompileTest.cpp
@@ -1,13 +1,12 @@
-#include <wrl/client.h>
+
 #include <d3d11_4.h>
 #include <dxgi1_6.h>
 
 import TypedD3D11;
-import TypedD3D12;
-import TypedDXGI;
+//import TypedD3D12;
+//import TypedDXGI;
 
 using namespace TypedD3D;
-using namespace Microsoft::WRL;
 
 void D3D11()
 {
@@ -31,51 +30,47 @@ void D3D11()
 	Wrapper<ID3D11DepthStencilView> dsv = device->CreateDepthStencilView(resource, nullptr);
 	{
 		ID3DBlob* temp = nullptr;
-		Wrapper<ID3D11InputLayout> layout = device->CreateInputLayout(D3D11_INPUT_ELEMENT_DESC{}, *temp);
-		layout = device->CreateInputLayout(std::span<D3D11_INPUT_ELEMENT_DESC>{}, *temp);
-		layout = device->CreateInputLayout(D3D11_INPUT_ELEMENT_DESC{}, nullptr, {});
-		layout = device->CreateInputLayout(std::span<D3D11_INPUT_ELEMENT_DESC>{}, nullptr, {});
+		Wrapper<ID3D11InputLayout> layout = device->CreateInputLayout(D3D11_INPUT_ELEMENT_DESC{}, temp);
+		layout = device->CreateInputLayout(std::span<D3D11_INPUT_ELEMENT_DESC>{}, temp);
+		layout = device->CreateInputLayout(D3D11_INPUT_ELEMENT_DESC{}, temp->GetBufferPointer(), {});
+		layout = device->CreateInputLayout(std::span<D3D11_INPUT_ELEMENT_DESC>{}, temp->GetBufferPointer(), {});
 
-		Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*temp, nullptr);
-		vs = device->CreateVertexShader(nullptr, {}, nullptr);
+		Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(temp, nullptr);
+		vs = device->CreateVertexShader(temp->GetBufferPointer(), {}, nullptr);
 
-		Wrapper<ID3D11GeometryShader> gs = device->CreateGeometryShader(*temp, nullptr);
-		gs = device->CreateGeometryShader(nullptr, {}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(*temp, D3D11_SO_DECLARATION_ENTRY{}, UINT{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(*temp, std::span<D3D11_SO_DECLARATION_ENTRY>{}, UINT{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(*temp, D3D11_SO_DECLARATION_ENTRY{}, std::span<UINT>{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(*temp, std::span<D3D11_SO_DECLARATION_ENTRY>{}, std::span<UINT>{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(nullptr, {}, D3D11_SO_DECLARATION_ENTRY{}, UINT{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(nullptr, {}, std::span<D3D11_SO_DECLARATION_ENTRY>{}, UINT{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(nullptr, {}, D3D11_SO_DECLARATION_ENTRY{}, std::span<UINT>{}, UINT{}, nullptr);
-		gs = device->CreateGeometryShaderWithStreamOutput(nullptr, {}, std::span<D3D11_SO_DECLARATION_ENTRY>{}, std::span<UINT>{}, UINT{}, nullptr);
+		Wrapper<ID3D11GeometryShader> gs = device->CreateGeometryShader(temp, nullptr);
+		gs = device->CreateGeometryShader(temp->GetBufferPointer(), {}, nullptr);
+		gs = device->CreateGeometryShaderWithStreamOutput(temp, std::span<D3D11_SO_DECLARATION_ENTRY>{}, std::span<UINT>{}, UINT{}, nullptr);
+		gs = device->CreateGeometryShaderWithStreamOutput(temp->GetBufferPointer(), {}, std::span<D3D11_SO_DECLARATION_ENTRY>{}, std::span<UINT>{}, UINT{}, nullptr);
 
-		Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*temp, nullptr);
-		ps = device->CreatePixelShader(nullptr, {}, nullptr);
+		Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(temp, nullptr);
+		ps = device->CreatePixelShader(temp->GetBufferPointer(), {}, nullptr);
 
-		Wrapper<ID3D11HullShader> hs = device->CreateHullShader(*temp, nullptr);
-		hs = device->CreateHullShader(nullptr, {}, nullptr);
+		Wrapper<ID3D11HullShader> hs = device->CreateHullShader(temp, nullptr);
+		hs = device->CreateHullShader(temp->GetBufferPointer(), {}, nullptr);
 
-		Wrapper<ID3D11DomainShader> ds = device->CreateDomainShader(*temp, nullptr);
-		ds = device->CreateDomainShader(nullptr, {}, nullptr);
+		Wrapper<ID3D11DomainShader> ds = device->CreateDomainShader(temp, nullptr);
+		ds = device->CreateDomainShader(temp->GetBufferPointer(), {}, nullptr);
 
-		Wrapper<ID3D11ComputeShader> cs = device->CreateComputeShader(*temp, nullptr);
-		cs = device->CreateComputeShader(nullptr, {}, nullptr);
+		Wrapper<ID3D11ComputeShader> cs = device->CreateComputeShader(temp, nullptr);
+		cs = device->CreateComputeShader(temp->GetBufferPointer(), {}, nullptr);
 	}
-	ComPtr<ID3D11ClassLinkage> classLink = device->CreateClassLinkage();
+	Wrapper<ID3D11ClassLinkage> classLink = device->CreateClassLinkage();
 	Wrapper<ID3D11BlendState> blendState = device->CreateBlendState({});
 	Wrapper<ID3D11DepthStencilState> depthStencilState = device->CreateDepthStencilState({});
 	Wrapper<ID3D11RasterizerState> rasterizerState = device->CreateRasterizerState({});
 	Wrapper<ID3D11SamplerState> samplerState = device->CreateSamplerState({});
-	ComPtr<ID3D11Query> query = device->CreateQuery({});
-	ComPtr<ID3D11Predicate> predicate = device->CreatePredicate({});
-	ComPtr<ID3D11Counter> counter = device->CreateCounter({});
+	Wrapper<ID3D11Query> query = device->CreateQuery({});
+	Wrapper<ID3D11Predicate> predicate = device->CreatePredicate({});
+	Wrapper<ID3D11Counter> counter = device->CreateCounter({});
 	Wrapper<ID3D11DeviceContext> deferredContext = device->CreateDeferredContext({});
 	HRESULT hr = device->OpenSharedResource({}, {}, {});
 	D3D11_FORMAT_SUPPORT formatSupport = device->CheckFormatSupport({});
 	UINT multisampleQuality = device->CheckMultisampleQualityLevels({}, {});
 	D3D11_COUNTER_INFO counterInfo = device->CheckCounterInfo();
-	hr = device->CheckCounter(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+	D3D11_COUNTER_TYPE counterType;
+	UINT activeCounters;
+	hr = device->CheckCounter({}, counterType, activeCounters, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 	{
 		auto f = device->CheckFeatureSupport<D3D11_FEATURE_THREADING>();
 		auto f1 = device->CheckFeatureSupport<D3D11_FEATURE_DOUBLES>();
@@ -115,88 +110,100 @@ void D3D11()
 
 	{
 		deviceContext->VSSetShader({}, nullptr);
-		deviceContext->VSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->VSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->VSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->VSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->VSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->VSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->VSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->VSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->VSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->VSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->VSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->VSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->VSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11VertexShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->VSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11VertexShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->VSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11VertexShader>, UINT> shader2 = deviceContext->VSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->VSGetShaderResources(0, 0);
 	}
 	{
 		deviceContext->PSSetShader({}, nullptr);
-		deviceContext->PSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->PSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->PSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->PSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->PSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->PSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->PSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->PSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->PSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->PSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->PSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->PSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->PSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11PixelShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->PSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11PixelShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->PSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11PixelShader>, UINT> shader2 = deviceContext->PSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->PSGetShaderResources(0, 0);
 	}
 	{
 		deviceContext->GSSetShader({}, nullptr);
-		deviceContext->GSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->GSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->GSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->GSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->GSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->GSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->GSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->GSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->GSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->GSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->GSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->GSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->GSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11GeometryShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->GSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11GeometryShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->GSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11GeometryShader>, UINT> shader2 = deviceContext->GSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->GSGetShaderResources(0, 0);
 	}
 	{
 		deviceContext->HSSetShader({}, nullptr);
-		deviceContext->HSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->HSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->HSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->HSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->HSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->HSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->HSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->HSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->HSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->HSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->HSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->HSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->HSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11HullShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->HSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11HullShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->HSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11HullShader>, UINT> shader2 = deviceContext->HSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->HSGetShaderResources(0, 0);
 	}
 	{
 		deviceContext->DSSetShader({}, nullptr);
-		deviceContext->DSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->DSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->DSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->DSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->DSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->DSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->DSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->DSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->DSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->DSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->DSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->DSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->DSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11DomainShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->DSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11DomainShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->DSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11DomainShader>, UINT> shader2 = deviceContext->DSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->DSGetShaderResources(0, 0);
 	}
 	{
 		deviceContext->CSSetShader({}, nullptr);
-		deviceContext->CSSetShader({}, std::span<ID3D11ClassInstance*>{});
-		deviceContext->CSSetConstantBuffers({}, Span<Wrapper<ID3D11Buffer>>{});
+		deviceContext->CSSetShader({}, Span<WrapperView<ID3D11ClassInstance>>{});
+		deviceContext->CSSetConstantBuffers({}, Span<WrapperView<ID3D11Buffer>>{});
 		deviceContext->CSSetConstantBuffers({}, Wrapper<ID3D11Buffer>{});
 		deviceContext->CSSetSamplers({}, Wrapper<ID3D11SamplerState>{});
-		deviceContext->CSSetSamplers({}, Span<Wrapper<ID3D11SamplerState>>{});
+		deviceContext->CSSetSamplers({}, Span<WrapperView<ID3D11SamplerState>>{});
 		deviceContext->CSSetShaderResources({}, Wrapper<ID3D11ShaderResourceView>{});
-		deviceContext->CSSetShaderResources({}, Span<Wrapper<ID3D11ShaderResourceView>>{});
+		deviceContext->CSSetShaderResources({}, Span<WrapperView<ID3D11ShaderResourceView>>{});
 		deviceContext->CSSetUnorderedAccessViews({}, nullptr, {});
 		deviceContext->CSSetUnorderedAccessViews({}, D3D11::CSSetUnorderedAccessViewsData{ {}, nullptr, nullptr });
 		Vector<Wrapper<ID3D11Buffer>> buffers = deviceContext->CSGetConstantBuffers(0, 0);
 		Vector<Wrapper<ID3D11SamplerState>> samplers = deviceContext->CSGetSamplers(0, 0);
-		std::pair<Wrapper<ID3D11ComputeShader>, std::vector<ComPtr<ID3D11ClassInstance>>> shader = deviceContext->CSGetShader(0);
+		UINT numInstances = 256;
+		std::pair<Wrapper<ID3D11ComputeShader>, Vector<Wrapper<ID3D11ClassInstance>>> shader = deviceContext->CSGetShader(numInstances);
+		std::pair<Wrapper<ID3D11ComputeShader>, UINT> shader2 = deviceContext->CSGetShader({});
 		Vector<Wrapper<ID3D11ShaderResourceView>> resources = deviceContext->CSGetShaderResources(0, 0);
 		Vector<Wrapper<ID3D11UnorderedAccessView>> uavs = deviceContext->CSGetUnorderedAccessViews(0, 0);
 	}
@@ -264,8 +271,8 @@ void D3D11()
 	deviceContext->IAGetPrimitiveTopology();
 	Wrapper<ID3D11InputLayout> layout = deviceContext->IAGetInputLayout();
 
-	//deviceContext->OMSetRenderTargets(nullptr, nullptr);
-	deviceContext->OMSetRenderTargets(Span<Wrapper<ID3D11RenderTargetView>>{}, nullptr);
+	deviceContext->OMSetRenderTargets(nullptr, nullptr);
+	deviceContext->OMSetRenderTargets(Span<WrapperView<ID3D11RenderTargetView>>{}, nullptr);
 	deviceContext->OMSetRenderTargetsAndUnorderedAccessViews({}, nullptr, {}, {}, nullptr);
 	deviceContext->OMSetBlendState({}, {}, {});
 	deviceContext->OMSetDepthStencilState({}, {});

--- a/TESTS/APICompileTest.cpp
+++ b/TESTS/APICompileTest.cpp
@@ -264,7 +264,7 @@ void D3D11()
 	deviceContext->IAGetPrimitiveTopology();
 	Wrapper<ID3D11InputLayout> layout = deviceContext->IAGetInputLayout();
 
-	deviceContext->OMSetRenderTargets(nullptr, nullptr);
+	//deviceContext->OMSetRenderTargets(nullptr, nullptr);
 	deviceContext->OMSetRenderTargets(Span<Wrapper<ID3D11RenderTargetView>>{}, nullptr);
 	deviceContext->OMSetRenderTargetsAndUnorderedAccessViews({}, nullptr, {}, {}, nullptr);
 	deviceContext->OMSetBlendState({}, {}, {});

--- a/TESTS/APICompileTest.cpp
+++ b/TESTS/APICompileTest.cpp
@@ -219,12 +219,12 @@ void D3D11()
 	deviceContext->Dispatch({}, {}, {});
 	deviceContext->DispatchIndirect(buffer, {});
 	{
-		deviceContext->Begin(*predicate.Get());
-		deviceContext->End(*predicate.Get());
-		deviceContext->GetData(*predicate.Get(), {});
+		deviceContext->Begin(predicate);
+		deviceContext->End(predicate);
+		deviceContext->GetData(predicate, {});
 	}
 	{
-		deviceContext->SetPredication(predicate.Get(), {});
+		deviceContext->SetPredication(predicate, {});
 		deviceContext->GetPredication();
 	}
 
@@ -237,7 +237,7 @@ void D3D11()
 
 	ID3D11CommandList* cl = nullptr;
 	deviceContext->FinishCommandList({});
-	deviceContext->ExecuteCommandList(*cl, {});
+	deviceContext->ExecuteCommandList(cl, {});
 
 	deviceContext->GenerateMips(srv);
 	deviceContext->SetResourceMinLOD(resource, {});

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -14,9 +14,9 @@
 #include <dxgidebug.h>
 #endif
 import TypedD3D11;
-import TypedDXGI;
-import TypedD3D.Containers;
-import xk.Exceptions;
+//import TypedDXGI;
+import TypedD3D.Shared;
+//import xk.Exceptions;
 #undef CreateWindow
 namespace
 {
@@ -38,187 +38,200 @@ static void CreateWindow();
 
 using Microsoft::WRL::ComPtr;
 
+
 void D3D11HelloWorld()
 {
-	CreateWindow();
+	auto [device, deviceContext] = TypedD3D::D3D11::CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, D3D_FEATURE_LEVEL_12_0, D3D11_SDK_VERSION);
 
-	TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-	D3D_FEATURE_LEVEL levels = D3D_FEATURE_LEVEL_12_0;
-	
-	auto [device, deviceContext] = TypedD3D11::CreateDevice<TypedD3D::Wrapper<ID3D11Device>, TypedD3D::Wrapper<ID3D11DeviceContext>>(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_DEBUG, std::span(&levels, 1), D3D11_SDK_VERSION);
-	TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
-		device,
-		handle,
-		DXGI_SWAP_CHAIN_DESC1
-		{
-			.Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-			.SampleDesc
-			{
-				.Count = 1
-			},
-			.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
-			.BufferCount = 2,
-			.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
-			.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
-		},
-		nullptr,
-		nullptr);
-	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice{ device.Get() };
+	D3D11_BUFFER_DESC desc{};
+	desc.ByteWidth = 32;
+	desc.Usage = D3D11_USAGE_DYNAMIC;
+	desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
-	TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr{ testDevice, testDevice };
-	const auto& arr2 = arr;
-	//testDevice->CheckCounterInfo();
-	//arr[0]->CheckCounterInfo();
-	arr[0] = testDevice;
-	arr[0] = nullptr;
-	arr[0] = std::move(testDevice);
-	testDevice = std::move(arr)[0];
-	testDevice = std::move(arr2)[1];
-
-	//testDevice = arr[1];
-	//arr[1] = nullptr;
-	//arr[0] == arr[1];
-
-	//arr2[0] = arr[1];
-	//arr2[0] == arr[0];
-	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
-
-	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
-	//ComPtr<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device.AsComPtr());
-	{
-		//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr2{ std::move(arr) };
-		//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice5 = TypedD3D::Cast<ID3D11Device5>(testDevice);
-		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>::interface_type<int>>);
-		static_assert(!std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, ID3D11Device*>);
-		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device5>::Interface<int>, ID3D11Device5*>);
-		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice2{ device.Get() };
-		//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice4{ testDevice2 };
-		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
-		//testDevice3->QueryInterface<ID3D11Device>(nullptr);
-		//TypedD3D::Wrapper<IDXGISwapChain1> swapChain1 = swapChain;
-
-		UINT backBuffer = 0;
-		MSG msg;
+	TypedD3D::Wrapper<ID3D11Buffer> buffer = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D11Buffer>>(&ID3D11Device::CreateBuffer, device.Get(), &desc, nullptr);
+	TypedD3D::Wrapper<ID3D11Buffer> buffer2 = device->CreateBuffer(desc, nullptr);
 
 
-		TypedD3D::Wrapper<ID3D11RenderTargetView> rtv;
-		rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
+	//CreateWindow();
+
+	//TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
+	//D3D_FEATURE_LEVEL levels = D3D_FEATURE_LEVEL_12_0;
+	//
+	//auto [device, deviceContext] = TypedD3D11::CreateDevice<TypedD3D::Wrapper<ID3D11Device>, TypedD3D::Wrapper<ID3D11DeviceContext>>(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_DEBUG, std::span(&levels, 1), D3D11_SDK_VERSION);
+	//TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
+	//	device,
+	//	handle,
+	//	DXGI_SWAP_CHAIN_DESC1
+	//	{
+	//		.Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+	//		.SampleDesc
+	//		{
+	//			.Count = 1
+	//		},
+	//		.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
+	//		.BufferCount = 2,
+	//		.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+	//		.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
+	//	},
+	//	nullptr,
+	//	nullptr);
+	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice{ device.Get() };
+
+	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
+	//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr{ testDevice, testDevice };
+	//const auto& arr2 = arr;
+	////testDevice->CheckCounterInfo();
+	////arr[0]->CheckCounterInfo();
+	//arr[0] = testDevice;
+	//arr[0] = nullptr;
+	//arr[0] = std::move(testDevice);
+	//testDevice = std::move(arr)[0];
+	//testDevice = std::move(arr2)[1];
+
+	////testDevice = arr[1];
+	////arr[1] = nullptr;
+	////arr[0] == arr[1];
+
+	////arr2[0] = arr[1];
+	////arr2[0] == arr[0];
+	////TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
+
+	////TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
+	////ComPtr<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device.AsComPtr());
+	//{
+	//	//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr2{ std::move(arr) };
+	//	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice5 = TypedD3D::Cast<ID3D11Device5>(testDevice);
+	//	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>::interface_type<int>>);
+	//	static_assert(!std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, ID3D11Device*>);
+	//	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device5>::Interface<int>, ID3D11Device5*>);
+	//	TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice2{ device.Get() };
+	//	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice4{ testDevice2 };
+	//	TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
+	//	//testDevice3->QueryInterface<ID3D11Device>(nullptr);
+	//	//TypedD3D::Wrapper<IDXGISwapChain1> swapChain1 = swapChain;
+
+	//	UINT backBuffer = 0;
+	//	MSG msg;
 
 
-		ComPtr<ID3DBlob> vertexBlob;
-		ComPtr<ID3DBlob> errorBlob;
-		HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
-		if(FAILED(hr))
-		{
-			char* message = static_cast<char*>(errorBlob->GetBufferPointer());
-			std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
-			MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
-			MessageBox(handle, messageT.get(), L"Error", MB_OK);
-			return;
-		}
-
-		TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*vertexBlob.Get(), nullptr);
-
-		ComPtr<ID3DBlob> pixelBlob;
-		hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
-		if(FAILED(hr))
-			return;
-
-		TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*pixelBlob.Get(), nullptr);
-
-		std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
-		{
-			D3D11_INPUT_ELEMENT_DESC
-			{
-				.SemanticName = "POSITION",
-				.SemanticIndex = 0,
-				.Format = DXGI_FORMAT_R32G32B32_FLOAT,
-				.InputSlot = 0,
-				.AlignedByteOffset = 0,
-				.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
-				.InstanceDataStepRate = 0
-			}
-		};
-
-		TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, *vertexBlob.Get());
-
-		auto vertices = std::to_array<Vertex>(
-			{
-				{ -0.5f, -0.5f, 0 },
-				{  0.0f,  0.5f, 0 },
-				{  0.5f, -0.5f, 0 },
-			});
-
-		D3D11_BUFFER_DESC desc
-		{
-			.ByteWidth = vertices.size() * sizeof(Vertex),
-			.Usage = D3D11_USAGE_DEFAULT,
-			.BindFlags = D3D11_BIND_VERTEX_BUFFER,
-			.CPUAccessFlags = 0,
-			.MiscFlags = 0,
-			.StructureByteStride = sizeof(Vertex)
-		};
-		D3D11_SUBRESOURCE_DATA data
-		{
-			.pSysMem = vertices.data(),
-			.SysMemPitch = sizeof(Vertex),
-			.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
-		};
-		TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
-		D3D11_VIEWPORT viewport
-		{
-			.TopLeftX = 0,
-			.TopLeftY = 0,
-			.Width = windowWidth,
-			.Height = windowHeight,
-			.MinDepth = 0,
-			.MaxDepth = 1
-		};
-
-		D3D11_RECT rect
-		{
-			.left = 0,
-			.top = 0,
-			.right = static_cast<LONG>(windowWidth),
-			.bottom = static_cast<LONG>(windowHeight)
-		};
-		while(true)
-		{
-			if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-			{
-				TranslateMessage(&msg);
-				DispatchMessageW(&msg);
-
-				if(msg.message == WM_QUIT)
-					break;
-			}
-			else
-			{
-				deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
-				deviceContext->OMSetRenderTargets(rtv, nullptr);
-
-				deviceContext->IASetInputLayout(inputLayout);
-				deviceContext->RSSetViewports(std::span(&viewport, 1));
-				deviceContext->RSSetScissorRects(std::span(&rect, 1));
-				deviceContext->VSSetShader(vs, {});
-				deviceContext->PSSetShader(ps, {});
-				deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-				deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
-				deviceContext->Draw(3, 0);
-
-				swapChain->Present(1, 0);
-			}
-		}
-
-		assert(swapChain != nullptr);
-		assert(factory != nullptr);
+	//	TypedD3D::Wrapper<ID3D11RenderTargetView> rtv;
+	//	rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
 
 
-		UnregisterClassW(windowName, nullptr);
-	}
-	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Debug>::Interface<int>, ID3D11Debug*>);
-	debugDevice->ReportLiveDeviceObjects(D3D11_RLDO_FLAGS::D3D11_RLDO_SUMMARY | D3D11_RLDO_FLAGS::D3D11_RLDO_DETAIL | D3D11_RLDO_IGNORE_INTERNAL);
+	//	ComPtr<ID3DBlob> vertexBlob;
+	//	ComPtr<ID3DBlob> errorBlob;
+	//	HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
+	//	if(FAILED(hr))
+	//	{
+	//		char* message = static_cast<char*>(errorBlob->GetBufferPointer());
+	//		std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
+	//		MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
+	//		MessageBox(handle, messageT.get(), L"Error", MB_OK);
+	//		return;
+	//	}
+
+	//	TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*vertexBlob.Get(), nullptr);
+
+	//	ComPtr<ID3DBlob> pixelBlob;
+	//	hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
+	//	if(FAILED(hr))
+	//		return;
+
+	//	TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*pixelBlob.Get(), nullptr);
+
+	//	std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
+	//	{
+	//		D3D11_INPUT_ELEMENT_DESC
+	//		{
+	//			.SemanticName = "POSITION",
+	//			.SemanticIndex = 0,
+	//			.Format = DXGI_FORMAT_R32G32B32_FLOAT,
+	//			.InputSlot = 0,
+	//			.AlignedByteOffset = 0,
+	//			.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
+	//			.InstanceDataStepRate = 0
+	//		}
+	//	};
+
+	//	TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, *vertexBlob.Get());
+
+	//	auto vertices = std::to_array<Vertex>(
+	//		{
+	//			{ -0.5f, -0.5f, 0 },
+	//			{  0.0f,  0.5f, 0 },
+	//			{  0.5f, -0.5f, 0 },
+	//		});
+
+	//	D3D11_BUFFER_DESC desc
+	//	{
+	//		.ByteWidth = vertices.size() * sizeof(Vertex),
+	//		.Usage = D3D11_USAGE_DEFAULT,
+	//		.BindFlags = D3D11_BIND_VERTEX_BUFFER,
+	//		.CPUAccessFlags = 0,
+	//		.MiscFlags = 0,
+	//		.StructureByteStride = sizeof(Vertex)
+	//	};
+	//	D3D11_SUBRESOURCE_DATA data
+	//	{
+	//		.pSysMem = vertices.data(),
+	//		.SysMemPitch = sizeof(Vertex),
+	//		.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
+	//	};
+	//	TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
+	//	D3D11_VIEWPORT viewport
+	//	{
+	//		.TopLeftX = 0,
+	//		.TopLeftY = 0,
+	//		.Width = windowWidth,
+	//		.Height = windowHeight,
+	//		.MinDepth = 0,
+	//		.MaxDepth = 1
+	//	};
+
+	//	D3D11_RECT rect
+	//	{
+	//		.left = 0,
+	//		.top = 0,
+	//		.right = static_cast<LONG>(windowWidth),
+	//		.bottom = static_cast<LONG>(windowHeight)
+	//	};
+	//	while(true)
+	//	{
+	//		if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+	//		{
+	//			TranslateMessage(&msg);
+	//			DispatchMessageW(&msg);
+
+	//			if(msg.message == WM_QUIT)
+	//				break;
+	//		}
+	//		else
+	//		{
+	//			deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
+	//			deviceContext->OMSetRenderTargets(rtv, nullptr);
+
+	//			deviceContext->IASetInputLayout(inputLayout);
+	//			deviceContext->RSSetViewports(std::span(&viewport, 1));
+	//			deviceContext->RSSetScissorRects(std::span(&rect, 1));
+	//			deviceContext->VSSetShader(vs, {});
+	//			deviceContext->PSSetShader(ps, {});
+	//			deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	//			deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
+	//			deviceContext->Draw(3, 0);
+
+	//			swapChain->Present(1, 0);
+	//		}
+	//	}
+
+	//	assert(swapChain != nullptr);
+	//	assert(factory != nullptr);
+
+
+	//	UnregisterClassW(windowName, nullptr);
+	//}
+	//static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Debug>::Interface<int>, ID3D11Debug*>);
+	//debugDevice->ReportLiveDeviceObjects(D3D11_RLDO_FLAGS::D3D11_RLDO_SUMMARY | D3D11_RLDO_FLAGS::D3D11_RLDO_DETAIL | D3D11_RLDO_IGNORE_INTERNAL);
 }
 
 

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -66,17 +66,30 @@ void D3D11HelloWorld()
 	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice{ device.Get() };
 
 	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
+	TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr{ testDevice, testDevice };
+	//testDevice->CheckCounterInfo();
+	//arr[0]->CheckCounterInfo();
+	arr[0] = testDevice;
+	arr[0] = nullptr;
+	arr[0] = std::move(testDevice);
+	testDevice = std::move(arr)[0];
+	testDevice = arr[1];
+	arr[1] = nullptr;
+	arr[0] == arr[1];
+	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
+
 	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
 	//ComPtr<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device.AsComPtr());
 	{
+		//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr2{ std::move(arr) };
 		//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice5 = TypedD3D::Cast<ID3D11Device5>(testDevice);
 		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>::interface_type<int>>);
 		static_assert(!std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, ID3D11Device*>);
 		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device5>::Interface<int>, ID3D11Device5*>);
 		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice2{ device.Get() };
 		//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice4{ testDevice2 };
-		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
-		testDevice3->QueryInterface<ID3D11Device>(nullptr);
+		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
+		//testDevice3->QueryInterface<ID3D11Device>(nullptr);
 		//TypedD3D::Wrapper<IDXGISwapChain1> swapChain1 = swapChain;
 
 		UINT backBuffer = 0;

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -74,11 +74,13 @@ void D3D11HelloWorld()
 	arr[0] = nullptr;
 	arr[0] = std::move(testDevice);
 	testDevice = std::move(arr)[0];
-	testDevice = arr[1];
-	arr[1] = nullptr;
-	arr[0] == arr[1];
+	testDevice = std::move(arr2)[1];
 
-	arr2[0] = arr[1];
+	//testDevice = arr[1];
+	//arr[1] = nullptr;
+	//arr[0] == arr[1];
+
+	//arr2[0] = arr[1];
 	//arr2[0] == arr[0];
 	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
 

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -67,6 +67,7 @@ void D3D11HelloWorld()
 
 	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
 	TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr{ testDevice, testDevice };
+	const auto& arr2 = arr;
 	//testDevice->CheckCounterInfo();
 	//arr[0]->CheckCounterInfo();
 	arr[0] = testDevice;
@@ -76,6 +77,9 @@ void D3D11HelloWorld()
 	testDevice = arr[1];
 	arr[1] = nullptr;
 	arr[0] == arr[1];
+
+	arr2[0] = arr[1];
+	//arr2[0] == arr[0];
 	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
 
 	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -10,8 +10,12 @@
 #include <array>
 #include <iostream>
 
+#ifdef _DEBUG
+#include <dxgidebug.h>
+#endif
 import TypedD3D11;
 import TypedDXGI;
+import TypedD3D.Containers;
 import xk.Exceptions;
 #undef CreateWindow
 namespace
@@ -40,7 +44,7 @@ void D3D11HelloWorld()
 
 	TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
 	D3D_FEATURE_LEVEL levels = D3D_FEATURE_LEVEL_12_0;
-
+	
 	auto [device, deviceContext] = TypedD3D11::CreateDevice<TypedD3D::Wrapper<ID3D11Device>, TypedD3D::Wrapper<ID3D11DeviceContext>>(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_DEBUG, std::span(&levels, 1), D3D11_SDK_VERSION);
 	TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
 		device,
@@ -59,125 +63,143 @@ void D3D11HelloWorld()
 		},
 		nullptr,
 		nullptr);
+	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice{ device.Get() };
 
-	UINT backBuffer = 0;
-	MSG msg;
-
-
-	TypedD3D::Wrapper<ID3D11RenderTargetView> rtv;
-	rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
-
-
-	ComPtr<ID3DBlob> vertexBlob;
-	ComPtr<ID3DBlob> errorBlob;
-	HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
-	if(FAILED(hr))
+	TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
+	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
+	//ComPtr<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device.AsComPtr());
 	{
-		char* message = static_cast<char*>(errorBlob->GetBufferPointer());
-		std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
-		MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
-		MessageBox(handle, messageT.get(), L"Error", MB_OK);
-		return;
+		//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice5 = TypedD3D::Cast<ID3D11Device5>(testDevice);
+		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>::interface_type<int>>);
+		static_assert(!std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, ID3D11Device*>);
+		static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device5>::Interface<int>, ID3D11Device5*>);
+		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice2{ device.Get() };
+		//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice4{ testDevice2 };
+		TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
+		testDevice3->QueryInterface<ID3D11Device>(nullptr);
+		//TypedD3D::Wrapper<IDXGISwapChain1> swapChain1 = swapChain;
+
+		UINT backBuffer = 0;
+		MSG msg;
+
+
+		TypedD3D::Wrapper<ID3D11RenderTargetView> rtv;
+		rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
+
+
+		ComPtr<ID3DBlob> vertexBlob;
+		ComPtr<ID3DBlob> errorBlob;
+		HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
+		if(FAILED(hr))
+		{
+			char* message = static_cast<char*>(errorBlob->GetBufferPointer());
+			std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
+			MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
+			MessageBox(handle, messageT.get(), L"Error", MB_OK);
+			return;
+		}
+
+		TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*vertexBlob.Get(), nullptr);
+
+		ComPtr<ID3DBlob> pixelBlob;
+		hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
+		if(FAILED(hr))
+			return;
+
+		TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*pixelBlob.Get(), nullptr);
+
+		std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
+		{
+			D3D11_INPUT_ELEMENT_DESC
+			{
+				.SemanticName = "POSITION",
+				.SemanticIndex = 0,
+				.Format = DXGI_FORMAT_R32G32B32_FLOAT,
+				.InputSlot = 0,
+				.AlignedByteOffset = 0,
+				.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
+				.InstanceDataStepRate = 0
+			}
+		};
+
+		TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, *vertexBlob.Get());
+
+		auto vertices = std::to_array<Vertex>(
+			{
+				{ -0.5f, -0.5f, 0 },
+				{  0.0f,  0.5f, 0 },
+				{  0.5f, -0.5f, 0 },
+			});
+
+		D3D11_BUFFER_DESC desc
+		{
+			.ByteWidth = vertices.size() * sizeof(Vertex),
+			.Usage = D3D11_USAGE_DEFAULT,
+			.BindFlags = D3D11_BIND_VERTEX_BUFFER,
+			.CPUAccessFlags = 0,
+			.MiscFlags = 0,
+			.StructureByteStride = sizeof(Vertex)
+		};
+		D3D11_SUBRESOURCE_DATA data
+		{
+			.pSysMem = vertices.data(),
+			.SysMemPitch = sizeof(Vertex),
+			.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
+		};
+		TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
+		D3D11_VIEWPORT viewport
+		{
+			.TopLeftX = 0,
+			.TopLeftY = 0,
+			.Width = windowWidth,
+			.Height = windowHeight,
+			.MinDepth = 0,
+			.MaxDepth = 1
+		};
+
+		D3D11_RECT rect
+		{
+			.left = 0,
+			.top = 0,
+			.right = static_cast<LONG>(windowWidth),
+			.bottom = static_cast<LONG>(windowHeight)
+		};
+		while(true)
+		{
+			if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+			{
+				TranslateMessage(&msg);
+				DispatchMessageW(&msg);
+
+				if(msg.message == WM_QUIT)
+					break;
+			}
+			else
+			{
+				deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
+				deviceContext->OMSetRenderTargets(rtv, nullptr);
+
+				deviceContext->IASetInputLayout(inputLayout);
+				deviceContext->RSSetViewports(std::span(&viewport, 1));
+				deviceContext->RSSetScissorRects(std::span(&rect, 1));
+				deviceContext->VSSetShader(vs, {});
+				deviceContext->PSSetShader(ps, {});
+				deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+				deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
+				deviceContext->Draw(3, 0);
+
+				swapChain->Present(1, 0);
+			}
+		}
+
+		assert(swapChain != nullptr);
+		assert(factory != nullptr);
+
+
+		UnregisterClassW(windowName, nullptr);
 	}
-
-	TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*vertexBlob.Get(), nullptr);
-
-	ComPtr<ID3DBlob> pixelBlob;
-	hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
-	if(FAILED(hr))
-		return;
-
-	TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*pixelBlob.Get(), nullptr);
-
-	std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
-	{
-		D3D11_INPUT_ELEMENT_DESC
-		{
-			.SemanticName = "POSITION",
-			.SemanticIndex = 0,
-			.Format = DXGI_FORMAT_R32G32B32_FLOAT,
-			.InputSlot = 0,
-			.AlignedByteOffset = 0,
-			.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
-			.InstanceDataStepRate = 0
-		}
-	};
-
-	TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, *vertexBlob.Get());
-
-	auto vertices = std::to_array<Vertex>(
-		{
-			{ -0.5f, -0.5f, 0 },
-			{  0.0f,  0.5f, 0 },
-			{  0.5f, -0.5f, 0 },
-		});
-
-	D3D11_BUFFER_DESC desc
-	{
-		.ByteWidth = vertices.size() * sizeof(Vertex),
-		.Usage = D3D11_USAGE_DEFAULT,
-		.BindFlags = D3D11_BIND_VERTEX_BUFFER,
-		.CPUAccessFlags = 0,
-		.MiscFlags = 0,
-		.StructureByteStride = sizeof(Vertex)
-	};
-	D3D11_SUBRESOURCE_DATA data
-	{
-		.pSysMem = vertices.data(),
-		.SysMemPitch = sizeof(Vertex),
-		.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
-	};
-	TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
-	D3D11_VIEWPORT viewport
-	{
-		.TopLeftX = 0,
-		.TopLeftY = 0,
-		.Width = windowWidth,
-		.Height = windowHeight,
-		.MinDepth = 0,
-		.MaxDepth = 1
-	};
-
-	D3D11_RECT rect
-	{
-		.left = 0,
-		.top = 0,
-		.right = static_cast<LONG>(windowWidth),
-		.bottom = static_cast<LONG>(windowHeight)
-	};
-	while(true)
-	{
-		if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessageW(&msg);
-
-			if(msg.message == WM_QUIT)
-				break;
-		}
-		else
-		{
-			deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
-			deviceContext->OMSetRenderTargets(rtv, nullptr);
-
-			deviceContext->IASetInputLayout(inputLayout);
-			deviceContext->RSSetViewports(std::span(&viewport, 1));
-			deviceContext->RSSetScissorRects(std::span(&rect, 1));
-			deviceContext->VSSetShader(vs, {});
-			deviceContext->PSSetShader(ps, {});
-			deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-			deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
-			deviceContext->Draw(3, 0);
-
-			swapChain->Present(1, 0);
-		}
-	}
-
-	assert(swapChain != nullptr);
-	assert(factory != nullptr);
-
-
-	UnregisterClassW(windowName, nullptr);
+	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Debug>::Interface<int>, ID3D11Debug*>);
+	debugDevice->ReportLiveDeviceObjects(D3D11_RLDO_FLAGS::D3D11_RLDO_SUMMARY | D3D11_RLDO_FLAGS::D3D11_RLDO_DETAIL | D3D11_RLDO_IGNORE_INTERNAL);
 }
 
 

--- a/TESTS/D3D11HelloWorld.cpp
+++ b/TESTS/D3D11HelloWorld.cpp
@@ -1,7 +1,6 @@
 #include <Windows.h>
 #include <tuple>
 #include <d3dcompiler.h>
-#include <wrl/client.h>
 #include <span>
 #include <dxgi1_6.h>
 #include <d3d11_4.h>
@@ -9,12 +8,13 @@
 #include <cassert>
 #include <array>
 #include <iostream>
+#include <functional>
 
 #ifdef _DEBUG
 #include <dxgidebug.h>
 #endif
 import TypedD3D11;
-//import TypedDXGI;
+import TypedDXGI;
 import TypedD3D.Shared;
 //import xk.Exceptions;
 #undef CreateWindow
@@ -36,202 +36,165 @@ namespace
 static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 static void CreateWindow();
 
-using Microsoft::WRL::ComPtr;
-
-
 void D3D11HelloWorld()
 {
-	auto [device, deviceContext] = TypedD3D::D3D11::CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, D3D_FEATURE_LEVEL_12_0, D3D11_SDK_VERSION);
+	//auto [device, deviceContext] = TypedD3D::D3D11::CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, 0, D3D_FEATURE_LEVEL_12_0, D3D11_SDK_VERSION);
 
-	D3D11_BUFFER_DESC desc{};
-	desc.ByteWidth = 32;
-	desc.Usage = D3D11_USAGE_DYNAMIC;
-	desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-	desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+	//D3D11_BUFFER_DESC desc{};
+	//desc.ByteWidth = 32;
+	//desc.Usage = D3D11_USAGE_DYNAMIC;
+	//desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	//desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-	TypedD3D::Wrapper<ID3D11Buffer> buffer = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D11Buffer>>(&ID3D11Device::CreateBuffer, device.Get(), &desc, nullptr);
-	TypedD3D::Wrapper<ID3D11Buffer> buffer2 = device->CreateBuffer(desc, nullptr);
-
-
-	//CreateWindow();
-
-	//TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-	//D3D_FEATURE_LEVEL levels = D3D_FEATURE_LEVEL_12_0;
-	//
-	//auto [device, deviceContext] = TypedD3D11::CreateDevice<TypedD3D::Wrapper<ID3D11Device>, TypedD3D::Wrapper<ID3D11DeviceContext>>(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_DEBUG, std::span(&levels, 1), D3D11_SDK_VERSION);
-	//TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
-	//	device,
-	//	handle,
-	//	DXGI_SWAP_CHAIN_DESC1
-	//	{
-	//		.Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-	//		.SampleDesc
-	//		{
-	//			.Count = 1
-	//		},
-	//		.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
-	//		.BufferCount = 2,
-	//		.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
-	//		.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
-	//	},
-	//	nullptr,
-	//	nullptr);
-	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice{ device.Get() };
-
-	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
-	//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr{ testDevice, testDevice };
-	//const auto& arr2 = arr;
-	////testDevice->CheckCounterInfo();
-	////arr[0]->CheckCounterInfo();
-	//arr[0] = testDevice;
-	//arr[0] = nullptr;
-	//arr[0] = std::move(testDevice);
-	//testDevice = std::move(arr)[0];
-	//testDevice = std::move(arr2)[1];
-
-	////testDevice = arr[1];
-	////arr[1] = nullptr;
-	////arr[0] == arr[1];
-
-	////arr2[0] = arr[1];
-	////arr2[0] == arr[0];
-	////TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> fafda = std::move(arr[1]);
-
-	////TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Debug>> debugDevice = TypedD3D::Cast<ID3D11Debug>(testDevice);
-	////ComPtr<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device.AsComPtr());
-	//{
-	//	//TypedD3D::TestArray<TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>, 2> arr2{ std::move(arr) };
-	//	//TypedD3D::WeakWrapper<TypedD3D::UntaggedTraits<ID3D11Device5>> testDevice5 = TypedD3D::Cast<ID3D11Device5>(testDevice);
-	//	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>>::interface_type<int>>);
-	//	static_assert(!std::same_as<TypedD3D::UntaggedTraits<ID3D11Device>::Interface<int>, ID3D11Device*>);
-	//	static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Device5>::Interface<int>, ID3D11Device5*>);
-	//	TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice2{ device.Get() };
-	//	//TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice4{ testDevice2 };
-	//	TypedD3D::StrongWrapper<TypedD3D::UntaggedTraits<ID3D11Device>> testDevice3 = TypedD3D::Cast<ID3D11Device5>(testDevice2);
-	//	//testDevice3->QueryInterface<ID3D11Device>(nullptr);
-	//	//TypedD3D::Wrapper<IDXGISwapChain1> swapChain1 = swapChain;
-
-	//	UINT backBuffer = 0;
-	//	MSG msg;
+	//TypedD3D::Wrapper<ID3D11Buffer> buffer = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D11Buffer>>(&ID3D11Device::CreateBuffer, device.Get(), &desc, nullptr);
+	//TypedD3D::Wrapper<ID3D11Buffer> buffer2 = device->CreateBuffer(desc, nullptr);
 
 
-	//	TypedD3D::Wrapper<ID3D11RenderTargetView> rtv;
-	//	rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
+	CreateWindow();
+
+	static_assert(requires(TypedD3D::Wrapper<IDXGIFactory2> w) { { std::invoke(&CreateDXGIFactory1, __uuidof(w), TypedD3D::OutPtr{ w }) } -> std::convertible_to<HRESULT>; });
+
+	TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
+	D3D_FEATURE_LEVEL levels = D3D_FEATURE_LEVEL_12_0;
+	
+	auto [device, deviceContext] = TypedD3D11::CreateDevice<ID3D11Device, ID3D11DeviceContext>(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_DEBUG, std::span(&levels, 1), D3D11_SDK_VERSION);
+	TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
+		device,
+		handle,
+		DXGI_SWAP_CHAIN_DESC1
+		{
+			.Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+			.SampleDesc
+			{
+				.Count = 1
+			},
+			.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
+			.BufferCount = 2,
+			.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+			.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
+		},
+		nullptr,
+		nullptr);
+	TypedD3D::WrapperView<ID3D11Debug> debugDevice = TypedD3D::Cast<ID3D11Debug>(device);
+
+	{
+		UINT backBuffer = 0;
+		MSG msg;
 
 
-	//	ComPtr<ID3DBlob> vertexBlob;
-	//	ComPtr<ID3DBlob> errorBlob;
-	//	HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
-	//	if(FAILED(hr))
-	//	{
-	//		char* message = static_cast<char*>(errorBlob->GetBufferPointer());
-	//		std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
-	//		MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
-	//		MessageBox(handle, messageT.get(), L"Error", MB_OK);
-	//		return;
-	//	}
+		TypedD3D::Wrapper<ID3D11RenderTargetView> rtv = device->CreateRenderTargetView(swapChain->GetBuffer<ID3D11Resource>(0), nullptr);
 
-	//	TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(*vertexBlob.Get(), nullptr);
+		TypedD3D::Wrapper<ID3DBlob> vertexBlob;
+		TypedD3D::Wrapper<ID3DBlob> errorBlob;
+		HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, TypedD3D::OutPtr{ vertexBlob }, TypedD3D::OutPtr{ errorBlob });
+		if(FAILED(hr))
+		{
+			char* message = static_cast<char*>(errorBlob->GetBufferPointer());
+			std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
+			MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
+			MessageBox(handle, messageT.get(), L"Error", MB_OK);
+			return;
+		}
 
-	//	ComPtr<ID3DBlob> pixelBlob;
-	//	hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
-	//	if(FAILED(hr))
-	//		return;
+		TypedD3D::Wrapper<ID3D11VertexShader> vs = device->CreateVertexShader(vertexBlob, nullptr);
 
-	//	TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(*pixelBlob.Get(), nullptr);
+		TypedD3D::Wrapper<ID3DBlob> pixelBlob;
+		hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, TypedD3D::OutPtr{ pixelBlob }, TypedD3D::OutPtr{ errorBlob });
+		if(FAILED(hr))
+			return;
 
-	//	std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
-	//	{
-	//		D3D11_INPUT_ELEMENT_DESC
-	//		{
-	//			.SemanticName = "POSITION",
-	//			.SemanticIndex = 0,
-	//			.Format = DXGI_FORMAT_R32G32B32_FLOAT,
-	//			.InputSlot = 0,
-	//			.AlignedByteOffset = 0,
-	//			.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
-	//			.InstanceDataStepRate = 0
-	//		}
-	//	};
+		TypedD3D::Wrapper<ID3D11PixelShader> ps = device->CreatePixelShader(pixelBlob, nullptr);
 
-	//	TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, *vertexBlob.Get());
+		std::array<D3D11_INPUT_ELEMENT_DESC, 1> inputElements
+		{
+			D3D11_INPUT_ELEMENT_DESC
+			{
+				.SemanticName = "POSITION",
+				.SemanticIndex = 0,
+				.Format = DXGI_FORMAT_R32G32B32_FLOAT,
+				.InputSlot = 0,
+				.AlignedByteOffset = 0,
+				.InputSlotClass = D3D11_INPUT_PER_VERTEX_DATA,
+				.InstanceDataStepRate = 0
+			}
+		};
 
-	//	auto vertices = std::to_array<Vertex>(
-	//		{
-	//			{ -0.5f, -0.5f, 0 },
-	//			{  0.0f,  0.5f, 0 },
-	//			{  0.5f, -0.5f, 0 },
-	//		});
+		TypedD3D::Wrapper<ID3D11InputLayout> inputLayout = device->CreateInputLayout(inputElements, vertexBlob);
 
-	//	D3D11_BUFFER_DESC desc
-	//	{
-	//		.ByteWidth = vertices.size() * sizeof(Vertex),
-	//		.Usage = D3D11_USAGE_DEFAULT,
-	//		.BindFlags = D3D11_BIND_VERTEX_BUFFER,
-	//		.CPUAccessFlags = 0,
-	//		.MiscFlags = 0,
-	//		.StructureByteStride = sizeof(Vertex)
-	//	};
-	//	D3D11_SUBRESOURCE_DATA data
-	//	{
-	//		.pSysMem = vertices.data(),
-	//		.SysMemPitch = sizeof(Vertex),
-	//		.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
-	//	};
-	//	TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
-	//	D3D11_VIEWPORT viewport
-	//	{
-	//		.TopLeftX = 0,
-	//		.TopLeftY = 0,
-	//		.Width = windowWidth,
-	//		.Height = windowHeight,
-	//		.MinDepth = 0,
-	//		.MaxDepth = 1
-	//	};
+		auto vertices = std::to_array<Vertex>(
+			{
+				{ -0.5f, -0.5f, 0 },
+				{  0.0f,  0.5f, 0 },
+				{  0.5f, -0.5f, 0 },
+			});
 
-	//	D3D11_RECT rect
-	//	{
-	//		.left = 0,
-	//		.top = 0,
-	//		.right = static_cast<LONG>(windowWidth),
-	//		.bottom = static_cast<LONG>(windowHeight)
-	//	};
-	//	while(true)
-	//	{
-	//		if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-	//		{
-	//			TranslateMessage(&msg);
-	//			DispatchMessageW(&msg);
+		D3D11_BUFFER_DESC desc
+		{
+			.ByteWidth = vertices.size() * sizeof(Vertex),
+			.Usage = D3D11_USAGE_DEFAULT,
+			.BindFlags = D3D11_BIND_VERTEX_BUFFER,
+			.CPUAccessFlags = 0,
+			.MiscFlags = 0,
+			.StructureByteStride = sizeof(Vertex)
+		};
+		D3D11_SUBRESOURCE_DATA data
+		{
+			.pSysMem = vertices.data(),
+			.SysMemPitch = sizeof(Vertex),
+			.SysMemSlicePitch = sizeof(Vertex) * vertices.size()
+		};
+		TypedD3D::Wrapper<ID3D11Buffer> vertexBuffer = device->CreateBuffer(desc, &data);
+		D3D11_VIEWPORT viewport
+		{
+			.TopLeftX = 0,
+			.TopLeftY = 0,
+			.Width = windowWidth,
+			.Height = windowHeight,
+			.MinDepth = 0,
+			.MaxDepth = 1
+		};
 
-	//			if(msg.message == WM_QUIT)
-	//				break;
-	//		}
-	//		else
-	//		{
-	//			deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
-	//			deviceContext->OMSetRenderTargets(rtv, nullptr);
+		D3D11_RECT rect
+		{
+			.left = 0,
+			.top = 0,
+			.right = static_cast<LONG>(windowWidth),
+			.bottom = static_cast<LONG>(windowHeight)
+		};
+		while(true)
+		{
+			if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+			{
+				TranslateMessage(&msg);
+				DispatchMessageW(&msg);
 
-	//			deviceContext->IASetInputLayout(inputLayout);
-	//			deviceContext->RSSetViewports(std::span(&viewport, 1));
-	//			deviceContext->RSSetScissorRects(std::span(&rect, 1));
-	//			deviceContext->VSSetShader(vs, {});
-	//			deviceContext->PSSetShader(ps, {});
-	//			deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-	//			deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
-	//			deviceContext->Draw(3, 0);
+				if(msg.message == WM_QUIT)
+					break;
+			}
+			else
+			{
+				deviceContext->ClearRenderTargetView(rtv, std::array{ 0.f, 0.3f, 0.7f, 1.f });
+				deviceContext->OMSetRenderTargets(rtv, nullptr);
 
-	//			swapChain->Present(1, 0);
-	//		}
-	//	}
+				deviceContext->IASetInputLayout(inputLayout);
+				deviceContext->RSSetViewports(std::span(&viewport, 1));
+				deviceContext->RSSetScissorRects(std::span(&rect, 1));
+				deviceContext->VSSetShader(vs, nullptr);
+				deviceContext->PSSetShader(ps, nullptr);
+				deviceContext->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+				deviceContext->IASetVertexBuffers(0, vertexBuffer.Get(), sizeof(Vertex), 0);
+				deviceContext->Draw(3, 0);
 
-	//	assert(swapChain != nullptr);
-	//	assert(factory != nullptr);
+				swapChain->Present(1, 0);
+			}
+		}
 
+		assert(swapChain != nullptr);
+		assert(factory != nullptr);
 
-	//	UnregisterClassW(windowName, nullptr);
-	//}
-	//static_assert(std::same_as<TypedD3D::UntaggedTraits<ID3D11Debug>::Interface<int>, ID3D11Debug*>);
-	//debugDevice->ReportLiveDeviceObjects(D3D11_RLDO_FLAGS::D3D11_RLDO_SUMMARY | D3D11_RLDO_FLAGS::D3D11_RLDO_DETAIL | D3D11_RLDO_IGNORE_INTERNAL);
+		UnregisterClassW(windowName, nullptr);
+	}
+	debugDevice->ReportLiveDeviceObjects(D3D11_RLDO_FLAGS::D3D11_RLDO_SUMMARY | D3D11_RLDO_FLAGS::D3D11_RLDO_DETAIL | D3D11_RLDO_IGNORE_INTERNAL);
 }
 
 

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -8,428 +8,432 @@
 #include "d3dx12.h"
 #include "dxgi1_6.h"
 
-import TypedD3D12;
-import TypedDXGI;
-import TypedD3D.Legacy.D3D12Helpers;
-
-#undef CreateWindow
-namespace
-{
-    HWND handle;
-    constexpr const wchar_t* windowName = L"Library Test";
-    constexpr float windowWidth = 800;
-    constexpr float windowHeight = 600;
-
-    struct Vertex
-    {
-        float x;
-        float y;
-        float z;
-    };
-}
-
-
-static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-static void CreateWindow();
-
-using Microsoft::WRL::ComPtr;
-
+import TypedD3D.Shared;
+//import TypedD3D12;
+//import TypedDXGI;
+//import TypedD3D.Legacy.D3D12Helpers;
+//
+//#undef CreateWindow
+//namespace
+//{
+//    HWND handle;
+//    constexpr const wchar_t* windowName = L"Library Test";
+//    constexpr float windowWidth = 800;
+//    constexpr float windowHeight = 600;
+//
+//    struct Vertex
+//    {
+//        float x;
+//        float y;
+//        float z;
+//    };
+//}
+//
+//
+//static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+//static void CreateWindow();
+//
+//using Microsoft::WRL::ComPtr;
+//
 void D3D12HelloWorld()
 {
-    CreateWindow();
-    TypedD3D12::CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> b;
-    //TypedD3D::expected<ComPtr<IDXGIFactory2>, HRESULT> factory = TypedD3D::IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory1);
-    //TypedD3D::Wrapper<IDXGIAdapter> adapter = factory->EnumAdapters<IDXGIAdapter>(0);
-    ComPtr<ID3D12Debug> debugLayer = TypedD3D::Helpers::D3D12::GetDebugInterface();
-    debugLayer->EnableDebugLayer();
-    TypedD3D12::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-    TypedD3D12::Wrapper<ID3D12Device1> device = TypedD3D12::CreateDevice<ID3D12Device1>(D3D_FEATURE_LEVEL_12_0);
-    ComPtr<ID3D12DebugDevice> debugDevice = TypedD3D::Cast<ID3D12DebugDevice>(device.Get());
-
-    constexpr UINT backBufferCount = 2;
-
-    using namespace TypedD3D;
-    TypedD3D12::Direct<ID3D12CommandQueue> commandQueue = device->CreateCommandQueue<D3D12_COMMAND_LIST_TYPE_DIRECT>(D3D12_COMMAND_QUEUE_PRIORITY_NORMAL, D3D12_COMMAND_QUEUE_FLAG_NONE, 0);
-    std::array<TypedD3D12::Direct<ID3D12CommandAllocator>, backBufferCount> commandAllocators;
-    commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
-    commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
-    TypedD3D12::Direct<ID3D12GraphicsCommandList> temp = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
-    TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList = TypedD3D::Cast<TypedD3D12::Direct<ID3D12GraphicsCommandList1>>(temp);
-    TypedD3D12::Compute<ID3D12GraphicsCommandList1> commandList54;
-
-    //TypedD3D::Compute<ID3D12GraphicsCommandList1> cltest = commandList;
-    UINT64 fenceValue = 0;
-    ComPtr<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
-    HANDLE syncEvent = CreateEventW(nullptr, false, false, nullptr);
-
-    TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
-        commandQueue,
-        handle,
-        DXGI_SWAP_CHAIN_DESC1
-        {
-            .Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-            .SampleDesc
-            {
-                .Count = 1
-            },
-            .BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
-            .BufferCount = backBufferCount,
-            .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
-            .Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
-        },
-        nullptr,
-        nullptr);
-
-    TypedD3D12::RTV<ID3D12DescriptorHeap> swapChainBufferDescriptorHeap = device->CreateDescriptorHeap<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>(2, 0);
-
-    UINT rtvOffset = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
-    DXGI_SWAP_CHAIN_DESC1 desc = swapChain->GetDesc1();
-
-    std::array<TypedD3D12::Wrapper<ID3D12Resource>, 2> swapChainBuffers;
-
-    for(UINT i = 0; i < desc.BufferCount; i++)
-    {
-        swapChainBuffers[i] = swapChain->GetBuffer<ID3D12Resource>(i);
-
-        device->CreateRenderTargetView(*swapChainBuffers[i].Get(), nullptr, descriptorHandle);
-        descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
-    }
+	//TypedD3D::WrapperView<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::WrapperView<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
 
 
-
-    D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc
-    {
-        .NumParameters = 0,
-        .pParameters = nullptr,
-        .NumStaticSamplers = 0,
-        .pStaticSamplers = nullptr,
-        .Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
-    };
-
-    ComPtr<ID3DBlob> signatureBlob;
-    D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, nullptr);
-    ComPtr<ID3D12RootSignature> rootSignature = device->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize());
-
-    ComPtr<ID3DBlob> vertexBlob;
-    ComPtr<ID3DBlob> errorBlob;
-    HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
-    if(FAILED(hr))
-    {
-        char* message = static_cast<char*>(errorBlob->GetBufferPointer());
-        std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
-        MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
-        MessageBox(handle, messageT.get(), L"Error", MB_OK);
-        return;
-    }
-    D3D12_SHADER_BYTECODE vertexByteCode{};
-    vertexByteCode.BytecodeLength = vertexBlob->GetBufferSize();
-    vertexByteCode.pShaderBytecode = vertexBlob->GetBufferPointer();
-
-    ComPtr<ID3DBlob> pixelBlob;
-    hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
-    if(FAILED(hr))
-        return;
-
-    D3D12_SHADER_BYTECODE pixelByteCode{};
-    pixelByteCode.BytecodeLength = pixelBlob->GetBufferSize();
-    pixelByteCode.pShaderBytecode = pixelBlob->GetBufferPointer();
-
-    std::array<D3D12_INPUT_ELEMENT_DESC, 1> inputLayout
-    {
-        D3D12_INPUT_ELEMENT_DESC
-        {
-            .SemanticName = "POSITION",
-            .SemanticIndex = 0,
-            .Format = DXGI_FORMAT_R32G32B32_FLOAT,
-            .InputSlot = 0,
-            .AlignedByteOffset = 0,
-            .InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-            .InstanceDataStepRate = 0
-        }
-    };
-
-    D3D12_INPUT_LAYOUT_DESC layoutDesc
-    {
-        .pInputElementDescs = inputLayout.data(),
-        .NumElements = static_cast<UINT>(inputLayout.size())
-    };
-
-    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineState
-    {
-        .pRootSignature = rootSignature.Get(),
-        .VS = vertexByteCode,
-        .PS = pixelByteCode,
-        .BlendState = D3D12_BLEND_DESC
-        {
-            .AlphaToCoverageEnable = false,
-            .IndependentBlendEnable = false
-        },
-        .SampleMask = 0xff'ff'ff'ff,
-        .RasterizerState = D3D12_RASTERIZER_DESC
-        {
-            .FillMode = D3D12_FILL_MODE_SOLID,
-            .CullMode = D3D12_CULL_MODE_NONE,
-            .FrontCounterClockwise = true,
-            .DepthBias = 0,
-            .DepthBiasClamp = 0,
-            .SlopeScaledDepthBias = 0,
-            .DepthClipEnable = true,
-            .MultisampleEnable = false,
-            .AntialiasedLineEnable = false,
-            .ForcedSampleCount = 0,
-            .ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
-        },
-        .InputLayout = layoutDesc,
-        .PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
-        .NumRenderTargets = 1,
-        .SampleDesc = TypedD3D::GetDescription(*swapChain.Get()).SampleDesc,
-    };
-
-    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
-    graphicsPipelineState.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
-    graphicsPipelineState.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
-    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
-    graphicsPipelineState.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
-    graphicsPipelineState.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
-    graphicsPipelineState.BlendState.RenderTarget[0].LogicOp = D3D12_LOGIC_OP_NOOP;
-    graphicsPipelineState.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-
-    graphicsPipelineState.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-
-    TypedD3D12::Graphics<ID3D12PipelineState> pipelineState = device->CreateGraphicsPipelineState(graphicsPipelineState);
-
-    auto vertices = std::to_array<Vertex>(
-        {
-            { -0.5f, -0.5f, 0 },
-            {  0.0f,  0.5f, 0 },
-            {  0.5f, -0.5f, 0 },
-        });
-
-    D3D12_HEAP_PROPERTIES vertexHeap
-    {
-        .Type = D3D12_HEAP_TYPE_DEFAULT,
-        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
-        .CreationNodeMask = 0,
-        .VisibleNodeMask = 0
-    };
-
-    D3D12_RESOURCE_DESC vertexDesc
-    {
-        .Dimension = D3D12_RESOURCE_DIMENSION_BUFFER,
-        .Alignment = 0,
-        .Width = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-        .Height = 1,
-        .DepthOrArraySize = 1,
-        .MipLevels = 1,
-        .Format = DXGI_FORMAT_UNKNOWN,
-        .SampleDesc = {.Count = 1, . Quality = 0},
-        .Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-        .Flags = D3D12_RESOURCE_FLAG_NONE
-    };
-
-
-    Wrapper<ID3D12Resource> vertexResource = device->CreateCommittedResource(
-        vertexHeap,
-        D3D12_HEAP_FLAG_NONE,
-        vertexDesc,
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        nullptr);
-
-
-    D3D12_HEAP_PROPERTIES uploadProperties
-    {
-        .Type = D3D12_HEAP_TYPE_UPLOAD,
-        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
-        .CreationNodeMask = 0,
-        .VisibleNodeMask = 0
-    };
-    Wrapper<ID3D12Resource> vertexUpload = device->CreateCommittedResource(
-        uploadProperties,
-        D3D12_HEAP_FLAG_NONE,
-        vertexDesc,
-        D3D12_RESOURCE_STATE_GENERIC_READ,
-        nullptr);
-
-    D3D12_SUBRESOURCE_DATA vertexData
-    {
-        .pData = vertices.data(),
-        .RowPitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-        .SlicePitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-    };
-
-    UpdateSubresources(commandList.Get(), vertexResource.Get(), vertexUpload.Get(), 0, 0, 1, &vertexData);
-
-    D3D12_RESOURCE_BARRIER barrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-        *vertexResource.Get(),
-        D3D12_RESOURCE_STATE_COPY_DEST,
-        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
-    commandList->ResourceBarrier(std::span(&barrier, 1));
-    commandList->Close();
-    TypedD3D12::Direct<ID3D12CommandList> a = commandList;
-    TypedD3D::Array<TypedD3D12::Direct<ID3D12CommandList>, 1> submitList{ commandList };
-    commandQueue->ExecuteCommandLists(TypedD3D::Span(submitList));
-
-    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
-
-    D3D12_VERTEX_BUFFER_VIEW vertexBufferView
-    {
-        .BufferLocation = vertexResource->GetGPUVirtualAddress(),
-        .SizeInBytes = static_cast<UINT>(sizeof(Vertex) * vertices.size()),
-        .StrideInBytes = static_cast<UINT>(sizeof(Vertex))
-    };
-
-    D3D12_VIEWPORT viewport
-    {
-        .TopLeftX = 0,
-        .TopLeftY = 0,
-        .Width = windowWidth,
-        .Height = windowHeight,
-        .MinDepth = 0,
-        .MaxDepth = 1
-    };
-
-    D3D12_RECT rect
-    {
-        .left = 0,
-        .top = 0,
-        .right = static_cast<LONG>(windowWidth),
-        .bottom = static_cast<LONG>(windowHeight)
-    };
-
-    UINT backBuffer = 0;
-    MSG msg;
-
-    std::array<UINT64, backBufferCount> frameWaitValues = {};
-
-    std::vector<ID3D12Resource*> resources(backBufferCount);
-    for(size_t i = 0; i < backBufferCount; i++)
-    {
-        resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
-    }
-
-
-    while(true)
-    {
-        if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
-
-            if(msg.message == WM_QUIT)
-                break;
-        }
-        else
-        {
-            TypedD3D::Helpers::D3D12::Frame(
-                { *swapChain.Get() },
-                { *fence.Get() },
-                *commandQueue.Get(),
-                frameWaitValues[backBuffer],
-                fenceValue,
-                backBuffer,
-                frameWaitValues.size(),
-                [&](const TypedD3D::Helpers::D3D12::FrameData& frameData)
-                {
-                    TypedD3D::Helpers::D3D12::RecordAndExecute(
-                        *commandList.Get(), 
-                        *commandAllocators[frameData.backBufferIndex].Get(), 
-                        frameData.commandQueue,
-                        [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
-                        {
-                            D3D12_RESOURCE_BARRIER beginBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-                                *swapChainBuffers[frameData.backBufferIndex].Get(),
-                                D3D12_RESOURCE_STATE_PRESENT,
-                                D3D12_RESOURCE_STATE_RENDER_TARGET);
-
-                            D3D12_RESOURCE_BARRIER endBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-                                *swapChainBuffers[frameData.backBufferIndex].Get(),
-                                D3D12_RESOURCE_STATE_RENDER_TARGET,
-                                D3D12_RESOURCE_STATE_PRESENT);
-
-                            TypedD3D::Helpers::D3D12::ResourceBarrier(*commandList.Get(), std::span(&beginBarrier, 1), std::span(&endBarrier, 1),
-                                [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
-                                {
-                                    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> backBufferHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset);
-                                    commandList->ClearRenderTargetView(backBufferHandle, std::to_array({ 0.f, 0.3f, 0.7f, 1.f }), {});
-                                    commandList->OMSetRenderTargets(std::span(&backBufferHandle, 1), true, nullptr);
-
-                                    commandList->SetPipelineState(pipelineState.Get());
-                                    commandList->SetGraphicsRootSignature(rootSignature.Get());
-                                    commandList->RSSetViewports(std::span(&viewport, 1));
-                                    commandList->RSSetScissorRects(std::span(&rect, 1));
-                                    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-                                    commandList->IASetVertexBuffers(0, std::span(&vertexBufferView, 1));
-                                    commandList->DrawInstanced(3, 1, 0, 0);
-                                });
-                        });
-                });
-        }
-    }
-    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
-
-    debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_FLAGS::D3D12_RLDO_SUMMARY | D3D12_RLDO_IGNORE_INTERNAL);
-
-    assert(swapChain != nullptr);
-    assert(factory != nullptr);
-
-
-    UnregisterClassW(windowName, nullptr);
+//    CreateWindow();
+//    TypedD3D12::CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> b;
+//    //TypedD3D::expected<ComPtr<IDXGIFactory2>, HRESULT> factory = TypedD3D::IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory1);
+//    //TypedD3D::Wrapper<IDXGIAdapter> adapter = factory->EnumAdapters<IDXGIAdapter>(0);
+//    ComPtr<ID3D12Debug> debugLayer = TypedD3D::Helpers::D3D12::GetDebugInterface();
+//    debugLayer->EnableDebugLayer();
+//    TypedD3D12::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
+//    TypedD3D12::Wrapper<ID3D12Device1> device = TypedD3D12::CreateDevice<ID3D12Device1>(D3D_FEATURE_LEVEL_12_0);
+//    ComPtr<ID3D12DebugDevice> debugDevice = TypedD3D::Cast<ID3D12DebugDevice>(device.Get());
+//
+//    constexpr UINT backBufferCount = 2;
+//
+//    using namespace TypedD3D;
+//    TypedD3D12::Direct<ID3D12CommandQueue> commandQueue = device->CreateCommandQueue<D3D12_COMMAND_LIST_TYPE_DIRECT>(D3D12_COMMAND_QUEUE_PRIORITY_NORMAL, D3D12_COMMAND_QUEUE_FLAG_NONE, 0);
+//    std::array<TypedD3D12::Direct<ID3D12CommandAllocator>, backBufferCount> commandAllocators;
+//    commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
+//    commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
+//    TypedD3D12::Direct<ID3D12GraphicsCommandList> temp = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
+//    TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList = TypedD3D::Cast<TypedD3D12::Direct<ID3D12GraphicsCommandList1>>(temp);
+//    TypedD3D12::Compute<ID3D12GraphicsCommandList1> commandList54;
+//
+//    //TypedD3D::Compute<ID3D12GraphicsCommandList1> cltest = commandList;
+//    UINT64 fenceValue = 0;
+//    ComPtr<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
+//    HANDLE syncEvent = CreateEventW(nullptr, false, false, nullptr);
+//
+//    TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
+//        commandQueue,
+//        handle,
+//        DXGI_SWAP_CHAIN_DESC1
+//        {
+//            .Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+//            .SampleDesc
+//            {
+//                .Count = 1
+//            },
+//            .BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
+//            .BufferCount = backBufferCount,
+//            .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+//            .Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
+//        },
+//        nullptr,
+//        nullptr);
+//
+//    TypedD3D12::RTV<ID3D12DescriptorHeap> swapChainBufferDescriptorHeap = device->CreateDescriptorHeap<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>(2, 0);
+//
+//    UINT rtvOffset = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+//    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
+//    DXGI_SWAP_CHAIN_DESC1 desc = swapChain->GetDesc1();
+//
+//    std::array<TypedD3D12::Wrapper<ID3D12Resource>, 2> swapChainBuffers;
+//
+//    for(UINT i = 0; i < desc.BufferCount; i++)
+//    {
+//        swapChainBuffers[i] = swapChain->GetBuffer<ID3D12Resource>(i);
+//
+//        device->CreateRenderTargetView(*swapChainBuffers[i].Get(), nullptr, descriptorHandle);
+//        descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
+//    }
+//
+//
+//
+//    D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc
+//    {
+//        .NumParameters = 0,
+//        .pParameters = nullptr,
+//        .NumStaticSamplers = 0,
+//        .pStaticSamplers = nullptr,
+//        .Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
+//    };
+//
+//    ComPtr<ID3DBlob> signatureBlob;
+//    D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, nullptr);
+//    ComPtr<ID3D12RootSignature> rootSignature = device->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize());
+//
+//    ComPtr<ID3DBlob> vertexBlob;
+//    ComPtr<ID3DBlob> errorBlob;
+//    HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
+//    if(FAILED(hr))
+//    {
+//        char* message = static_cast<char*>(errorBlob->GetBufferPointer());
+//        std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
+//        MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
+//        MessageBox(handle, messageT.get(), L"Error", MB_OK);
+//        return;
+//    }
+//    D3D12_SHADER_BYTECODE vertexByteCode{};
+//    vertexByteCode.BytecodeLength = vertexBlob->GetBufferSize();
+//    vertexByteCode.pShaderBytecode = vertexBlob->GetBufferPointer();
+//
+//    ComPtr<ID3DBlob> pixelBlob;
+//    hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
+//    if(FAILED(hr))
+//        return;
+//
+//    D3D12_SHADER_BYTECODE pixelByteCode{};
+//    pixelByteCode.BytecodeLength = pixelBlob->GetBufferSize();
+//    pixelByteCode.pShaderBytecode = pixelBlob->GetBufferPointer();
+//
+//    std::array<D3D12_INPUT_ELEMENT_DESC, 1> inputLayout
+//    {
+//        D3D12_INPUT_ELEMENT_DESC
+//        {
+//            .SemanticName = "POSITION",
+//            .SemanticIndex = 0,
+//            .Format = DXGI_FORMAT_R32G32B32_FLOAT,
+//            .InputSlot = 0,
+//            .AlignedByteOffset = 0,
+//            .InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
+//            .InstanceDataStepRate = 0
+//        }
+//    };
+//
+//    D3D12_INPUT_LAYOUT_DESC layoutDesc
+//    {
+//        .pInputElementDescs = inputLayout.data(),
+//        .NumElements = static_cast<UINT>(inputLayout.size())
+//    };
+//
+//    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineState
+//    {
+//        .pRootSignature = rootSignature.Get(),
+//        .VS = vertexByteCode,
+//        .PS = pixelByteCode,
+//        .BlendState = D3D12_BLEND_DESC
+//        {
+//            .AlphaToCoverageEnable = false,
+//            .IndependentBlendEnable = false
+//        },
+//        .SampleMask = 0xff'ff'ff'ff,
+//        .RasterizerState = D3D12_RASTERIZER_DESC
+//        {
+//            .FillMode = D3D12_FILL_MODE_SOLID,
+//            .CullMode = D3D12_CULL_MODE_NONE,
+//            .FrontCounterClockwise = true,
+//            .DepthBias = 0,
+//            .DepthBiasClamp = 0,
+//            .SlopeScaledDepthBias = 0,
+//            .DepthClipEnable = true,
+//            .MultisampleEnable = false,
+//            .AntialiasedLineEnable = false,
+//            .ForcedSampleCount = 0,
+//            .ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
+//        },
+//        .InputLayout = layoutDesc,
+//        .PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+//        .NumRenderTargets = 1,
+//        .SampleDesc = TypedD3D::GetDescription(*swapChain.Get()).SampleDesc,
+//    };
+//
+//    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
+//    graphicsPipelineState.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
+//    graphicsPipelineState.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+//    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+//    graphicsPipelineState.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+//    graphicsPipelineState.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
+//    graphicsPipelineState.BlendState.RenderTarget[0].LogicOp = D3D12_LOGIC_OP_NOOP;
+//    graphicsPipelineState.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+//
+//    graphicsPipelineState.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+//
+//    TypedD3D12::Graphics<ID3D12PipelineState> pipelineState = device->CreateGraphicsPipelineState(graphicsPipelineState);
+//
+//    auto vertices = std::to_array<Vertex>(
+//        {
+//            { -0.5f, -0.5f, 0 },
+//            {  0.0f,  0.5f, 0 },
+//            {  0.5f, -0.5f, 0 },
+//        });
+//
+//    D3D12_HEAP_PROPERTIES vertexHeap
+//    {
+//        .Type = D3D12_HEAP_TYPE_DEFAULT,
+//        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+//        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
+//        .CreationNodeMask = 0,
+//        .VisibleNodeMask = 0
+//    };
+//
+//    D3D12_RESOURCE_DESC vertexDesc
+//    {
+//        .Dimension = D3D12_RESOURCE_DIMENSION_BUFFER,
+//        .Alignment = 0,
+//        .Width = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+//        .Height = 1,
+//        .DepthOrArraySize = 1,
+//        .MipLevels = 1,
+//        .Format = DXGI_FORMAT_UNKNOWN,
+//        .SampleDesc = {.Count = 1, . Quality = 0},
+//        .Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+//        .Flags = D3D12_RESOURCE_FLAG_NONE
+//    };
+//
+//
+//    Wrapper<ID3D12Resource> vertexResource = device->CreateCommittedResource(
+//        vertexHeap,
+//        D3D12_HEAP_FLAG_NONE,
+//        vertexDesc,
+//        D3D12_RESOURCE_STATE_COPY_DEST,
+//        nullptr);
+//
+//
+//    D3D12_HEAP_PROPERTIES uploadProperties
+//    {
+//        .Type = D3D12_HEAP_TYPE_UPLOAD,
+//        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+//        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
+//        .CreationNodeMask = 0,
+//        .VisibleNodeMask = 0
+//    };
+//    Wrapper<ID3D12Resource> vertexUpload = device->CreateCommittedResource(
+//        uploadProperties,
+//        D3D12_HEAP_FLAG_NONE,
+//        vertexDesc,
+//        D3D12_RESOURCE_STATE_GENERIC_READ,
+//        nullptr);
+//
+//    D3D12_SUBRESOURCE_DATA vertexData
+//    {
+//        .pData = vertices.data(),
+//        .RowPitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+//        .SlicePitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+//    };
+//
+//    UpdateSubresources(commandList.Get(), vertexResource.Get(), vertexUpload.Get(), 0, 0, 1, &vertexData);
+//
+//    D3D12_RESOURCE_BARRIER barrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+//        *vertexResource.Get(),
+//        D3D12_RESOURCE_STATE_COPY_DEST,
+//        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
+//    commandList->ResourceBarrier(std::span(&barrier, 1));
+//    commandList->Close();
+//    TypedD3D12::Direct<ID3D12CommandList> a = commandList;
+//    TypedD3D::Array<TypedD3D12::Direct<ID3D12CommandList>, 1> submitList{ commandList };
+//    commandQueue->ExecuteCommandLists(TypedD3D::Span(submitList));
+//
+//    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
+//
+//    D3D12_VERTEX_BUFFER_VIEW vertexBufferView
+//    {
+//        .BufferLocation = vertexResource->GetGPUVirtualAddress(),
+//        .SizeInBytes = static_cast<UINT>(sizeof(Vertex) * vertices.size()),
+//        .StrideInBytes = static_cast<UINT>(sizeof(Vertex))
+//    };
+//
+//    D3D12_VIEWPORT viewport
+//    {
+//        .TopLeftX = 0,
+//        .TopLeftY = 0,
+//        .Width = windowWidth,
+//        .Height = windowHeight,
+//        .MinDepth = 0,
+//        .MaxDepth = 1
+//    };
+//
+//    D3D12_RECT rect
+//    {
+//        .left = 0,
+//        .top = 0,
+//        .right = static_cast<LONG>(windowWidth),
+//        .bottom = static_cast<LONG>(windowHeight)
+//    };
+//
+//    UINT backBuffer = 0;
+//    MSG msg;
+//
+//    std::array<UINT64, backBufferCount> frameWaitValues = {};
+//
+//    std::vector<ID3D12Resource*> resources(backBufferCount);
+//    for(size_t i = 0; i < backBufferCount; i++)
+//    {
+//        resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
+//    }
+//
+//
+//    while(true)
+//    {
+//        if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+//        {
+//            TranslateMessage(&msg);
+//            DispatchMessageW(&msg);
+//
+//            if(msg.message == WM_QUIT)
+//                break;
+//        }
+//        else
+//        {
+//            TypedD3D::Helpers::D3D12::Frame(
+//                { *swapChain.Get() },
+//                { *fence.Get() },
+//                *commandQueue.Get(),
+//                frameWaitValues[backBuffer],
+//                fenceValue,
+//                backBuffer,
+//                frameWaitValues.size(),
+//                [&](const TypedD3D::Helpers::D3D12::FrameData& frameData)
+//                {
+//                    TypedD3D::Helpers::D3D12::RecordAndExecute(
+//                        *commandList.Get(), 
+//                        *commandAllocators[frameData.backBufferIndex].Get(), 
+//                        frameData.commandQueue,
+//                        [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
+//                        {
+//                            D3D12_RESOURCE_BARRIER beginBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+//                                *swapChainBuffers[frameData.backBufferIndex].Get(),
+//                                D3D12_RESOURCE_STATE_PRESENT,
+//                                D3D12_RESOURCE_STATE_RENDER_TARGET);
+//
+//                            D3D12_RESOURCE_BARRIER endBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+//                                *swapChainBuffers[frameData.backBufferIndex].Get(),
+//                                D3D12_RESOURCE_STATE_RENDER_TARGET,
+//                                D3D12_RESOURCE_STATE_PRESENT);
+//
+//                            TypedD3D::Helpers::D3D12::ResourceBarrier(*commandList.Get(), std::span(&beginBarrier, 1), std::span(&endBarrier, 1),
+//                                [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
+//                                {
+//                                    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> backBufferHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset);
+//                                    commandList->ClearRenderTargetView(backBufferHandle, std::to_array({ 0.f, 0.3f, 0.7f, 1.f }), {});
+//                                    commandList->OMSetRenderTargets(std::span(&backBufferHandle, 1), true, nullptr);
+//
+//                                    commandList->SetPipelineState(pipelineState.Get());
+//                                    commandList->SetGraphicsRootSignature(rootSignature.Get());
+//                                    commandList->RSSetViewports(std::span(&viewport, 1));
+//                                    commandList->RSSetScissorRects(std::span(&rect, 1));
+//                                    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+//                                    commandList->IASetVertexBuffers(0, std::span(&vertexBufferView, 1));
+//                                    commandList->DrawInstanced(3, 1, 0, 0);
+//                                });
+//                        });
+//                });
+//        }
+//    }
+//    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
+//
+//    debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_FLAGS::D3D12_RLDO_SUMMARY | D3D12_RLDO_IGNORE_INTERNAL);
+//
+//    assert(swapChain != nullptr);
+//    assert(factory != nullptr);
+//
+//
+//    UnregisterClassW(windowName, nullptr);
 }
-
-
-
-
-static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-    switch(uMsg)
-    {
-    case WM_DESTROY:
-        PostQuitMessage(0);
-        return 0;
-        break;
-    }
-
-    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
-}
-
-void CreateWindow()
-{
-    WNDCLASSW windowClass{};
-    windowClass.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
-    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-    windowClass.hInstance = NULL;
-    windowClass.lpfnWndProc = WndProc;
-    windowClass.lpszClassName = windowName;
-    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-
-
-    if(!RegisterClassW(&windowClass))
-    {
-        MessageBoxW(NULL, L"Could not register class", L"Error", MB_OK);
-        throw std::exception("Could not register class");
-    }
-
-    handle = CreateWindowExW(0,
-        windowName,
-        windowName,
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        static_cast<int>(windowWidth),
-        static_cast<int>(windowHeight),
-        NULL,
-        NULL,
-        NULL,
-        NULL);
-
-    if(!handle)
-    {
-        MessageBox(NULL, L"Could not create window", L"Error", MB_OK);
-        throw std::exception("Could not create window");
-    }
-
-    ShowWindow(handle, SW_RESTORE);
-}
+//
+//
+//
+//
+//static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+//{
+//    switch(uMsg)
+//    {
+//    case WM_DESTROY:
+//        PostQuitMessage(0);
+//        return 0;
+//        break;
+//    }
+//
+//    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+//}
+//
+//void CreateWindow()
+//{
+//    WNDCLASSW windowClass{};
+//    windowClass.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
+//    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+//    windowClass.hInstance = NULL;
+//    windowClass.lpfnWndProc = WndProc;
+//    windowClass.lpszClassName = windowName;
+//    windowClass.style = CS_HREDRAW | CS_VREDRAW;
+//
+//
+//    if(!RegisterClassW(&windowClass))
+//    {
+//        MessageBoxW(NULL, L"Could not register class", L"Error", MB_OK);
+//        throw std::exception("Could not register class");
+//    }
+//
+//    handle = CreateWindowExW(0,
+//        windowName,
+//        windowName,
+//        WS_OVERLAPPEDWINDOW,
+//        CW_USEDEFAULT,
+//        CW_USEDEFAULT,
+//        static_cast<int>(windowWidth),
+//        static_cast<int>(windowHeight),
+//        NULL,
+//        NULL,
+//        NULL,
+//        NULL);
+//
+//    if(!handle)
+//    {
+//        MessageBox(NULL, L"Could not create window", L"Error", MB_OK);
+//        throw std::exception("Could not create window");
+//    }
+//
+//    ShowWindow(handle, SW_RESTORE);
+//}

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -362,7 +362,7 @@ void D3D12HelloWorld()
                                     TypedD3D::Array<TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE>, 1> backBufferHandle
                                     { swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset) };
                                     TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> b2;
-
+                                    backBufferHandle[0].Offset(0);
                                     b2 = backBufferHandle[0];
                                     auto color = std::to_array({ 0.f, 0.3f, 0.7f, 1.f });
                                     std::span<const float, 4> f = color;

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -35,19 +35,10 @@ static void CreateWindow();
 
 void D3D12HelloWorld()
 {
-	//TypedD3D::WrapperView<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::WrapperView<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
-
-
     CreateWindow();
-    //TypedD3D12::CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> b;
-    //TypedD3D::expected<ComPtr<IDXGIFactory2>, HRESULT> factory = TypedD3D::IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory1);
-    //TypedD3D::Wrapper<IDXGIAdapter> adapter = factory->EnumAdapters<IDXGIAdapter>(0);
-    //ComPtr<ID3D12Debug> debugLayer = TypedD3D::Helpers::D3D12::GetDebugInterface();
-    //debugLayer->EnableDebugLayer();
+
     TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-    //TypedD3D::Wrapper<ID3D12Device> device = TypedD3D12::CreateDevice<ID3D12Device>(D3D_FEATURE_LEVEL_12_0);
     TypedD3D::Wrapper<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
-    //ComPtr<ID3D12DebugDevice> debugDevice = TypedD3D::Cast<ID3D12DebugDevice>(device.Get());
 
     constexpr UINT backBufferCount = 2;
 
@@ -57,10 +48,7 @@ void D3D12HelloWorld()
     commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
     commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
     TypedD3D::Direct<ID3D12GraphicsCommandList> commandList = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
-    //TypedD3D::Direct<ID3D12GraphicsCommandList1> commandList = TypedD3D::Cast<TypedD3D::Direct<ID3D12GraphicsCommandList1>>(temp);
-    //TypedD3D::Compute<ID3D12GraphicsCommandList1> commandList54;
 
-    //TypedD3D::Compute<ID3D12GraphicsCommandList1> cltest = commandList;
     UINT64 fenceValue = 0;
     TypedD3D::Wrapper<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
     HANDLE syncEvent = CreateEventW(nullptr, false, false, nullptr);
@@ -95,7 +83,7 @@ void D3D12HelloWorld()
     {
         swapChainBuffers[i] = swapChain->GetBuffer<ID3D12Resource>(i);
 
-        device->CreateRenderTargetView(*swapChainBuffers[i].Get(), nullptr, descriptorHandle);
+        device->CreateRenderTargetView(swapChainBuffers[i], nullptr, descriptorHandle);
         descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
     }
 
@@ -272,6 +260,7 @@ void D3D12HelloWorld()
         *vertexResource.Get(),
         D3D12_RESOURCE_STATE_COPY_DEST,
         D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
+
     commandList->ResourceBarrier(std::span(&barrier, 1));
     commandList->Close();
 
@@ -315,8 +304,7 @@ void D3D12HelloWorld()
     {
         resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
     }
-    Span<const RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> test;
-    Span<RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> test2;
+
 
     while(true)
     {

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -49,6 +49,10 @@ void D3D12HelloWorld()
     commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
     commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
     TypedD3D::Direct<ID3D12GraphicsCommandList> commandList = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
+    TypedD3D::Wrapper<ID3D12GraphicsCommandList> commandList2 = commandList;
+    commandList2 = commandList;
+    //commandList = TypedD3D::Direct<ID3D12GraphicsCommandList>{ commandList2 };
+
 
     UINT64 fenceValue = 0;
     TypedD3D::Wrapper<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
@@ -76,6 +80,10 @@ void D3D12HelloWorld()
 
     UINT rtvOffset = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
     TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
+    TypedD3D::Wrapper<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle2 = descriptorHandle;
+    descriptorHandle2 = descriptorHandle;
+    descriptorHandle = TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE>{ descriptorHandle2 };
+    TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle3{ descriptorHandle2 };
     DXGI_SWAP_CHAIN_DESC1 desc = swapChain->GetDesc1();
 
     std::array<TypedD3D::Wrapper<ID3D12Resource>, 2> swapChainBuffers;
@@ -87,8 +95,6 @@ void D3D12HelloWorld()
         device->CreateRenderTargetView(swapChainBuffers[i], nullptr, descriptorHandle);
         descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
     }
-
-
 
     D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc
     {

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -315,7 +315,8 @@ void D3D12HelloWorld()
     {
         resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
     }
-
+    Span<const RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> test;
+    Span<RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> test2;
 
     while(true)
     {
@@ -358,14 +359,16 @@ void D3D12HelloWorld()
                             TypedD3D::Helpers::D3D12::ResourceBarrier(*commandList.Get(), std::span(&beginBarrier, 1), std::span(&endBarrier, 1),
                                 [&](TypedD3D::Direct<ID3D12GraphicsCommandList> commandList)
                                 {
-                                    TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> backBufferHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset);
+                                    TypedD3D::Array<TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE>, 1> backBufferHandle
+                                    { swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset) };
                                     TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> b2;
-                                    b2 = backBufferHandle;
+
+                                    b2 = backBufferHandle[0];
                                     auto color = std::to_array({ 0.f, 0.3f, 0.7f, 1.f });
                                     std::span<const float, 4> f = color;
 
-                                    commandList->ClearRenderTargetView(backBufferHandle, std::to_array({ 0.f, 0.3f, 0.7f, 1.f }));
-                                    commandList->OMSetRenderTargets(std::span<const TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE>>(&backBufferHandle, 1), true, nullptr);
+                                    commandList->ClearRenderTargetView(backBufferHandle[0], std::to_array({ 0.f, 0.3f, 0.7f, 1.f }));
+                                    commandList->OMSetRenderTargets(backBufferHandle, true, nullptr);
 
                                     commandList->SetPipelineState(pipelineState);
                                     commandList->SetGraphicsRootSignature(rootSignature.Get());

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -38,7 +38,8 @@ void D3D12HelloWorld()
     CreateWindow();
 
     TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-    TypedD3D::Wrapper<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
+
+    TypedD3D::Wrapper<ID3D12Device> device = TypedD3D12::CreateDevice(D3D_FEATURE_LEVEL_12_0);
 
     constexpr UINT backBufferCount = 2;
 

--- a/TESTS/D3D12HelloWorld.cpp
+++ b/TESTS/D3D12HelloWorld.cpp
@@ -3,437 +3,444 @@
 #include <assert.h>
 #include <Windows.h>
 #include <exception>
-#include <wrl/client.h>
 #include <array>
-#include "d3dx12.h"
-#include "dxgi1_6.h"
+#include <d3dx12.h>
+#include <dxgi1_6.h>
+#include <memory>
 
 import TypedD3D.Shared;
-//import TypedD3D12;
-//import TypedDXGI;
-//import TypedD3D.Legacy.D3D12Helpers;
-//
-//#undef CreateWindow
-//namespace
-//{
-//    HWND handle;
-//    constexpr const wchar_t* windowName = L"Library Test";
-//    constexpr float windowWidth = 800;
-//    constexpr float windowHeight = 600;
-//
-//    struct Vertex
-//    {
-//        float x;
-//        float y;
-//        float z;
-//    };
-//}
-//
-//
-//static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-//static void CreateWindow();
-//
-//using Microsoft::WRL::ComPtr;
-//
+import TypedD3D12;
+import TypedDXGI;
+import TypedD3D.Legacy.D3D12Helpers;
+
+#undef CreateWindow
+namespace
+{
+    HWND handle;
+    constexpr const wchar_t* windowName = L"Library Test";
+    constexpr float windowWidth = 800;
+    constexpr float windowHeight = 600;
+
+    struct Vertex
+    {
+        float x;
+        float y;
+        float z;
+    };
+}
+
+
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+static void CreateWindow();
+
 void D3D12HelloWorld()
 {
 	//TypedD3D::WrapperView<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::WrapperView<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
 
 
-//    CreateWindow();
-//    TypedD3D12::CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> b;
-//    //TypedD3D::expected<ComPtr<IDXGIFactory2>, HRESULT> factory = TypedD3D::IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory1);
-//    //TypedD3D::Wrapper<IDXGIAdapter> adapter = factory->EnumAdapters<IDXGIAdapter>(0);
-//    ComPtr<ID3D12Debug> debugLayer = TypedD3D::Helpers::D3D12::GetDebugInterface();
-//    debugLayer->EnableDebugLayer();
-//    TypedD3D12::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
-//    TypedD3D12::Wrapper<ID3D12Device1> device = TypedD3D12::CreateDevice<ID3D12Device1>(D3D_FEATURE_LEVEL_12_0);
-//    ComPtr<ID3D12DebugDevice> debugDevice = TypedD3D::Cast<ID3D12DebugDevice>(device.Get());
-//
-//    constexpr UINT backBufferCount = 2;
-//
-//    using namespace TypedD3D;
-//    TypedD3D12::Direct<ID3D12CommandQueue> commandQueue = device->CreateCommandQueue<D3D12_COMMAND_LIST_TYPE_DIRECT>(D3D12_COMMAND_QUEUE_PRIORITY_NORMAL, D3D12_COMMAND_QUEUE_FLAG_NONE, 0);
-//    std::array<TypedD3D12::Direct<ID3D12CommandAllocator>, backBufferCount> commandAllocators;
-//    commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
-//    commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
-//    TypedD3D12::Direct<ID3D12GraphicsCommandList> temp = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
-//    TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList = TypedD3D::Cast<TypedD3D12::Direct<ID3D12GraphicsCommandList1>>(temp);
-//    TypedD3D12::Compute<ID3D12GraphicsCommandList1> commandList54;
-//
-//    //TypedD3D::Compute<ID3D12GraphicsCommandList1> cltest = commandList;
-//    UINT64 fenceValue = 0;
-//    ComPtr<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
-//    HANDLE syncEvent = CreateEventW(nullptr, false, false, nullptr);
-//
-//    TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
-//        commandQueue,
-//        handle,
-//        DXGI_SWAP_CHAIN_DESC1
-//        {
-//            .Format = DXGI_FORMAT_R8G8B8A8_UNORM,
-//            .SampleDesc
-//            {
-//                .Count = 1
-//            },
-//            .BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
-//            .BufferCount = backBufferCount,
-//            .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
-//            .Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
-//        },
-//        nullptr,
-//        nullptr);
-//
-//    TypedD3D12::RTV<ID3D12DescriptorHeap> swapChainBufferDescriptorHeap = device->CreateDescriptorHeap<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>(2, 0);
-//
-//    UINT rtvOffset = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-//    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
-//    DXGI_SWAP_CHAIN_DESC1 desc = swapChain->GetDesc1();
-//
-//    std::array<TypedD3D12::Wrapper<ID3D12Resource>, 2> swapChainBuffers;
-//
-//    for(UINT i = 0; i < desc.BufferCount; i++)
-//    {
-//        swapChainBuffers[i] = swapChain->GetBuffer<ID3D12Resource>(i);
-//
-//        device->CreateRenderTargetView(*swapChainBuffers[i].Get(), nullptr, descriptorHandle);
-//        descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
-//    }
-//
-//
-//
-//    D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc
-//    {
-//        .NumParameters = 0,
-//        .pParameters = nullptr,
-//        .NumStaticSamplers = 0,
-//        .pStaticSamplers = nullptr,
-//        .Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
-//    };
-//
-//    ComPtr<ID3DBlob> signatureBlob;
-//    D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, nullptr);
-//    ComPtr<ID3D12RootSignature> rootSignature = device->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize());
-//
-//    ComPtr<ID3DBlob> vertexBlob;
-//    ComPtr<ID3DBlob> errorBlob;
-//    HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &vertexBlob, &errorBlob);
-//    if(FAILED(hr))
-//    {
-//        char* message = static_cast<char*>(errorBlob->GetBufferPointer());
-//        std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
-//        MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
-//        MessageBox(handle, messageT.get(), L"Error", MB_OK);
-//        return;
-//    }
-//    D3D12_SHADER_BYTECODE vertexByteCode{};
-//    vertexByteCode.BytecodeLength = vertexBlob->GetBufferSize();
-//    vertexByteCode.pShaderBytecode = vertexBlob->GetBufferPointer();
-//
-//    ComPtr<ID3DBlob> pixelBlob;
-//    hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, &pixelBlob, nullptr);
-//    if(FAILED(hr))
-//        return;
-//
-//    D3D12_SHADER_BYTECODE pixelByteCode{};
-//    pixelByteCode.BytecodeLength = pixelBlob->GetBufferSize();
-//    pixelByteCode.pShaderBytecode = pixelBlob->GetBufferPointer();
-//
-//    std::array<D3D12_INPUT_ELEMENT_DESC, 1> inputLayout
-//    {
-//        D3D12_INPUT_ELEMENT_DESC
-//        {
-//            .SemanticName = "POSITION",
-//            .SemanticIndex = 0,
-//            .Format = DXGI_FORMAT_R32G32B32_FLOAT,
-//            .InputSlot = 0,
-//            .AlignedByteOffset = 0,
-//            .InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-//            .InstanceDataStepRate = 0
-//        }
-//    };
-//
-//    D3D12_INPUT_LAYOUT_DESC layoutDesc
-//    {
-//        .pInputElementDescs = inputLayout.data(),
-//        .NumElements = static_cast<UINT>(inputLayout.size())
-//    };
-//
-//    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineState
-//    {
-//        .pRootSignature = rootSignature.Get(),
-//        .VS = vertexByteCode,
-//        .PS = pixelByteCode,
-//        .BlendState = D3D12_BLEND_DESC
-//        {
-//            .AlphaToCoverageEnable = false,
-//            .IndependentBlendEnable = false
-//        },
-//        .SampleMask = 0xff'ff'ff'ff,
-//        .RasterizerState = D3D12_RASTERIZER_DESC
-//        {
-//            .FillMode = D3D12_FILL_MODE_SOLID,
-//            .CullMode = D3D12_CULL_MODE_NONE,
-//            .FrontCounterClockwise = true,
-//            .DepthBias = 0,
-//            .DepthBiasClamp = 0,
-//            .SlopeScaledDepthBias = 0,
-//            .DepthClipEnable = true,
-//            .MultisampleEnable = false,
-//            .AntialiasedLineEnable = false,
-//            .ForcedSampleCount = 0,
-//            .ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
-//        },
-//        .InputLayout = layoutDesc,
-//        .PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
-//        .NumRenderTargets = 1,
-//        .SampleDesc = TypedD3D::GetDescription(*swapChain.Get()).SampleDesc,
-//    };
-//
-//    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
-//    graphicsPipelineState.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
-//    graphicsPipelineState.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
-//    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
-//    graphicsPipelineState.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
-//    graphicsPipelineState.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
-//    graphicsPipelineState.BlendState.RenderTarget[0].LogicOp = D3D12_LOGIC_OP_NOOP;
-//    graphicsPipelineState.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-//
-//    graphicsPipelineState.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
-//
-//    TypedD3D12::Graphics<ID3D12PipelineState> pipelineState = device->CreateGraphicsPipelineState(graphicsPipelineState);
-//
-//    auto vertices = std::to_array<Vertex>(
-//        {
-//            { -0.5f, -0.5f, 0 },
-//            {  0.0f,  0.5f, 0 },
-//            {  0.5f, -0.5f, 0 },
-//        });
-//
-//    D3D12_HEAP_PROPERTIES vertexHeap
-//    {
-//        .Type = D3D12_HEAP_TYPE_DEFAULT,
-//        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-//        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
-//        .CreationNodeMask = 0,
-//        .VisibleNodeMask = 0
-//    };
-//
-//    D3D12_RESOURCE_DESC vertexDesc
-//    {
-//        .Dimension = D3D12_RESOURCE_DIMENSION_BUFFER,
-//        .Alignment = 0,
-//        .Width = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-//        .Height = 1,
-//        .DepthOrArraySize = 1,
-//        .MipLevels = 1,
-//        .Format = DXGI_FORMAT_UNKNOWN,
-//        .SampleDesc = {.Count = 1, . Quality = 0},
-//        .Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-//        .Flags = D3D12_RESOURCE_FLAG_NONE
-//    };
-//
-//
-//    Wrapper<ID3D12Resource> vertexResource = device->CreateCommittedResource(
-//        vertexHeap,
-//        D3D12_HEAP_FLAG_NONE,
-//        vertexDesc,
-//        D3D12_RESOURCE_STATE_COPY_DEST,
-//        nullptr);
-//
-//
-//    D3D12_HEAP_PROPERTIES uploadProperties
-//    {
-//        .Type = D3D12_HEAP_TYPE_UPLOAD,
-//        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-//        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
-//        .CreationNodeMask = 0,
-//        .VisibleNodeMask = 0
-//    };
-//    Wrapper<ID3D12Resource> vertexUpload = device->CreateCommittedResource(
-//        uploadProperties,
-//        D3D12_HEAP_FLAG_NONE,
-//        vertexDesc,
-//        D3D12_RESOURCE_STATE_GENERIC_READ,
-//        nullptr);
-//
-//    D3D12_SUBRESOURCE_DATA vertexData
-//    {
-//        .pData = vertices.data(),
-//        .RowPitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-//        .SlicePitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
-//    };
-//
-//    UpdateSubresources(commandList.Get(), vertexResource.Get(), vertexUpload.Get(), 0, 0, 1, &vertexData);
-//
-//    D3D12_RESOURCE_BARRIER barrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-//        *vertexResource.Get(),
-//        D3D12_RESOURCE_STATE_COPY_DEST,
-//        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
-//    commandList->ResourceBarrier(std::span(&barrier, 1));
-//    commandList->Close();
-//    TypedD3D12::Direct<ID3D12CommandList> a = commandList;
-//    TypedD3D::Array<TypedD3D12::Direct<ID3D12CommandList>, 1> submitList{ commandList };
-//    commandQueue->ExecuteCommandLists(TypedD3D::Span(submitList));
-//
-//    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
-//
-//    D3D12_VERTEX_BUFFER_VIEW vertexBufferView
-//    {
-//        .BufferLocation = vertexResource->GetGPUVirtualAddress(),
-//        .SizeInBytes = static_cast<UINT>(sizeof(Vertex) * vertices.size()),
-//        .StrideInBytes = static_cast<UINT>(sizeof(Vertex))
-//    };
-//
-//    D3D12_VIEWPORT viewport
-//    {
-//        .TopLeftX = 0,
-//        .TopLeftY = 0,
-//        .Width = windowWidth,
-//        .Height = windowHeight,
-//        .MinDepth = 0,
-//        .MaxDepth = 1
-//    };
-//
-//    D3D12_RECT rect
-//    {
-//        .left = 0,
-//        .top = 0,
-//        .right = static_cast<LONG>(windowWidth),
-//        .bottom = static_cast<LONG>(windowHeight)
-//    };
-//
-//    UINT backBuffer = 0;
-//    MSG msg;
-//
-//    std::array<UINT64, backBufferCount> frameWaitValues = {};
-//
-//    std::vector<ID3D12Resource*> resources(backBufferCount);
-//    for(size_t i = 0; i < backBufferCount; i++)
-//    {
-//        resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
-//    }
-//
-//
-//    while(true)
-//    {
-//        if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
-//        {
-//            TranslateMessage(&msg);
-//            DispatchMessageW(&msg);
-//
-//            if(msg.message == WM_QUIT)
-//                break;
-//        }
-//        else
-//        {
-//            TypedD3D::Helpers::D3D12::Frame(
-//                { *swapChain.Get() },
-//                { *fence.Get() },
-//                *commandQueue.Get(),
-//                frameWaitValues[backBuffer],
-//                fenceValue,
-//                backBuffer,
-//                frameWaitValues.size(),
-//                [&](const TypedD3D::Helpers::D3D12::FrameData& frameData)
-//                {
-//                    TypedD3D::Helpers::D3D12::RecordAndExecute(
-//                        *commandList.Get(), 
-//                        *commandAllocators[frameData.backBufferIndex].Get(), 
-//                        frameData.commandQueue,
-//                        [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
-//                        {
-//                            D3D12_RESOURCE_BARRIER beginBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-//                                *swapChainBuffers[frameData.backBufferIndex].Get(),
-//                                D3D12_RESOURCE_STATE_PRESENT,
-//                                D3D12_RESOURCE_STATE_RENDER_TARGET);
-//
-//                            D3D12_RESOURCE_BARRIER endBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
-//                                *swapChainBuffers[frameData.backBufferIndex].Get(),
-//                                D3D12_RESOURCE_STATE_RENDER_TARGET,
-//                                D3D12_RESOURCE_STATE_PRESENT);
-//
-//                            TypedD3D::Helpers::D3D12::ResourceBarrier(*commandList.Get(), std::span(&beginBarrier, 1), std::span(&endBarrier, 1),
-//                                [&](TypedD3D12::Direct<ID3D12GraphicsCommandList1> commandList)
-//                                {
-//                                    TypedD3D12::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> backBufferHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset);
-//                                    commandList->ClearRenderTargetView(backBufferHandle, std::to_array({ 0.f, 0.3f, 0.7f, 1.f }), {});
-//                                    commandList->OMSetRenderTargets(std::span(&backBufferHandle, 1), true, nullptr);
-//
-//                                    commandList->SetPipelineState(pipelineState.Get());
-//                                    commandList->SetGraphicsRootSignature(rootSignature.Get());
-//                                    commandList->RSSetViewports(std::span(&viewport, 1));
-//                                    commandList->RSSetScissorRects(std::span(&rect, 1));
-//                                    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-//                                    commandList->IASetVertexBuffers(0, std::span(&vertexBufferView, 1));
-//                                    commandList->DrawInstanced(3, 1, 0, 0);
-//                                });
-//                        });
-//                });
-//        }
-//    }
-//    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
-//
-//    debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_FLAGS::D3D12_RLDO_SUMMARY | D3D12_RLDO_IGNORE_INTERNAL);
-//
-//    assert(swapChain != nullptr);
-//    assert(factory != nullptr);
-//
-//
-//    UnregisterClassW(windowName, nullptr);
+    CreateWindow();
+    //TypedD3D12::CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> b;
+    //TypedD3D::expected<ComPtr<IDXGIFactory2>, HRESULT> factory = TypedD3D::IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory1);
+    //TypedD3D::Wrapper<IDXGIAdapter> adapter = factory->EnumAdapters<IDXGIAdapter>(0);
+    //ComPtr<ID3D12Debug> debugLayer = TypedD3D::Helpers::D3D12::GetDebugInterface();
+    //debugLayer->EnableDebugLayer();
+    TypedD3D::Wrapper<IDXGIFactory2> factory = TypedDXGI::CreateFactory1<IDXGIFactory2>();
+    //TypedD3D::Wrapper<ID3D12Device> device = TypedD3D12::CreateDevice<ID3D12Device>(D3D_FEATURE_LEVEL_12_0);
+    TypedD3D::Wrapper<ID3D12Device> device = TypedD3D::ForwardFunction<TypedD3D::Wrapper<ID3D12Device>>(D3D12CreateDevice, nullptr, D3D_FEATURE_LEVEL_12_0);
+    //ComPtr<ID3D12DebugDevice> debugDevice = TypedD3D::Cast<ID3D12DebugDevice>(device.Get());
+
+    constexpr UINT backBufferCount = 2;
+
+    using namespace TypedD3D;
+    TypedD3D::Direct<ID3D12CommandQueue> commandQueue = device->CreateCommandQueue<D3D12_COMMAND_LIST_TYPE_DIRECT>(D3D12_COMMAND_QUEUE_PRIORITY_NORMAL, D3D12_COMMAND_QUEUE_FLAG_NONE, 0);
+    std::array<TypedD3D::Direct<ID3D12CommandAllocator>, backBufferCount> commandAllocators;
+    commandAllocators[0] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
+    commandAllocators[1] = device->CreateCommandAllocator<D3D12_COMMAND_LIST_TYPE_DIRECT>();
+    TypedD3D::Direct<ID3D12GraphicsCommandList> commandList = device->CreateCommandList<D3D12_COMMAND_LIST_TYPE_DIRECT>(commandAllocators[0]);
+    //TypedD3D::Direct<ID3D12GraphicsCommandList1> commandList = TypedD3D::Cast<TypedD3D::Direct<ID3D12GraphicsCommandList1>>(temp);
+    //TypedD3D::Compute<ID3D12GraphicsCommandList1> commandList54;
+
+    //TypedD3D::Compute<ID3D12GraphicsCommandList1> cltest = commandList;
+    UINT64 fenceValue = 0;
+    TypedD3D::Wrapper<ID3D12Fence> fence = device->CreateFence(fenceValue, D3D12_FENCE_FLAG_NONE);
+    HANDLE syncEvent = CreateEventW(nullptr, false, false, nullptr);
+
+    TypedD3D::Wrapper<IDXGISwapChain3> swapChain = factory->CreateSwapChainForHwnd<IDXGISwapChain3>(
+        commandQueue,
+        handle,
+        DXGI_SWAP_CHAIN_DESC1
+        {
+            .Format = DXGI_FORMAT_R8G8B8A8_UNORM,
+            .SampleDesc
+            {
+                .Count = 1
+            },
+            .BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            .BufferCount = backBufferCount,
+            .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,
+            .Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH
+        },
+        nullptr,
+        nullptr);
+
+    TypedD3D::RTV<ID3D12DescriptorHeap> swapChainBufferDescriptorHeap = device->CreateDescriptorHeap<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>(2, 0);
+
+    UINT rtvOffset = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+    TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> descriptorHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
+    DXGI_SWAP_CHAIN_DESC1 desc = swapChain->GetDesc1();
+
+    std::array<TypedD3D::Wrapper<ID3D12Resource>, 2> swapChainBuffers;
+
+    for(UINT i = 0; i < desc.BufferCount; i++)
+    {
+        swapChainBuffers[i] = swapChain->GetBuffer<ID3D12Resource>(i);
+
+        device->CreateRenderTargetView(*swapChainBuffers[i].Get(), nullptr, descriptorHandle);
+        descriptorHandle = descriptorHandle.Offset(1, rtvOffset);
+    }
+
+
+
+    D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc
+    {
+        .NumParameters = 0,
+        .pParameters = nullptr,
+        .NumStaticSamplers = 0,
+        .pStaticSamplers = nullptr,
+        .Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
+    };
+
+    //static_assert(std::same_as<TypedD3D::TypedStruct<TypedD3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE, D3D12_CPU_DESCRIPTOR_HANDLE>>, RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> ;
+
+
+    TypedD3D::Wrapper<ID3DBlob> signatureBlob;
+    D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, TypedD3D::OutPtr{ signatureBlob }, nullptr);
+    TypedD3D::Wrapper<ID3D12RootSignature> rootSignature = device->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize());
+
+    TypedD3D::Wrapper<ID3DBlob> vertexBlob;
+    TypedD3D::Wrapper<ID3DBlob> errorBlob;
+    HRESULT hr = D3DCompileFromFile(L"VertexShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "vs_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, TypedD3D::OutPtr{ vertexBlob }, TypedD3D::OutPtr{ errorBlob });
+    if(FAILED(hr))
+    {
+        char* message = static_cast<char*>(errorBlob->GetBufferPointer());
+        std::unique_ptr<wchar_t[]> messageT = std::make_unique<wchar_t[]>(errorBlob->GetBufferSize());
+        MultiByteToWideChar(CP_ACP, MB_COMPOSITE, message, static_cast<int>(errorBlob->GetBufferSize()), messageT.get(), static_cast<int>(errorBlob->GetBufferSize()));
+        MessageBox(handle, messageT.get(), L"Error", MB_OK);
+        return;
+    }
+    D3D12_SHADER_BYTECODE vertexByteCode{};
+    vertexByteCode.BytecodeLength = vertexBlob->GetBufferSize();
+    vertexByteCode.pShaderBytecode = vertexBlob->GetBufferPointer();
+
+    TypedD3D::Wrapper<ID3DBlob> pixelBlob;
+    hr = D3DCompileFromFile(L"PixelShader.hlsl", nullptr, D3D_COMPILE_STANDARD_FILE_INCLUDE, "main", "ps_5_0", D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION, 0, TypedD3D::OutPtr{ pixelBlob }, nullptr);
+    if(FAILED(hr))
+        return;
+
+    D3D12_SHADER_BYTECODE pixelByteCode{};
+    pixelByteCode.BytecodeLength = pixelBlob->GetBufferSize();
+    pixelByteCode.pShaderBytecode = pixelBlob->GetBufferPointer();
+
+    std::array<D3D12_INPUT_ELEMENT_DESC, 1> inputLayout
+    {
+        D3D12_INPUT_ELEMENT_DESC
+        {
+            .SemanticName = "POSITION",
+            .SemanticIndex = 0,
+            .Format = DXGI_FORMAT_R32G32B32_FLOAT,
+            .InputSlot = 0,
+            .AlignedByteOffset = 0,
+            .InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
+            .InstanceDataStepRate = 0
+        }
+    };
+
+    D3D12_INPUT_LAYOUT_DESC layoutDesc
+    {
+        .pInputElementDescs = inputLayout.data(),
+        .NumElements = static_cast<UINT>(inputLayout.size())
+    };
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC graphicsPipelineState
+    {
+        .pRootSignature = rootSignature.Get(),
+        .VS = vertexByteCode,
+        .PS = pixelByteCode,
+        .BlendState = D3D12_BLEND_DESC
+        {
+            .AlphaToCoverageEnable = false,
+            .IndependentBlendEnable = false
+        },
+        .SampleMask = 0xff'ff'ff'ff,
+        .RasterizerState = D3D12_RASTERIZER_DESC
+        {
+            .FillMode = D3D12_FILL_MODE_SOLID,
+            .CullMode = D3D12_CULL_MODE_NONE,
+            .FrontCounterClockwise = true,
+            .DepthBias = 0,
+            .DepthBiasClamp = 0,
+            .SlopeScaledDepthBias = 0,
+            .DepthClipEnable = true,
+            .MultisampleEnable = false,
+            .AntialiasedLineEnable = false,
+            .ForcedSampleCount = 0,
+            .ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
+        },
+        .InputLayout = layoutDesc,
+        .PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+        .NumRenderTargets = 1,
+        .SampleDesc = swapChain->GetDesc().SampleDesc,
+    };
+
+    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlend = D3D12_BLEND_ONE;
+    graphicsPipelineState.BlendState.RenderTarget[0].DestBlend = D3D12_BLEND_ZERO;
+    graphicsPipelineState.BlendState.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
+    graphicsPipelineState.BlendState.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
+    graphicsPipelineState.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+    graphicsPipelineState.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
+    graphicsPipelineState.BlendState.RenderTarget[0].LogicOp = D3D12_LOGIC_OP_NOOP;
+    graphicsPipelineState.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+
+    graphicsPipelineState.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    TypedD3D::Graphics<ID3D12PipelineState> pipelineState = device->CreateGraphicsPipelineState(graphicsPipelineState);
+
+    auto vertices = std::to_array<Vertex>(
+        {
+            { -0.5f, -0.5f, 0 },
+            {  0.0f,  0.5f, 0 },
+            {  0.5f, -0.5f, 0 },
+        });
+
+    D3D12_HEAP_PROPERTIES vertexHeap
+    {
+        .Type = D3D12_HEAP_TYPE_DEFAULT,
+        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
+        .CreationNodeMask = 0,
+        .VisibleNodeMask = 0
+    };
+
+    D3D12_RESOURCE_DESC vertexDesc
+    {
+        .Dimension = D3D12_RESOURCE_DIMENSION_BUFFER,
+        .Alignment = 0,
+        .Width = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+        .Height = 1,
+        .DepthOrArraySize = 1,
+        .MipLevels = 1,
+        .Format = DXGI_FORMAT_UNKNOWN,
+        .SampleDesc = {.Count = 1, . Quality = 0},
+        .Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        .Flags = D3D12_RESOURCE_FLAG_NONE
+    };
+
+
+    Wrapper<ID3D12Resource> vertexResource = device->CreateCommittedResource(
+        vertexHeap,
+        D3D12_HEAP_FLAG_NONE,
+        vertexDesc,
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        nullptr);
+
+
+    D3D12_HEAP_PROPERTIES uploadProperties
+    {
+        .Type = D3D12_HEAP_TYPE_UPLOAD,
+        .CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+        .MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN,
+        .CreationNodeMask = 0,
+        .VisibleNodeMask = 0
+    };
+    Wrapper<ID3D12Resource> vertexUpload = device->CreateCommittedResource(
+        uploadProperties,
+        D3D12_HEAP_FLAG_NONE,
+        vertexDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr);
+
+    D3D12_SUBRESOURCE_DATA vertexData
+    {
+        .pData = vertices.data(),
+        .RowPitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+        .SlicePitch = static_cast<UINT>(vertices.size() * sizeof(Vertex)),
+    };
+
+    UpdateSubresources(commandList.Get(), vertexResource.Get(), vertexUpload.Get(), 0, 0, 1, &vertexData);
+
+    D3D12_RESOURCE_BARRIER barrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+        *vertexResource.Get(),
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER);
+    commandList->ResourceBarrier(std::span(&barrier, 1));
+    commandList->Close();
+
+    TypedD3D::Array<TypedD3D::DirectView<ID3D12CommandList>, 1> submitList{ commandList };
+    commandQueue->ExecuteCommandLists(TypedD3D::Span(submitList));
+
+    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
+
+    D3D12_VERTEX_BUFFER_VIEW vertexBufferView
+    {
+        .BufferLocation = vertexResource->GetGPUVirtualAddress(),
+        .SizeInBytes = static_cast<UINT>(sizeof(Vertex) * vertices.size()),
+        .StrideInBytes = static_cast<UINT>(sizeof(Vertex))
+    };
+
+    D3D12_VIEWPORT viewport
+    {
+        .TopLeftX = 0,
+        .TopLeftY = 0,
+        .Width = windowWidth,
+        .Height = windowHeight,
+        .MinDepth = 0,
+        .MaxDepth = 1
+    };
+
+    D3D12_RECT rect
+    {
+        .left = 0,
+        .top = 0,
+        .right = static_cast<LONG>(windowWidth),
+        .bottom = static_cast<LONG>(windowHeight)
+    };
+
+    UINT backBuffer = 0;
+    MSG msg;
+
+    std::array<UINT64, backBufferCount> frameWaitValues = {};
+
+    std::vector<ID3D12Resource*> resources(backBufferCount);
+    for(size_t i = 0; i < backBufferCount; i++)
+    {
+        resources[i] = swapChain->GetBuffer<ID3D12Resource>(i).Get();
+    }
+
+
+    while(true)
+    {
+        if(PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+        {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+
+            if(msg.message == WM_QUIT)
+                break;
+        }
+        else
+        {
+            TypedD3D::Helpers::D3D12::Frame(
+                { *swapChain.Get() },
+                { *fence.Get() },
+                *commandQueue.Get(),
+                frameWaitValues[backBuffer],
+                fenceValue,
+                backBuffer,
+                frameWaitValues.size(),
+                [&](const TypedD3D::Helpers::D3D12::FrameData& frameData)
+                {
+                    TypedD3D::Helpers::D3D12::RecordAndExecute(
+                        *commandList.Get(), 
+                        *commandAllocators[frameData.backBufferIndex].Get(), 
+                        frameData.commandQueue,
+                        [&](TypedD3D::Direct<ID3D12GraphicsCommandList> commandList)
+                        {
+                            D3D12_RESOURCE_BARRIER beginBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+                                *swapChainBuffers[frameData.backBufferIndex].Get(),
+                                D3D12_RESOURCE_STATE_PRESENT,
+                                D3D12_RESOURCE_STATE_RENDER_TARGET);
+
+                            D3D12_RESOURCE_BARRIER endBarrier = TypedD3D::Helpers::D3D12::TransitionBarrier(
+                                *swapChainBuffers[frameData.backBufferIndex].Get(),
+                                D3D12_RESOURCE_STATE_RENDER_TARGET,
+                                D3D12_RESOURCE_STATE_PRESENT);
+
+                            TypedD3D::Helpers::D3D12::ResourceBarrier(*commandList.Get(), std::span(&beginBarrier, 1), std::span(&endBarrier, 1),
+                                [&](TypedD3D::Direct<ID3D12GraphicsCommandList> commandList)
+                                {
+                                    TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> backBufferHandle = swapChainBufferDescriptorHeap->GetCPUDescriptorHandleForHeapStart().Offset(frameData.backBufferIndex, rtvOffset);
+                                    TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE> b2;
+                                    b2 = backBufferHandle;
+                                    auto color = std::to_array({ 0.f, 0.3f, 0.7f, 1.f });
+                                    std::span<const float, 4> f = color;
+
+                                    commandList->ClearRenderTargetView(backBufferHandle, std::to_array({ 0.f, 0.3f, 0.7f, 1.f }));
+                                    commandList->OMSetRenderTargets(std::span<const TypedD3D::RTV<D3D12_CPU_DESCRIPTOR_HANDLE>>(&backBufferHandle, 1), true, nullptr);
+
+                                    commandList->SetPipelineState(pipelineState);
+                                    commandList->SetGraphicsRootSignature(rootSignature.Get());
+                                    commandList->RSSetViewports(std::span(&viewport, 1));
+                                    commandList->RSSetScissorRects(std::span(&rect, 1));
+                                    commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+                                    commandList->IASetVertexBuffers(0, std::span(&vertexBufferView, 1));
+                                    commandList->DrawInstanced(3, 1, 0, 0);
+                                });
+                        });
+                });
+        }
+    }
+    TypedD3D::Helpers::D3D12::FlushCommandQueue(*commandQueue.Get(), *fence.Get(), fenceValue, syncEvent);
+
+    //debugDevice->ReportLiveDeviceObjects(D3D12_RLDO_DETAIL | D3D12_RLDO_FLAGS::D3D12_RLDO_SUMMARY | D3D12_RLDO_IGNORE_INTERNAL);
+
+    assert(swapChain != nullptr);
+    assert(factory != nullptr);
+
+
+    UnregisterClassW(windowName, nullptr);
 }
-//
-//
-//
-//
-//static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-//{
-//    switch(uMsg)
-//    {
-//    case WM_DESTROY:
-//        PostQuitMessage(0);
-//        return 0;
-//        break;
-//    }
-//
-//    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
-//}
-//
-//void CreateWindow()
-//{
-//    WNDCLASSW windowClass{};
-//    windowClass.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
-//    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
-//    windowClass.hInstance = NULL;
-//    windowClass.lpfnWndProc = WndProc;
-//    windowClass.lpszClassName = windowName;
-//    windowClass.style = CS_HREDRAW | CS_VREDRAW;
-//
-//
-//    if(!RegisterClassW(&windowClass))
-//    {
-//        MessageBoxW(NULL, L"Could not register class", L"Error", MB_OK);
-//        throw std::exception("Could not register class");
-//    }
-//
-//    handle = CreateWindowExW(0,
-//        windowName,
-//        windowName,
-//        WS_OVERLAPPEDWINDOW,
-//        CW_USEDEFAULT,
-//        CW_USEDEFAULT,
-//        static_cast<int>(windowWidth),
-//        static_cast<int>(windowHeight),
-//        NULL,
-//        NULL,
-//        NULL,
-//        NULL);
-//
-//    if(!handle)
-//    {
-//        MessageBox(NULL, L"Could not create window", L"Error", MB_OK);
-//        throw std::exception("Could not create window");
-//    }
-//
-//    ShowWindow(handle, SW_RESTORE);
-//}
+
+
+
+
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch(uMsg)
+    {
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+        break;
+    }
+
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+}
+
+void CreateWindow()
+{
+    WNDCLASSW windowClass{};
+    windowClass.hbrBackground = (HBRUSH)GetStockObject(WHITE_BRUSH);
+    windowClass.hCursor = LoadCursor(NULL, IDC_ARROW);
+    windowClass.hInstance = NULL;
+    windowClass.lpfnWndProc = WndProc;
+    windowClass.lpszClassName = windowName;
+    windowClass.style = CS_HREDRAW | CS_VREDRAW;
+
+
+    if(!RegisterClassW(&windowClass))
+    {
+        MessageBoxW(NULL, L"Could not register class", L"Error", MB_OK);
+        throw std::exception("Could not register class");
+    }
+
+    handle = CreateWindowExW(0,
+        windowName,
+        windowName,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        static_cast<int>(windowWidth),
+        static_cast<int>(windowHeight),
+        NULL,
+        NULL,
+        NULL,
+        NULL);
+
+    if(!handle)
+    {
+        MessageBox(NULL, L"Could not create window", L"Error", MB_OK);
+        throw std::exception("Could not create window");
+    }
+
+    ShowWindow(handle, SW_RESTORE);
+}

--- a/TESTS/Source.cpp
+++ b/TESTS/Source.cpp
@@ -1,11 +1,53 @@
 #include <Windows.h>
-
+#include <concepts>
 extern void D3D12HelloWorld();
 extern void D3D11HelloWorld();
 
+struct Foo
+{
+    struct Bar
+    {
+
+        Bar* operator->() { return this; }
+    };
+
+    Bar operator->() const { return Bar{}; }
+    Bar operator*() const { return Bar{}; }
+};
+
+struct Baz
+{
+
+};
+
+template<class Ty>
+struct FooBaz
+{
+
+};
+
+template<std::derived_from<Foo> Ty>
+struct FooBaz<Ty>
+{
+
+};
+
+template<std::derived_from<Baz> Ty>
+struct FooBaz<Ty>
+{
+
+};
+
+template<>
+struct FooBaz<Baz>
+{
+
+};
+
+
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPWSTR lpCmdLine, _In_ int nCmdShow)
 {
-    D3D12HelloWorld();
+    D3D11HelloWorld();
 
     return 0;
 }

--- a/TESTS/Source.cpp
+++ b/TESTS/Source.cpp
@@ -5,7 +5,7 @@ extern void D3D11HelloWorld();
 
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPWSTR lpCmdLine, _In_ int nCmdShow)
 {
-    D3D11HelloWorld();
+    D3D12HelloWorld();
 
     return 0;
 }

--- a/TESTS/Source.cpp
+++ b/TESTS/Source.cpp
@@ -3,48 +3,6 @@
 extern void D3D12HelloWorld();
 extern void D3D11HelloWorld();
 
-struct Foo
-{
-    struct Bar
-    {
-
-        Bar* operator->() { return this; }
-    };
-
-    Bar operator->() const { return Bar{}; }
-    Bar operator*() const { return Bar{}; }
-};
-
-struct Baz
-{
-
-};
-
-template<class Ty>
-struct FooBaz
-{
-
-};
-
-template<std::derived_from<Foo> Ty>
-struct FooBaz<Ty>
-{
-
-};
-
-template<std::derived_from<Baz> Ty>
-struct FooBaz<Ty>
-{
-
-};
-
-template<>
-struct FooBaz<Baz>
-{
-
-};
-
-
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPWSTR lpCmdLine, _In_ int nCmdShow)
 {
     D3D11HelloWorld();

--- a/TypedD3D.sln
+++ b/TypedD3D.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.31911.260
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11121.172 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TESTS", "TESTS\TESTS.vcxproj", "{7E42D240-4BB9-476F-9776-35A097441584}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TypedD3D", "TypedD3D\TypedD3D12.vcxproj", "{4C07B140-D4BD-40D4-BE41-18E6AA4D78EF}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExceptionHierarchy", "ExceptionHierarchy\ExceptionHierarchy\ExceptionHierarchy.vcxproj", "{BB10395F-CED5-4F0D-BC01-8740A181207D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "API_TESTS", "API_TESTS\API_TESTS.vcxproj", "{A6886362-A0EE-4A35-8582-85B34E4D5248}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,14 @@ Global
 		{BB10395F-CED5-4F0D-BC01-8740A181207D}.Release|x64.Build.0 = Release|x64
 		{BB10395F-CED5-4F0D-BC01-8740A181207D}.Release|x86.ActiveCfg = Release|Win32
 		{BB10395F-CED5-4F0D-BC01-8740A181207D}.Release|x86.Build.0 = Release|Win32
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Debug|x64.ActiveCfg = Debug|x64
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Debug|x64.Build.0 = Debug|x64
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Debug|x86.ActiveCfg = Debug|Win32
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Debug|x86.Build.0 = Debug|Win32
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Release|x64.ActiveCfg = Release|x64
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Release|x64.Build.0 = Release|x64
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Release|x86.ActiveCfg = Release|Win32
+		{A6886362-A0EE-4A35-8582-85B34E4D5248}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TypedD3D/Containers.ixx
+++ b/TypedD3D/Containers.ixx
@@ -536,6 +536,11 @@ namespace TypedD3D
 		{
 			return ptr == rh.Get();
 		}
+
+		bool operator==(const ElementReference& rh) const
+		{
+			return ptr == rh.Get();
+		}
 	public:
 		operator Wrapper() const noexcept { return { ptr }; }
 

--- a/TypedD3D/Containers.ixx
+++ b/TypedD3D/Containers.ixx
@@ -226,9 +226,9 @@ namespace TypedD3D
 			return this->ptr == ptr.Get();
 		}
 
-		template<class OtherTrait>
-			requires std::equality_comparable_with<unknown_type*, typename OtherTrait::unknown_type*>
-		bool operator==(const WeakWrapper<OtherTrait>& ptr) const noexcept
+		template<IUnknownWrapperTest Wrapper>
+			requires ConvertibleTraitTo<typename Wrapper::trait_type, trait_type>
+		bool operator==(const Wrapper& ptr) const noexcept
 		{
 			return this->ptr == ptr.Get();
 		}
@@ -419,9 +419,9 @@ namespace TypedD3D
 			return this->ptr == ptr.Get();
 		}
 
-		template<class OtherTrait>
-			requires std::equality_comparable_with<unknown_type*, typename OtherTrait::unknown_type*>
-		bool operator==(const StrongWrapper<OtherTrait>& ptr) const noexcept
+		template<IUnknownWrapperTest Wrapper>
+			requires ConvertibleTraitTo<typename Wrapper::trait_type, trait_type>
+		bool operator==(const Wrapper& ptr) const noexcept
 		{
 			return this->ptr == ptr.Get();
 		}
@@ -486,12 +486,6 @@ namespace TypedD3D
 		operator void** () noexcept { return &ptr; }
 		operator Wrapper::unknown_type** () noexcept { return &ptr; }
 	};
-
-	template<IUnknownTrait Trait1, IUnknownTrait Trait2>
-	bool operator==(const StrongWrapper<Trait1>& lh, const WeakWrapper<Trait2> rh) noexcept
-	{
-		return lh.Get() == rh.Get();
-	}
 
 	export template<class To, class From, template<class> class Trait>
 	WeakWrapper<Trait<To>> Cast(WeakWrapper<Trait<From>> ptr) noexcept
@@ -684,7 +678,8 @@ namespace TypedD3D
 		return Cast<To>(Wrapper<Trait<From>>{ ptr });
 	}
 
-	export template<class Wrapper, std::size_t N>
+
+	export template<IUnknownWrapperTest Wrapper, std::size_t N>
 	class TestArray
 	{
 		using unknown_type = Wrapper::unknown_type;

--- a/TypedD3D/Containers.ixx
+++ b/TypedD3D/Containers.ixx
@@ -1,0 +1,452 @@
+module;
+
+#include <concepts>
+#include <Unknwn.h>
+#include <utility>
+#include <d3d11.h>
+
+export module TypedD3D.Containers;
+
+namespace TypedD3D
+{
+	template<class Ty>
+	struct LiftType
+	{
+		using type = Ty;
+	};
+
+	template<template<class> class Outer, class Inner>
+	struct LiftType<Outer<Inner>>
+	{
+		template<class Ty>
+		using type = Outer<Ty>;
+	};
+
+	template<class Ty>
+	struct InnerTypeImpl
+	{
+		using type = Ty;
+	};
+
+	template<template<class> class Outer, class Inner>
+	struct InnerTypeImpl<Outer<Inner>>
+	{
+		using type = Inner;
+	};
+
+	template<class Ty>
+	using InnerType = InnerTypeImpl<Ty>::type;
+
+	template<class Ty>
+	concept IUnknownTrait = requires()
+	{
+		typename Ty::template Interface<void>;
+	} && std::derived_from<InnerType<Ty>, IUnknown> && std::same_as<typename LiftType<Ty>::template type<InnerType<Ty>>, Ty>;
+
+	export template<IUnknownTrait Trait>
+	class InterfaceProxy : public Trait::template Interface<InterfaceProxy<Trait>>
+	{
+		using unknown_type = Trait::unknown_type;
+		using trait_type = Trait;
+		template<class Derived>
+		using interface_type = trait_type::template Interface<Derived>;
+
+	private:
+		unknown_type* ptr;
+
+		friend Trait::template Interface<InterfaceProxy>;
+	public:
+		InterfaceProxy(unknown_type* ptr) noexcept : ptr{ ptr }
+		{
+		}
+
+	public:
+		auto operator->() noexcept { return this; }
+
+	private:
+		unknown_type* Get() const noexcept { return ptr; }
+	};
+
+	export template<IUnknownTrait Trait>
+	class WeakWrapper
+	{
+	public:
+		using unknown_type = Trait::unknown_type;
+		using trait_type = Trait;
+		template<class Derived>
+		using interface_type = trait_type::template Interface<Derived>;
+
+		template<IUnknownTrait Trait>
+		friend class WeakWrapper;
+
+	private:
+		unknown_type* ptr = nullptr;
+
+	public:
+		WeakWrapper() noexcept = default;
+		WeakWrapper(const WeakWrapper&) noexcept = default;
+		WeakWrapper(WeakWrapper&& other) noexcept : ptr{ std::exchange(other.ptr, nullptr) }
+		{
+
+		}
+
+		template<IUnknownTrait Trait2>
+		WeakWrapper(const WeakWrapper<Trait2>& other) noexcept : ptr{ other.ptr }
+		{
+
+		}
+
+		template<IUnknownTrait Trait2>
+		WeakWrapper(WeakWrapper<Trait2>&& other) noexcept : ptr{ std::exchange(other.ptr, nullptr) }
+		{
+
+		}
+		~WeakWrapper() = default;
+		WeakWrapper(std::nullptr_t) noexcept {}
+		WeakWrapper(unknown_type* ptr) noexcept : ptr{ ptr } {}
+
+		WeakWrapper& operator=(const WeakWrapper&) noexcept = default;
+		WeakWrapper& operator=(WeakWrapper&& other) noexcept
+		{
+			ptr = std::exchange(other.ptr, nullptr);
+			return *this;
+		}
+		WeakWrapper& operator=(std::nullptr_t) noexcept
+		{
+			ptr = nullptr;
+			return *this;
+		}
+		WeakWrapper& operator=(unknown_type* ptr) noexcept
+		{
+			this->ptr = ptr;
+			return *this;
+		}
+
+		bool operator==(std::nullptr_t) const noexcept
+		{
+			return ptr == nullptr;
+		}
+
+		bool operator==(unknown_type* ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		bool operator==(const WeakWrapper& ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		template<class OtherTrait>
+			requires std::equality_comparable_with<unknown_type, typename OtherTrait::unknown_type>
+		bool operator==(const WeakWrapper<OtherTrait>& ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		InterfaceProxy<Trait> operator->() const noexcept requires (!std::same_as<interface_type<InterfaceProxy<Trait>>, unknown_type*>) { return ptr; }
+		InterfaceProxy<Trait> operator*() const noexcept requires (!std::same_as<interface_type<InterfaceProxy<Trait>>, unknown_type*>) { return ptr; }
+
+		unknown_type* operator->() const noexcept { return ptr; }
+		unknown_type& operator*() const noexcept { return *ptr; }
+		
+		explicit operator bool() const noexcept { return ptr; }
+
+		friend void swap(WeakWrapper& lh, WeakWrapper& rh) noexcept
+		{
+			std::swap(lh.ptr, rh.ptr);
+		}
+
+	public:
+		unknown_type* Get() const { return ptr; }
+
+		void Attach(unknown_type* ptr) noexcept
+		{
+			this->ptr = ptr;
+		}
+
+		unknown_type* Detach() noexcept
+		{
+			return std::exchange(ptr, nullptr);
+		}
+
+		ULONG Acquire() noexcept
+		{
+			return ptr->AddRef();
+		}
+		ULONG Release() noexcept
+		{
+			return ptr->Release();
+		}
+	};
+
+	export template<IUnknownTrait Trait>
+	class StrongWrapper
+	{
+	public:
+		using unknown_type = Trait::unknown_type;
+		using trait_type = Trait;
+		template<class Derived>
+		using interface_type = trait_type::template Interface<Derived>;
+
+		template<IUnknownTrait Trait>
+		friend class StrongWrapper;
+
+	private:
+		unknown_type* ptr = nullptr;
+
+	public:
+		StrongWrapper() noexcept = default;
+		StrongWrapper(const StrongWrapper& other) noexcept : ptr{ other.ptr }
+		{
+			if(ptr)
+				Acquire();
+		}
+		StrongWrapper(StrongWrapper&& other) noexcept : ptr{ std::exchange(other.ptr, nullptr) }
+		{
+
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper(const StrongWrapper<Trait2>& other) noexcept : ptr{ other.ptr }
+		{
+			if(ptr)
+				Acquire();
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper(StrongWrapper<Trait2>&& other) noexcept : ptr{ std::exchange(other.ptr, nullptr) }
+		{
+
+		}
+		~StrongWrapper()
+		{
+			if(ptr)
+				Release();
+		}
+		StrongWrapper(std::nullptr_t) noexcept {}
+		StrongWrapper(unknown_type* ptr) noexcept : ptr{ ptr }
+		{
+			if(ptr)
+				Acquire();
+		}
+
+		StrongWrapper(const WeakWrapper<Trait>& other) noexcept : ptr{ other.Get() }
+		{
+			if(ptr)
+				Acquire();
+		}
+		StrongWrapper(WeakWrapper<Trait>&& other) noexcept : ptr{ other.Detach() }
+		{
+			if(ptr)
+				Acquire();
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper(const WeakWrapper<Trait2>& other) noexcept : ptr{ other.Get() }
+		{
+			if(ptr)
+				Acquire();
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper(WeakWrapper<Trait2>&& other) noexcept : ptr{ other.Detach() }
+		{
+			if(ptr)
+				Acquire();
+		}
+
+		StrongWrapper& operator=(StrongWrapper other) noexcept
+		{
+			swap(*this, other);
+			return *this;
+		}
+		StrongWrapper& operator=(StrongWrapper&& other) noexcept
+		{
+			auto temp = std::move(other);
+			swap(*this, temp);
+			return *this;
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper& operator=(StrongWrapper<Trait2> other) noexcept
+		{
+			StrongWrapper temp{ std::move(other) };
+			swap(*this, temp);
+			return *this;
+		}
+		template<IUnknownTrait Trait2>
+		StrongWrapper& operator=(StrongWrapper<Trait2>&& other) noexcept
+		{
+			StrongWrapper temp = std::move(other);
+			swap(*this, temp);
+			return *this;
+		}
+
+		StrongWrapper& operator=(WeakWrapper<Trait> other) noexcept
+		{
+			StrongWrapper temp{ std::move(other) };
+			swap(*this, other);
+			return *this;
+		}
+		StrongWrapper& operator=(WeakWrapper<Trait>&& other) noexcept
+		{
+			StrongWrapper temp{ std::move(other) };
+			swap(*this, temp);
+			return *this;
+		}
+
+		template<IUnknownTrait Trait2>
+		StrongWrapper& operator=(WeakWrapper<Trait2> other) noexcept
+		{
+			StrongWrapper temp{ std::move(other) };
+			swap(*this, temp);
+			return *this;
+		}
+		template<IUnknownTrait Trait2>
+		StrongWrapper& operator=(WeakWrapper<Trait2>&& other) noexcept
+		{
+			StrongWrapper temp = std::move(other);
+			swap(*this, temp);
+			return *this;
+		}
+
+		StrongWrapper& operator=(std::nullptr_t) noexcept
+		{
+			StrongWrapper temp;
+			swap(*this, temp);
+			return *this;
+		}
+		StrongWrapper& operator=(unknown_type* ptr) noexcept
+		{
+			StrongWrapper temp{ ptr };
+			swap(*this, temp);
+			return *this;
+		}
+
+		bool operator==(std::nullptr_t) const noexcept
+		{
+			return ptr == nullptr;
+		}
+
+		bool operator==(unknown_type* ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		bool operator==(const StrongWrapper& ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		template<class OtherTrait>
+			requires std::equality_comparable_with<unknown_type, typename OtherTrait::unknown_type>
+		bool operator==(const StrongWrapper<OtherTrait>& ptr) const noexcept
+		{
+			return this->ptr == ptr;
+		}
+
+		InterfaceProxy<Trait> operator->() const noexcept requires (!std::same_as<interface_type<InterfaceProxy<Trait>>, unknown_type*>) { return ptr; }
+		InterfaceProxy<Trait> operator*() const noexcept requires (!std::same_as<interface_type<InterfaceProxy<Trait>>, unknown_type*>) { return ptr; }
+
+		unknown_type* operator->() const noexcept { return ptr; }
+		unknown_type& operator*() const noexcept { return *ptr; }
+
+		explicit operator bool() const noexcept { return ptr; }
+
+		operator WeakWrapper<Trait>() const noexcept { return { Get() }; }
+
+		friend void swap(StrongWrapper& lh, StrongWrapper& rh) noexcept
+		{
+			std::swap(lh.ptr, rh.ptr);
+		}
+
+	public:
+		unknown_type* Get() const noexcept { return ptr; }
+
+		void Attach(unknown_type* ptr) noexcept
+		{
+			if(this->ptr)
+				this->ptr->Release();
+			this->ptr = ptr;
+		}
+
+		unknown_type* Detach() noexcept
+		{
+			return std::exchange(ptr, nullptr);
+		}
+
+	private:
+		ULONG Acquire() noexcept
+		{
+			return ptr->AddRef();
+		}
+		ULONG Release() noexcept
+		{
+			return ptr->Release();
+		}
+	};
+
+	template<class Wrapper>
+	class OutPtr
+	{
+		Wrapper::unknown_type* ptr;
+		Wrapper& wrapper;
+
+	public:
+		OutPtr(Wrapper& wrapper) noexcept :
+			wrapper{ wrapper }
+		{
+		}
+
+		~OutPtr()
+		{
+			wrapper.Attach(ptr);
+		}
+
+		operator void** () noexcept { return &ptr; }
+		operator Wrapper::unknown_type** () noexcept { return &ptr; }
+	};
+
+	template<IUnknownTrait Trait1, IUnknownTrait Trait2>
+	bool operator==(const StrongWrapper<Trait1>& lh, const WeakWrapper<Trait2> rh) noexcept
+	{
+		return lh.Get() == rh.Get();
+	}
+
+	export template<class To, class From, template<class> class Trait>
+	WeakWrapper<Trait<To>> Cast(WeakWrapper<Trait<From>> ptr) noexcept
+	{
+		if(!ptr)
+			return {};
+
+		WeakWrapper<Trait<To>> to;
+
+		if(SUCCEEDED(ptr.Get()->QueryInterface<To>(OutPtr{ to })))
+			to->Release();
+
+		return to;
+	}
+
+	export template<class To, class From, template<class> class Trait>
+	StrongWrapper<Trait<To>> Cast(const StrongWrapper<Trait<From>>& ptr) noexcept
+	{
+		if(!ptr)
+			return {};
+
+		StrongWrapper<Trait<To>> out;
+		ptr.Get()->QueryInterface<To>(OutPtr{ out });
+		return out;
+	}
+
+	export template<class To, class From, template<class> class Trait>
+	StrongWrapper<Trait<To>> Cast(StrongWrapper<Trait<From>>&& ptr) noexcept
+	{
+		if(!ptr)
+			return {};
+
+		StrongWrapper<Trait<To>> out;
+		ptr.Get()->QueryInterface<To>(OutPtr{ out });
+		return out;
+	}
+}

--- a/TypedD3D/Containers.ixx
+++ b/TypedD3D/Containers.ixx
@@ -678,6 +678,72 @@ namespace TypedD3D
 		return Cast<To>(Wrapper<Trait<From>>{ ptr });
 	}
 
+	export template<IUnknownWrapperTest Wrapper, bool IsConst>
+	class ContiguousIterator
+	{
+		using unknown_type = Wrapper::unknown_type;
+
+	private:
+		std::conditional_t<IsConst, unknown_type* const, unknown_type*>* ptr = nullptr;
+
+	public:
+		ContiguousIterator() = default;
+		ContiguousIterator(std::conditional_t<IsConst, unknown_type* const, unknown_type*>* ptr) : ptr{ ptr }
+		{
+
+		}
+
+	public:
+		ContiguousIterator& operator++()
+		{
+			++ptr;
+			return *this;
+		}
+		ContiguousIterator operator++(int)
+		{
+			return ptr++;
+		}
+		ContiguousIterator& operator--()
+		{
+			--ptr;
+			return *this;
+		}
+		ContiguousIterator operator--(int)
+		{
+			return ptr--;
+		}
+
+		ContiguousIterator operator+(std::size_t i) const
+		{
+			return ptr + i;
+		}
+
+		ContiguousIterator& operator+=(std::size_t i)
+		{
+			ptr += i;
+			return *this;
+		}
+
+		ContiguousIterator operator-(std::size_t i) const
+		{
+			return ptr + i;
+		}
+
+		ContiguousIterator& operator-=(std::size_t i)
+		{
+			ptr += i;
+			return *this;
+		}
+
+		bool operator==(const ContiguousIterator& other) const
+		{
+			return ptr == other.ptr;
+		}
+
+		ElementReferenceTest<Wrapper, IsConst> operator*() const { return *ptr; }
+		ElementReferenceTest<Wrapper, IsConst> operator->() const { return *ptr; }
+	};
+
 
 	export template<IUnknownWrapperTest Wrapper, std::size_t N>
 	class TestArray
@@ -741,43 +807,49 @@ namespace TypedD3D
 			return values[i];
 		}
 
-		ElementReferenceTest<Wrapper, false> At(std::size_t i) & { return values.at(i); }
-		ElementReferenceTest<Wrapper, true> At(std::size_t i) const& { return values.at(i); }
-		Wrapper At(std::size_t i)&&
+		ElementReferenceTest<Wrapper, false> at(std::size_t i) & { return values.at(i); }
+		ElementReferenceTest<Wrapper, true> at(std::size_t i) const& { return values.at(i); }
+		Wrapper at(std::size_t i)&&
 		{
 			Wrapper out;
 			out.Attach(std::exchange(values.at(i), nullptr));
 			return out;
 		}
-		Wrapper At(std::size_t i) const&&
+		Wrapper at(std::size_t i) const&&
 		{
 			return values.at(i);
 		}
 
-		ElementReferenceTest<Wrapper, false> Front()& { return values.front(); }
-		ElementReferenceTest<Wrapper, true> Front() const& { return values.front(); }
+		ElementReferenceTest<Wrapper, false> front()& { return values.front(); }
+		ElementReferenceTest<Wrapper, true> front() const& { return values.front(); }
 
-		Wrapper Front()&& 
+		Wrapper front()&&
 		{
 			Wrapper out;
 			out.Attach(std::exchange(values.front(), nullptr));
 			return out;
 		}
-		Wrapper Front() const&& { return values.front(); }
+		Wrapper front() const&& { return values.front(); }
 
-		ElementReferenceTest<Wrapper, false> Back()& { return values.back(); }
-		ElementReferenceTest<Wrapper, true> Back() const& { return values.back(); }
+		ElementReferenceTest<Wrapper, false> back()& { return values.back(); }
+		ElementReferenceTest<Wrapper, true> back() const& { return values.back(); }
 
-		Wrapper Back()&&
+		Wrapper back()&&
 		{
 			Wrapper out;
 			out.Attach(std::exchange(values.back(), nullptr));
 			return out;
 		}
-		Wrapper Back() const&& { return values.back(); }
+		Wrapper back() const&& { return values.back(); }
 
-		auto Data() { return values.data(); }
-		const auto Data() const { return values.data(); }
+		auto data() { return values.data(); }
+		const auto data() const { return values.data(); }
+
+		ContiguousIterator<Wrapper, false> begin() { return &values[0]; }
+		ContiguousIterator<Wrapper, false> end() { return &values[values.size()]; }
+
+		ContiguousIterator<Wrapper, true> begin() const { return &values[0]; }
+		ContiguousIterator<Wrapper, true> end() const { return &values[values.size()]; }
 
 	private:
 		void Acquire()

--- a/TypedD3D/TypedD3D12.vcxproj
+++ b/TypedD3D/TypedD3D12.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="source\D3D12\CommandList.ixx" />
     <ClCompile Include="source\D3D12\CommandQueue.ixx" />
     <ClCompile Include="source\D3D12\D3D12DeviceChild.ixx" />
+    <ClCompile Include="source\D3D12\D3D12Object.ixx" />
     <ClCompile Include="source\D3D12\D3D12Wrappers.ixx" />
     <ClCompile Include="source\D3D12\DescriptorHeap.ixx" />
     <ClCompile Include="source\D3D12\D3D12Device.ixx" />

--- a/TypedD3D/TypedD3D12.vcxproj
+++ b/TypedD3D/TypedD3D12.vcxproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="build.cpp" />
-    <ClCompile Include="Containers.ixx" />
+    <ClCompile Include="source\Containers.ixx" />
     <ClCompile Include="source\D3D11\D3D11Constants.ixx" />
     <ClCompile Include="source\D3D11\D3D11Device.ixx" />
     <ClCompile Include="source\D3D11\DeviceContext.ixx" />

--- a/TypedD3D/TypedD3D12.vcxproj
+++ b/TypedD3D/TypedD3D12.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="source\D3D12\PipelineState.ixx" />
     <ClCompile Include="source\D3D11\DeviceChild.ixx" />
     <ClCompile Include="source\DXGI\Adapter.ixx" />
+    <ClCompile Include="source\DXGI\DXGIObject.ixx" />
     <ClCompile Include="source\DXGI\Factory.ixx" />
     <ClCompile Include="source\DXGI\SwapChain.ixx" />
     <ClCompile Include="source\Legacy\D3D12LegacyHelpers.ixx" />

--- a/TypedD3D/TypedD3D12.vcxproj
+++ b/TypedD3D/TypedD3D12.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="build.cpp" />
+    <ClCompile Include="Containers.ixx" />
     <ClCompile Include="source\D3D11\D3D11Constants.ixx" />
     <ClCompile Include="source\D3D11\D3D11Device.ixx" />
     <ClCompile Include="source\D3D11\DeviceContext.ixx" />

--- a/TypedD3D/TypedD3D12.vcxproj.filters
+++ b/TypedD3D/TypedD3D12.vcxproj.filters
@@ -116,6 +116,9 @@
     <ClCompile Include="source\DXGI\DXGIObject.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="source\D3D12\D3D12Object.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="gsl\algorithm" />

--- a/TypedD3D/TypedD3D12.vcxproj.filters
+++ b/TypedD3D/TypedD3D12.vcxproj.filters
@@ -56,9 +56,6 @@
     <ClCompile Include="source\TypedDXGI.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="source\DXGI\Adapter.ixx">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="source\DXGI\Factory.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -111,6 +108,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="source\Containers.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\DXGI\Adapter.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\DXGI\DXGIObject.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TypedD3D/TypedD3D12.vcxproj.filters
+++ b/TypedD3D/TypedD3D12.vcxproj.filters
@@ -110,7 +110,7 @@
     <ClCompile Include="source\D3D12\D3D12DeviceChild.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Containers.ixx">
+    <ClCompile Include="source\Containers.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/TypedD3D/TypedD3D12.vcxproj.filters
+++ b/TypedD3D/TypedD3D12.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClCompile Include="source\D3D12\D3D12DeviceChild.ixx">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Containers.ixx">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="gsl\algorithm" />

--- a/TypedD3D/source/Containers.ixx
+++ b/TypedD3D/source/Containers.ixx
@@ -3,7 +3,6 @@ module;
 #include <concepts>
 #include <Unknwn.h>
 #include <utility>
-#include <d3d11.h>
 #include <algorithm>
 #include <array>
 #include <span>
@@ -121,7 +120,7 @@ namespace TypedD3D
 	class WeakWrapper
 	{
 	public:
-		using inner_type = InnerType<Trait>;
+		using inner_type = Trait::inner_type;
 		using trait_type = Trait;
 		template<class Derived>
 		using interface_type = trait_type::template Interface<Derived>;
@@ -289,7 +288,7 @@ namespace TypedD3D
 	class StrongWrapper
 	{
 	public:
-		using inner_type = InnerType<Trait>;
+		using inner_type = Trait::inner_type;
 		using trait_type = Trait;
 		template<class Derived>
 		using interface_type = trait_type::template Interface<Derived>;
@@ -808,7 +807,10 @@ namespace TypedD3D
 	};
 
 	export template <class Ty>
-	concept TypedStructTrait = LiftableType<Ty> && !std::derived_from<InnerType<Ty>, IUnknown>;
+	concept TypedStructTrait = requires()
+	{
+		typename Ty::template Interface<void>;
+	} && LiftableType<Ty> && !std::derived_from<InnerType<Ty>, IUnknown>;
 
 	export template<TypedStructTrait Ty>
 	struct TypedStruct : private InnerType<Ty>, public Ty::template Interface<TypedStruct<Ty>>

--- a/TypedD3D/source/D3D11/D3D11Device.ixx
+++ b/TypedD3D/source/D3D11/D3D11Device.ixx
@@ -145,21 +145,37 @@ namespace TypedD3D::D3D11
 namespace TypedD3D
 {
 	template<std::derived_from<ID3D11Device> Ty>
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
 		using inner_type = Ty;
 
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
 		template<class Derived>
 		using Interface = Ty*;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 	};
 
 	template<>
-	struct UntaggedTraits<ID3D11Device>
+	struct Trait<Untagged<ID3D11Device>>
 	{
 		using inner_type = ID3D11Device;
 
+		using inner_tag = ID3D11Device;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		struct Interface : public InterfaceBase<UntaggedTraits<Derived>>
+		struct Interface : public InterfaceBase<Untagged<Derived>>
 		{
 			HRESULT CheckCounter(
 				const D3D11_COUNTER_DESC& desc,
@@ -548,8 +564,8 @@ namespace TypedD3D
 				return Self().SetPrivateDataInterface(guid, pData);
 			}
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/D3D11Device.ixx
+++ b/TypedD3D/source/D3D11/D3D11Device.ixx
@@ -147,6 +147,8 @@ namespace TypedD3D
 	template<std::derived_from<ID3D11Device> Ty>
 	struct UntaggedTraits<Ty>
 	{
+		using inner_type = Ty;
+
 		template<class Derived>
 		using Interface = Ty*;
 	};
@@ -154,7 +156,7 @@ namespace TypedD3D
 	template<>
 	struct UntaggedTraits<ID3D11Device>
 	{
-		using unknown_type = ID3D11Device;
+		using inner_type = ID3D11Device;
 
 		template<class Derived>
 		struct Interface : public InterfaceBase<UntaggedTraits<Derived>>
@@ -213,19 +215,19 @@ namespace TypedD3D
 
 			Wrapper<ID3D11BlendState> CreateBlendState(const D3D11_BLEND_DESC& desc)
 			{
-				return ForwardFunction<Wrapper<ID3D11BlendState>>(&unknown_type::CreateBlendState, Self(), &desc);
+				return ForwardFunction<Wrapper<ID3D11BlendState>>(&inner_type::CreateBlendState, Self(), &desc);
 			}
 
 			Wrapper<ID3D11Buffer> CreateBuffer(
 				const D3D11_BUFFER_DESC& desc,
 				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11Buffer>>(&unknown_type::CreateBuffer, Self(), &desc, optInitialData);
+				return ForwardFunction<Wrapper<ID3D11Buffer>>(&inner_type::CreateBuffer, Self(), &desc, optInitialData);
 			}
 
 			Wrapper<ID3D11ClassLinkage> CreateClassLinkage()
 			{
-				return ForwardFunction<Wrapper<ID3D11ClassLinkage>>(&unknown_type::CreateClassLinkage, Self());
+				return ForwardFunction<Wrapper<ID3D11ClassLinkage>>(&inner_type::CreateClassLinkage, Self());
 			}
 
 			Wrapper<ID3D11ComputeShader> CreateComputeShader(
@@ -240,33 +242,33 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11ComputeShader>>(&unknown_type::CreateComputeShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11ComputeShader>>(&inner_type::CreateComputeShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			Wrapper<ID3D11Counter> CreateCounter(
 				const D3D11_COUNTER_DESC& pCounterDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11Counter>>(&unknown_type::CreateCounter, Self(), &pCounterDesc);
+				return ForwardFunction<Wrapper<ID3D11Counter>>(&inner_type::CreateCounter, Self(), &pCounterDesc);
 			}
 
 			template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
 			Wrapper<DeviceContextTy> CreateDeferredContext(
 				UINT ContextFlags)
 			{
-				return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&unknown_type::CreateDeferredContext, Self(), ContextFlags);
+				return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&inner_type::CreateDeferredContext, Self(), ContextFlags);
 			}
 
 			Wrapper<ID3D11DepthStencilState> CreateDepthStencilState(
 				const D3D11_DEPTH_STENCIL_DESC& pDepthStencilDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11DepthStencilState>>(&unknown_type::CreateDepthStencilState, Self(), &pDepthStencilDesc);
+				return ForwardFunction<Wrapper<ID3D11DepthStencilState>>(&inner_type::CreateDepthStencilState, Self(), &pDepthStencilDesc);
 			}
 
 			Wrapper<ID3D11DepthStencilView> CreateDepthStencilView(
 				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				const D3D11_DEPTH_STENCIL_VIEW_DESC* optDesc = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11DepthStencilView>>(&unknown_type::CreateDepthStencilView, Self(), pResource.get().Get(), optDesc);
+				return ForwardFunction<Wrapper<ID3D11DepthStencilView>>(&inner_type::CreateDepthStencilView, Self(), pResource.get().Get(), optDesc);
 			}
 
 			Wrapper<ID3D11DomainShader> CreateDomainShader(
@@ -281,7 +283,7 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11DomainShader>>(&unknown_type::CreateDomainShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11DomainShader>>(&inner_type::CreateDomainShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			Wrapper<ID3D11GeometryShader> CreateGeometryShader(
@@ -296,7 +298,7 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&unknown_type::CreateGeometryShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&inner_type::CreateGeometryShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
@@ -323,7 +325,7 @@ namespace TypedD3D
 				UINT RasterizedStream,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&unknown_type::CreateGeometryShaderWithStreamOutput,
+				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&inner_type::CreateGeometryShaderWithStreamOutput,
 					Self(),
 					pShaderBytecode,
 					BytecodeLength,
@@ -347,7 +349,7 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11HullShader>>(&unknown_type::CreateHullShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11HullShader>>(&inner_type::CreateHullShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			Wrapper<ID3D11InputLayout> CreateInputLayout(
@@ -381,7 +383,7 @@ namespace TypedD3D
 				SIZE_T BytecodeLength)
 			{
 				return ForwardFunction<Wrapper<ID3D11InputLayout>>(
-					&unknown_type::CreateInputLayout,
+					&inner_type::CreateInputLayout,
 					Self(),
 					inputElementDescs.data(),
 					static_cast<UINT>(inputElementDescs.size()),
@@ -401,71 +403,71 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11PixelShader>>(&unknown_type::CreatePixelShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11PixelShader>>(&inner_type::CreatePixelShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			Wrapper<ID3D11Predicate> CreatePredicate(const D3D11_QUERY_DESC& pPredicateDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11Predicate>>(&unknown_type::CreatePredicate, Self(), &pPredicateDesc);
+				return ForwardFunction<Wrapper<ID3D11Predicate>>(&inner_type::CreatePredicate, Self(), &pPredicateDesc);
 			}
 
 			Wrapper<ID3D11Query> CreateQuery(const D3D11_QUERY_DESC& pQueryDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11Query>>(&unknown_type::CreateQuery, Self(), &pQueryDesc);
+				return ForwardFunction<Wrapper<ID3D11Query>>(&inner_type::CreateQuery, Self(), &pQueryDesc);
 			}
 
 			Wrapper<ID3D11RasterizerState>  CreateRasterizerState(
 				const D3D11_RASTERIZER_DESC& pRasterizerDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11RasterizerState>>(&unknown_type::CreateRasterizerState, Self(), &pRasterizerDesc);
+				return ForwardFunction<Wrapper<ID3D11RasterizerState>>(&inner_type::CreateRasterizerState, Self(), &pRasterizerDesc);
 			}
 
 			Wrapper<ID3D11RenderTargetView> CreateRenderTargetView(
 				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				const D3D11_RENDER_TARGET_VIEW_DESC* optDesc = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11RenderTargetView>>(&unknown_type::CreateRenderTargetView, Self(), pResource.get().Get(), optDesc);
+				return ForwardFunction<Wrapper<ID3D11RenderTargetView>>(&inner_type::CreateRenderTargetView, Self(), pResource.get().Get(), optDesc);
 			}
 
 			Wrapper<ID3D11SamplerState> CreateSamplerState(
 				const D3D11_SAMPLER_DESC& pSamplerDesc)
 			{
-				return ForwardFunction<Wrapper<ID3D11SamplerState>>(&unknown_type::CreateSamplerState, Self(), &pSamplerDesc);
+				return ForwardFunction<Wrapper<ID3D11SamplerState>>(&inner_type::CreateSamplerState, Self(), &pSamplerDesc);
 			}
 
 			Wrapper<ID3D11ShaderResourceView> CreateShaderResourceView(
 				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				const D3D11_SHADER_RESOURCE_VIEW_DESC* optDesc = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11ShaderResourceView>>(&unknown_type::CreateShaderResourceView, Self(), pResource.get().Get(), optDesc);
+				return ForwardFunction<Wrapper<ID3D11ShaderResourceView>>(&inner_type::CreateShaderResourceView, Self(), pResource.get().Get(), optDesc);
 			}
 
 			Wrapper<ID3D11Texture1D> CreateTexture1D(
 				const D3D11_TEXTURE1D_DESC& pDesc,
 				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11Texture1D>>(&unknown_type::CreateTexture1D, Self(), &pDesc, optInitialData);
+				return ForwardFunction<Wrapper<ID3D11Texture1D>>(&inner_type::CreateTexture1D, Self(), &pDesc, optInitialData);
 			}
 
 			Wrapper<ID3D11Texture2D> CreateTexture2D(
 				const D3D11_TEXTURE2D_DESC& pDesc,
 				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11Texture2D>>(&unknown_type::CreateTexture2D, Self(), &pDesc, optInitialData);
+				return ForwardFunction<Wrapper<ID3D11Texture2D>>(&inner_type::CreateTexture2D, Self(), &pDesc, optInitialData);
 			}
 
 			Wrapper<ID3D11Texture3D> CreateTexture3D(
 				const D3D11_TEXTURE3D_DESC& pDesc,
 				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11Texture3D>>(&unknown_type::CreateTexture3D, Self(), &pDesc, optInitialData);
+				return ForwardFunction<Wrapper<ID3D11Texture3D>>(&inner_type::CreateTexture3D, Self(), &pDesc, optInitialData);
 			}
 
 			Wrapper<ID3D11UnorderedAccessView> CreateUnorderedAccessView(
 				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				const D3D11_UNORDERED_ACCESS_VIEW_DESC* optDesc = nullptr)
 			{
-				return ForwardFunction<Wrapper<ID3D11UnorderedAccessView>>(&unknown_type::CreateUnorderedAccessView, Self(), pResource.get().Get(), optDesc);
+				return ForwardFunction<Wrapper<ID3D11UnorderedAccessView>>(&inner_type::CreateUnorderedAccessView, Self(), pResource.get().Get(), optDesc);
 			}
 
 
@@ -481,7 +483,7 @@ namespace TypedD3D
 				SIZE_T BytecodeLength,
 				WrapperView<ID3D11ClassLinkage> pClassLinkage)
 			{
-				return ForwardFunction<Wrapper<ID3D11VertexShader>>(&unknown_type::CreateVertexShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+				return ForwardFunction<Wrapper<ID3D11VertexShader>>(&inner_type::CreateVertexShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
 			}
 
 			D3D11_CREATE_DEVICE_FLAG GetCreationFlags()
@@ -507,7 +509,7 @@ namespace TypedD3D
 			template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
             Wrapper<DeviceContextTy> GetImmediateContext()
             {
-                return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&unknown_type::GetImmediateContext, Self());
+                return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&inner_type::GetImmediateContext, Self());
             }
 
 			HRESULT GetPrivateData(REFGUID guid,

--- a/TypedD3D/source/D3D11/D3D11Device.ixx
+++ b/TypedD3D/source/D3D11/D3D11Device.ixx
@@ -4,7 +4,7 @@ module;
 #include <d3d11_4.h>
 #include <span>
 
-#include <wrl/client.h>
+
 
 export module TypedD3D11:Device;
 import :DeviceChild;
@@ -18,748 +18,586 @@ import TypedD3D.Shared;
 
 namespace TypedD3D::D3D11
 {
-#pragma region Device Feature Map
-
-    template<D3D11_FEATURE Feature>
-    struct DeviceFeatureMap;
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_THREADING>
-    {
-        using type = D3D11_FEATURE_DATA_THREADING;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_DOUBLES>
-    {
-        using type = D3D11_FEATURE_DATA_DOUBLES;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_FORMAT_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_FORMAT_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_FORMAT_SUPPORT2>
-    {
-        using type = D3D11_FEATURE_DATA_FORMAT_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS>
-    {
-        using type = D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_ARCHITECTURE_INFO>
-    {
-        using type = D3D11_FEATURE_DATA_ARCHITECTURE_INFO;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D9_OPTIONS>
-    {
-        using type = D3D11_FEATURE_DATA_D3D9_OPTIONS;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_SHADER_MIN_PRECISION_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D9_SHADOW_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS1>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS1;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D9_SIMPLE_INSTANCING_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_MARKER_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_MARKER_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D9_OPTIONS1>
-    {
-        using type = D3D11_FEATURE_DATA_D3D9_OPTIONS1;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS2>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS2;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS3>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS3;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT>
-    {
-        using type = D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS4>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS4;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_SHADER_CACHE>
-    {
-        using type = D3D11_FEATURE_DATA_SHADER_CACHE;
-    };
-
-    template<>
-    struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS5>
-    {
-        using type = D3D11_FEATURE_DATA_D3D11_OPTIONS5;
-    };
-
-#pragma endregion
-
-    template<class Ty>
-    struct DeviceTraits
-    {
-        using unknown_type = Ty;
-        template<class DerivedSelf>
-        using Interface = Ty*;
-    };
-
-    template<>
-    struct DeviceTraits<ID3D11Device>
-    {
-        using value_type = ID3D11Device;
-        using pointer = ID3D11Device*;
-        using const_pointer = const ID3D11Device*;
-        using reference = ID3D11Device&;
-        using const_reference = const ID3D11Device&;
-
-        using unknown_type = ID3D11Device;
-
-        template<class DerivedSelf>
-        class Interface
-        {
-        private:
-            using derived_self = DerivedSelf;
-
-        public:
-            Wrapper<ID3D11Buffer> CreateBuffer(
-                const D3D11_BUFFER_DESC& pDesc,
-                const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11Buffer>(&value_type::CreateBuffer, Get(), &pDesc, optInitialData);
-            }
-
-            Wrapper<ID3D11Texture1D> CreateTexture1D(
-                const D3D11_TEXTURE1D_DESC& pDesc,
-                const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11Texture1D>(&value_type::CreateTexture1D, Get(), &pDesc, optInitialData);
-            }
-
-            Wrapper<ID3D11Texture2D> CreateTexture2D(
-                const D3D11_TEXTURE2D_DESC& pDesc,
-                const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11Texture2D>(&value_type::CreateTexture2D, Get(), &pDesc, optInitialData);
-            }
-
-            Wrapper<ID3D11Texture3D> CreateTexture3D(
-                const D3D11_TEXTURE3D_DESC& pDesc,
-                const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11Texture3D>(&value_type::CreateTexture3D, Get(), &pDesc, optInitialData);
-            }
-
-            Wrapper<ID3D11ShaderResourceView> CreateShaderResourceView(
-                gsl::not_null<Wrapper<ID3D11Resource>> pResource,
-                const D3D11_SHADER_RESOURCE_VIEW_DESC* optDesc = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11ShaderResourceView>(&value_type::CreateShaderResourceView, Get(), pResource.get().Get(), optDesc);
-            }
-
-            Wrapper<ID3D11UnorderedAccessView> CreateUnorderedAccessView(
-                gsl::not_null<Wrapper<ID3D11Resource>> pResource,
-                const D3D11_UNORDERED_ACCESS_VIEW_DESC* optDesc = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11UnorderedAccessView>(&value_type::CreateUnorderedAccessView, Get(), pResource.get().Get(), optDesc);
-            }
-
-            Wrapper<ID3D11RenderTargetView> CreateRenderTargetView(
-                gsl::not_null<Wrapper<ID3D11Resource>> pResource,
-                const D3D11_RENDER_TARGET_VIEW_DESC* optDesc = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11RenderTargetView>(&value_type::CreateRenderTargetView, Get(), pResource.get().Get(), optDesc);
-            }
-
-            Wrapper<ID3D11DepthStencilView> CreateDepthStencilView(
-                gsl::not_null<Wrapper<ID3D11Resource>> pResource,
-                const D3D11_DEPTH_STENCIL_VIEW_DESC* optDesc = nullptr)
-            {
-                return UnknownObjectForwardFunction<ID3D11DepthStencilView>(&value_type::CreateDepthStencilView, Get(), pResource.get().Get(), optDesc);
-            }
-
-            Wrapper<ID3D11InputLayout> CreateInputLayout(
-                std::span<const D3D11_INPUT_ELEMENT_DESC> inputElementDescs,
-                ID3DBlob& pShaderBytecodeWithInputSignature)
-            {
-                return CreateInputLayout(inputElementDescs, pShaderBytecodeWithInputSignature.GetBufferPointer(), pShaderBytecodeWithInputSignature.GetBufferSize());
-            }
-
-            Wrapper<ID3D11InputLayout> CreateInputLayout(
-                D3D11_INPUT_ELEMENT_DESC inputElementDescs,
-                ID3DBlob& pShaderBytecodeWithInputSignature)
-            {
-                return CreateInputLayout(inputElementDescs, pShaderBytecodeWithInputSignature.GetBufferPointer(), pShaderBytecodeWithInputSignature.GetBufferSize());
-            }
-
-            Wrapper<ID3D11InputLayout> CreateInputLayout(
-                D3D11_INPUT_ELEMENT_DESC inputElementDescs,
-                const void* pShaderBytecodeWithInputSignature,
-                SIZE_T BytecodeLength)
-            {
-                return CreateInputLayout(
-                    std::span{ &inputElementDescs, 1 },
-                    pShaderBytecodeWithInputSignature,
-                    BytecodeLength);
-            }
-
-            Wrapper<ID3D11InputLayout> CreateInputLayout(
-                std::span<const D3D11_INPUT_ELEMENT_DESC> inputElementDescs,
-                const void* pShaderBytecodeWithInputSignature,
-                SIZE_T BytecodeLength)
-            {
-                return UnknownObjectForwardFunction<ID3D11InputLayout>(
-                    &value_type::CreateInputLayout, 
-                    Get(), 
-                    inputElementDescs.data(), 
-                    static_cast<UINT>(inputElementDescs.size()), 
-                    pShaderBytecodeWithInputSignature, 
-                    BytecodeLength);
-            }
-
-            Wrapper<ID3D11VertexShader> CreateVertexShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreateVertexShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11VertexShader> CreateVertexShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11VertexShader>(&value_type::CreateVertexShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreateGeometryShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11GeometryShader>(&value_type::CreateGeometryShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                ID3DBlob& pShaderBytecode,
-                std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
-                std::span<const UINT> pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode.GetBufferPointer(),
-                    pShaderBytecode.GetBufferSize(),
-                    pSODeclaration,
-                    pBufferStrides,
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                ID3DBlob& pShaderBytecode,
-                std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
-                UINT pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode.GetBufferPointer(),
-                    pShaderBytecode.GetBufferSize(),
-                    pSODeclaration,
-                    pBufferStrides,
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                ID3DBlob& pShaderBytecode,
-                D3D11_SO_DECLARATION_ENTRY pSODeclaration,
-                std::span<const UINT> pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode.GetBufferPointer(),
-                    pShaderBytecode.GetBufferSize(),
-                    pSODeclaration,
-                    pBufferStrides,
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                ID3DBlob& pShaderBytecode,
-                D3D11_SO_DECLARATION_ENTRY pSODeclaration,
-                UINT pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode.GetBufferPointer(),
-                    pShaderBytecode.GetBufferSize(),
-                    pSODeclaration,
-                    pBufferStrides,
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
-                std::span<const UINT> pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11GeometryShader>(
-                    &value_type::CreateGeometryShaderWithStreamOutput,
-                    Get(),
-                    pShaderBytecode,
-                    BytecodeLength,
-                    pSODeclaration.data(),
-                    static_cast<UINT>(pSODeclaration.size()),
-                    pBufferStrides.data(),
-                    static_cast<UINT>(pBufferStrides.size()),
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                D3D11_SO_DECLARATION_ENTRY pSODeclaration,
-                std::span<const UINT> pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode,
-                    BytecodeLength,
-                    std::span{ &pSODeclaration, 1 },
-                    pBufferStrides,
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
-                UINT pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode,
-                    BytecodeLength,
-                    pSODeclaration,
-                    std::span{ &pBufferStrides, 1 },
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                D3D11_SO_DECLARATION_ENTRY pSODeclaration,
-                UINT pBufferStrides,
-                UINT RasterizedStream,
-                ID3D11ClassLinkage* optClassLinkage)
-            {
-                return CreateGeometryShaderWithStreamOutput(
-                    pShaderBytecode,
-                    BytecodeLength,
-                    std::span{ &pSODeclaration, 1 },
-                    std::span{ &pBufferStrides, 1 },
-                    RasterizedStream,
-                    optClassLinkage);
-            }
-
-            Wrapper<ID3D11PixelShader> CreatePixelShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreatePixelShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11PixelShader> CreatePixelShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11PixelShader>(&value_type::CreatePixelShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Wrapper<ID3D11HullShader> CreateHullShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreateHullShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11HullShader> CreateHullShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11HullShader>(&value_type::CreateHullShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Wrapper<ID3D11DomainShader> CreateDomainShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreateDomainShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11DomainShader> CreateDomainShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11DomainShader>(&value_type::CreateDomainShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Wrapper<ID3D11ComputeShader> CreateComputeShader(
-                ID3DBlob& pShaderBytecode,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return CreateComputeShader(pShaderBytecode.GetBufferPointer(), pShaderBytecode.GetBufferSize(), pClassLinkage);
-            }
-
-            Wrapper<ID3D11ComputeShader> CreateComputeShader(
-                const void* pShaderBytecode,
-                SIZE_T BytecodeLength,
-                ID3D11ClassLinkage* pClassLinkage)
-            {
-                return UnknownObjectForwardFunction<ID3D11ComputeShader>(&value_type::CreateComputeShader, Get(), pShaderBytecode, BytecodeLength, pClassLinkage);
-            }
-
-            Microsoft::WRL::ComPtr<ID3D11ClassLinkage> CreateClassLinkage()
-            {
-                return UnknownObjectForwardFunction<ID3D11ClassLinkage>(&value_type::CreateClassLinkage, Get());
-            }
-
-            Wrapper<ID3D11BlendState> CreateBlendState(
-                const D3D11_BLEND_DESC& pBlendStateDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11BlendState>(&value_type::CreateBlendState, Get(), &pBlendStateDesc);
-            }
-
-            Wrapper<ID3D11DepthStencilState> CreateDepthStencilState(
-                const D3D11_DEPTH_STENCIL_DESC& pDepthStencilDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11DepthStencilState>(&value_type::CreateDepthStencilState, Get(), &pDepthStencilDesc);
-            }
-
-            Wrapper<ID3D11RasterizerState>  CreateRasterizerState(
-                const D3D11_RASTERIZER_DESC& pRasterizerDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11RasterizerState>(&value_type::CreateRasterizerState, Get(), &pRasterizerDesc);
-            }
-
-            Wrapper<ID3D11SamplerState> CreateSamplerState(
-                const D3D11_SAMPLER_DESC& pSamplerDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11SamplerState>(&value_type::CreateSamplerState, Get(), &pSamplerDesc);
-            }
-
-            Microsoft::WRL::ComPtr<ID3D11Query> CreateQuery(
-                const D3D11_QUERY_DESC& pQueryDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11Query>(&value_type::CreateQuery, Get(), &pQueryDesc);
-            }
-
-            Microsoft::WRL::ComPtr<ID3D11Predicate> CreatePredicate(
-                const D3D11_QUERY_DESC& pPredicateDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11Predicate>(&value_type::CreatePredicate, Get(), &pPredicateDesc);
-            }
-
-            Microsoft::WRL::ComPtr<ID3D11Counter> CreateCounter(
-                const D3D11_COUNTER_DESC& pCounterDesc)
-            {
-                return UnknownObjectForwardFunction<ID3D11Counter>(&value_type::CreateCounter, Get(), &pCounterDesc);
-            }
-
-            template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
-            Wrapper<DeviceContextTy> CreateDeferredContext(
-                UINT ContextFlags)
-            {
-                return UnknownObjectForwardFunction<DeviceContextTy>(&value_type::CreateDeferredContext, Get(), ContextFlags);
-            }
-
-              //TODO: Figure out how this works to update to a more modern API
-            HRESULT OpenSharedResource(
-                HANDLE hResource,
-                REFIID ReturnedInterface,
-                void** ppResource)
-            {
-                return Get().OpenSharedResource(hResource, ReturnedInterface, ppResource);
-            }
-
-            D3D11_FORMAT_SUPPORT CheckFormatSupport(
-                DXGI_FORMAT Format)
-            {
-                UINT FormatSupport;
-                ThrowIfFailed(Get().CheckFormatSupport(Format, &FormatSupport));
-                return static_cast<D3D11_FORMAT_SUPPORT>(FormatSupport);
-            }
-
-            UINT CheckMultisampleQualityLevels(
-                DXGI_FORMAT Format,
-                UINT SampleCount)
-            {
-                UINT NumQualityLevels;
-                ThrowIfFailed(Get().CheckMultisampleQualityLevels(Format, SampleCount, &NumQualityLevels));
-                return NumQualityLevels;
-            }
-
-            D3D11_COUNTER_INFO CheckCounterInfo()
-            {
-                D3D11_COUNTER_INFO pCounterInfo;
-                Get().CheckCounterInfo(&pCounterInfo);
-                return pCounterInfo;
-            }
-
-            //TODO: Figure out how this works to update to a more modern API
-            HRESULT CheckCounter(
-                const D3D11_COUNTER_DESC* pDesc,
-                D3D11_COUNTER_TYPE* pType,
-                UINT* pActiveCounters,
-                LPSTR szName,
-                UINT* pNameLength,
-                LPSTR szUnits,
-                UINT* pUnitsLength,
-                LPSTR szDescription,
-                UINT* pDescriptionLength)
-            {
-                return Get().CheckCounter(pDesc, pType, pActiveCounters, szName, pNameLength, szUnits, pUnitsLength, szDescription, pDescriptionLength);
-            }
-
-            template<D3D11_FEATURE Feature>
-            typename DeviceFeatureMap<Feature>::type CheckFeatureSupport()
-            {
-                using feature_type = typename DeviceFeatureMap<Feature>::type;
-                feature_type feature;
-                Get().CheckFeatureSupport(Feature, &feature, sizeof(feature_type));
-                return feature;
-            }
-
-              //TODO: Figure out how this works to update to a more modern API
-            HRESULT GetPrivateData(
-                REFGUID guid,
-                UINT* pDataSize,
-                void* pData)
-            {
-                return Get().GetPrivateData(guid, pDataSize, pData);
-            }
-
-            //TODO: Figure out how this works to update to a more modern API
-            HRESULT SetPrivateData(
-                REFGUID guid,
-                UINT DataSize,
-                const void* pData)
-            {
-                return Get().SetPrivateData(guid, DataSize, pData);
-            }
-
-             //TODO: Figure out how this works to update to a more modern API
-            HRESULT SetPrivateDataInterface(
-                REFGUID guid,
-                const IUnknown* pData)
-            {
-                return Get().SetPrivateDataInterface(guid, pData);
-            }
-
-            D3D_FEATURE_LEVEL GetFeatureLevel()
-            {
-                return Get().GetFeatureLevel();
-            }
-
-            UINT GetCreationFlags()
-            {
-                return Get().GetCreationFlags();
-            }
-
-            HRESULT GetDeviceRemovedReason()
-            {
-                return Get().GetDeviceRemovedReason();
-            }
-
-            template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
+	template<D3D11_FEATURE Feature>
+	struct DeviceFeatureMap;
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_THREADING>
+	{
+		using type = D3D11_FEATURE_DATA_THREADING;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_DOUBLES>
+	{
+		using type = D3D11_FEATURE_DATA_DOUBLES;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_FORMAT_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_FORMAT_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_FORMAT_SUPPORT2>
+	{
+		using type = D3D11_FEATURE_DATA_FORMAT_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS>
+	{
+		using type = D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_ARCHITECTURE_INFO>
+	{
+		using type = D3D11_FEATURE_DATA_ARCHITECTURE_INFO;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D9_OPTIONS>
+	{
+		using type = D3D11_FEATURE_DATA_D3D9_OPTIONS;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_SHADER_MIN_PRECISION_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D9_SHADOW_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS1>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS1;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D9_SIMPLE_INSTANCING_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_MARKER_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_MARKER_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D9_OPTIONS1>
+	{
+		using type = D3D11_FEATURE_DATA_D3D9_OPTIONS1;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS2>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS2;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS3>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS3;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT>
+	{
+		using type = D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS4>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS4;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_SHADER_CACHE>
+	{
+		using type = D3D11_FEATURE_DATA_SHADER_CACHE;
+	};
+
+	template<>
+	struct DeviceFeatureMap<D3D11_FEATURE_D3D11_OPTIONS5>
+	{
+		using type = D3D11_FEATURE_DATA_D3D11_OPTIONS5;
+	};
+}
+
+namespace TypedD3D
+{
+	template<std::derived_from<ID3D11Device> Ty>
+	struct UntaggedTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
+
+	template<>
+	struct UntaggedTraits<ID3D11Device>
+	{
+		using unknown_type = ID3D11Device;
+
+		template<class Derived>
+		struct Interface : public InterfaceBase<UntaggedTraits<Derived>>
+		{
+			HRESULT CheckCounter(
+				const D3D11_COUNTER_DESC& desc,
+				D3D11_COUNTER_TYPE& type,
+				UINT& activeCounters,
+				LPSTR optName,
+				UINT* optNameLength,
+				LPSTR optUnits,
+				UINT* optUnitsLength,
+				LPSTR optDescription,
+				UINT* optDescriptionLength)
+			{
+				return Self().CheckCounter(
+					&desc,
+					&type,
+					&activeCounters,
+					optName,
+					optNameLength,
+					optUnits,
+					optUnitsLength,
+					optDescription,
+					optDescriptionLength);
+			}
+
+			D3D11_COUNTER_INFO CheckCounterInfo()
+			{
+				D3D11_COUNTER_INFO info;
+				Self().CheckCounterInfo(&info);
+				return info;
+			}
+
+			template<D3D11_FEATURE Feature>
+			typename D3D11::DeviceFeatureMap<Feature>::type CheckFeatureSupport()
+			{
+				typename D3D11::DeviceFeatureMap<Feature>::type data;
+				ThrowIfFailed(Self().CheckFeatureSupport(Feature, &data, sizeof(data)));
+				return data;
+			}
+
+			D3D11_FORMAT_SUPPORT CheckFormatSupport(DXGI_FORMAT format)
+			{
+				UINT formatSupport;
+				ThrowIfFailed(Self().CheckFormatSupport(format, &formatSupport));
+				return static_cast<D3D11_FORMAT_SUPPORT>(formatSupport);
+			}
+
+			UINT CheckMultisampleQualityLevels(DXGI_FORMAT format, UINT sampleCount)
+			{
+				UINT qualityLevels;
+				ThrowIfFailed(Self().CheckMultisampleQualityLevels(format, sampleCount, &qualityLevels));
+				return qualityLevels;
+			}
+
+			Wrapper<ID3D11BlendState> CreateBlendState(const D3D11_BLEND_DESC& desc)
+			{
+				return ForwardFunction<Wrapper<ID3D11BlendState>>(&unknown_type::CreateBlendState, Self(), &desc);
+			}
+
+			Wrapper<ID3D11Buffer> CreateBuffer(
+				const D3D11_BUFFER_DESC& desc,
+				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11Buffer>>(&unknown_type::CreateBuffer, Self(), &desc, optInitialData);
+			}
+
+			Wrapper<ID3D11ClassLinkage> CreateClassLinkage()
+			{
+				return ForwardFunction<Wrapper<ID3D11ClassLinkage>>(&unknown_type::CreateClassLinkage, Self());
+			}
+
+			Wrapper<ID3D11ComputeShader> CreateComputeShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateComputeShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11ComputeShader> CreateComputeShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11ComputeShader>>(&unknown_type::CreateComputeShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11Counter> CreateCounter(
+				const D3D11_COUNTER_DESC& pCounterDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11Counter>>(&unknown_type::CreateCounter, Self(), &pCounterDesc);
+			}
+
+			template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
+			Wrapper<DeviceContextTy> CreateDeferredContext(
+				UINT ContextFlags)
+			{
+				return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&unknown_type::CreateDeferredContext, Self(), ContextFlags);
+			}
+
+			Wrapper<ID3D11DepthStencilState> CreateDepthStencilState(
+				const D3D11_DEPTH_STENCIL_DESC& pDepthStencilDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11DepthStencilState>>(&unknown_type::CreateDepthStencilState, Self(), &pDepthStencilDesc);
+			}
+
+			Wrapper<ID3D11DepthStencilView> CreateDepthStencilView(
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
+				const D3D11_DEPTH_STENCIL_VIEW_DESC* optDesc = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11DepthStencilView>>(&unknown_type::CreateDepthStencilView, Self(), pResource.get().Get(), optDesc);
+			}
+
+			Wrapper<ID3D11DomainShader> CreateDomainShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateDomainShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11DomainShader> CreateDomainShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11DomainShader>>(&unknown_type::CreateDomainShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11GeometryShader> CreateGeometryShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateGeometryShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11GeometryShader> CreateGeometryShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&unknown_type::CreateGeometryShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
+				std::span<const UINT> pBufferStrides,
+				UINT RasterizedStream,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateGeometryShaderWithStreamOutput(
+					pShaderBytecode->GetBufferPointer(),
+					pShaderBytecode->GetBufferSize(),
+					pSODeclaration,
+					pBufferStrides,
+					RasterizedStream,
+					pClassLinkage);
+			}
+
+			Wrapper<ID3D11GeometryShader> CreateGeometryShaderWithStreamOutput(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				std::span<const D3D11_SO_DECLARATION_ENTRY> pSODeclaration,
+				std::span<const UINT> pBufferStrides,
+				UINT RasterizedStream,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11GeometryShader>>(&unknown_type::CreateGeometryShaderWithStreamOutput,
+					Self(),
+					pShaderBytecode,
+					BytecodeLength,
+					pSODeclaration.data(),
+					pSODeclaration.size(),
+					pBufferStrides.data(),
+					pBufferStrides.size(),
+					RasterizedStream,
+					pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11HullShader> CreateHullShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateHullShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11HullShader> CreateHullShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11HullShader>>(&unknown_type::CreateHullShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11InputLayout> CreateInputLayout(
+				std::span<const D3D11_INPUT_ELEMENT_DESC> inputElementDescs,
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecodeWithInputSignature)
+			{
+				return CreateInputLayout(inputElementDescs, pShaderBytecodeWithInputSignature->GetBufferPointer(), pShaderBytecodeWithInputSignature->GetBufferSize());
+			}
+
+			Wrapper<ID3D11InputLayout> CreateInputLayout(
+				D3D11_INPUT_ELEMENT_DESC inputElementDescs,
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecodeWithInputSignature)
+			{
+				return CreateInputLayout(inputElementDescs, pShaderBytecodeWithInputSignature->GetBufferPointer(), pShaderBytecodeWithInputSignature->GetBufferSize());
+			}
+
+			Wrapper<ID3D11InputLayout> CreateInputLayout(
+				D3D11_INPUT_ELEMENT_DESC inputElementDescs,
+				gsl::not_null<const void*> pShaderBytecodeWithInputSignature,
+				SIZE_T BytecodeLength)
+			{
+				return CreateInputLayout(
+					std::span{ &inputElementDescs, 1 },
+					pShaderBytecodeWithInputSignature,
+					BytecodeLength);
+			}
+
+			Wrapper<ID3D11InputLayout> CreateInputLayout(
+				std::span<const D3D11_INPUT_ELEMENT_DESC> inputElementDescs,
+				gsl::not_null<const void*> pShaderBytecodeWithInputSignature,
+				SIZE_T BytecodeLength)
+			{
+				return ForwardFunction<Wrapper<ID3D11InputLayout>>(
+					&unknown_type::CreateInputLayout,
+					Self(),
+					inputElementDescs.data(),
+					static_cast<UINT>(inputElementDescs.size()),
+					pShaderBytecodeWithInputSignature,
+					BytecodeLength);
+			}
+
+			Wrapper<ID3D11PixelShader> CreatePixelShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreatePixelShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11PixelShader> CreatePixelShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11PixelShader>>(&unknown_type::CreatePixelShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			Wrapper<ID3D11Predicate> CreatePredicate(const D3D11_QUERY_DESC& pPredicateDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11Predicate>>(&unknown_type::CreatePredicate, Self(), &pPredicateDesc);
+			}
+
+			Wrapper<ID3D11Query> CreateQuery(const D3D11_QUERY_DESC& pQueryDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11Query>>(&unknown_type::CreateQuery, Self(), &pQueryDesc);
+			}
+
+			Wrapper<ID3D11RasterizerState>  CreateRasterizerState(
+				const D3D11_RASTERIZER_DESC& pRasterizerDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11RasterizerState>>(&unknown_type::CreateRasterizerState, Self(), &pRasterizerDesc);
+			}
+
+			Wrapper<ID3D11RenderTargetView> CreateRenderTargetView(
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
+				const D3D11_RENDER_TARGET_VIEW_DESC* optDesc = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11RenderTargetView>>(&unknown_type::CreateRenderTargetView, Self(), pResource.get().Get(), optDesc);
+			}
+
+			Wrapper<ID3D11SamplerState> CreateSamplerState(
+				const D3D11_SAMPLER_DESC& pSamplerDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D11SamplerState>>(&unknown_type::CreateSamplerState, Self(), &pSamplerDesc);
+			}
+
+			Wrapper<ID3D11ShaderResourceView> CreateShaderResourceView(
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
+				const D3D11_SHADER_RESOURCE_VIEW_DESC* optDesc = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11ShaderResourceView>>(&unknown_type::CreateShaderResourceView, Self(), pResource.get().Get(), optDesc);
+			}
+
+			Wrapper<ID3D11Texture1D> CreateTexture1D(
+				const D3D11_TEXTURE1D_DESC& pDesc,
+				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11Texture1D>>(&unknown_type::CreateTexture1D, Self(), &pDesc, optInitialData);
+			}
+
+			Wrapper<ID3D11Texture2D> CreateTexture2D(
+				const D3D11_TEXTURE2D_DESC& pDesc,
+				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11Texture2D>>(&unknown_type::CreateTexture2D, Self(), &pDesc, optInitialData);
+			}
+
+			Wrapper<ID3D11Texture3D> CreateTexture3D(
+				const D3D11_TEXTURE3D_DESC& pDesc,
+				const D3D11_SUBRESOURCE_DATA* optInitialData = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11Texture3D>>(&unknown_type::CreateTexture3D, Self(), &pDesc, optInitialData);
+			}
+
+			Wrapper<ID3D11UnorderedAccessView> CreateUnorderedAccessView(
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
+				const D3D11_UNORDERED_ACCESS_VIEW_DESC* optDesc = nullptr)
+			{
+				return ForwardFunction<Wrapper<ID3D11UnorderedAccessView>>(&unknown_type::CreateUnorderedAccessView, Self(), pResource.get().Get(), optDesc);
+			}
+
+
+			Wrapper<ID3D11VertexShader> CreateVertexShader(
+				gsl::not_null<WrapperView<ID3DBlob>> pShaderBytecode,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return CreateVertexShader(pShaderBytecode->GetBufferPointer(), pShaderBytecode->GetBufferSize(), pClassLinkage);
+			}
+
+			Wrapper<ID3D11VertexShader> CreateVertexShader(
+				gsl::not_null<const void*> pShaderBytecode,
+				SIZE_T BytecodeLength,
+				WrapperView<ID3D11ClassLinkage> pClassLinkage)
+			{
+				return ForwardFunction<Wrapper<ID3D11VertexShader>>(&unknown_type::CreateVertexShader, Self(), pShaderBytecode, BytecodeLength, pClassLinkage.Get());
+			}
+
+			D3D11_CREATE_DEVICE_FLAG GetCreationFlags()
+			{
+				return static_cast<D3D11_CREATE_DEVICE_FLAG>(Self().GetCreationFlags());
+			}
+
+			HRESULT GetDeviceRemovedReason()
+			{
+				return Self().GetDeviceRemovedReason();
+			}
+
+			D3D11_RAISE_FLAG GetExceptionMode()
+			{
+				return static_cast<D3D11_RAISE_FLAG>(Self().GetExceptionMode());
+			}
+
+			D3D_FEATURE_LEVEL GetFeatureLevel()
+			{
+				return Self().GetFeatureLevel();
+			}
+
+			template<std::derived_from<ID3D11DeviceContext> DeviceContextTy = ID3D11DeviceContext>
             Wrapper<DeviceContextTy> GetImmediateContext()
             {
-                if constexpr(std::same_as<DeviceContextTy, ID3D11DeviceContext>)
-                {
-                    return UnknownObjectForwardFunction<ID3D11DeviceContext>(&value_type::GetImmediateContext, Get());
-                }
-                else
-                {
-                    return Cast<DeviceContextTy>(UnknownObjectForwardFunction<ID3D11DeviceContext>(&value_type::GetImmediateContext, Get()));
-                }
+                return ForwardFunction<Wrapper<DeviceContextTy>, ID3D11DeviceContext>(&unknown_type::GetImmediateContext, Self());
             }
 
-            void SetExceptionMode(
-                UINT RaiseFlags)
-            {
-                return ThrowIfFailed(Get().SetExceptionMode(RaiseFlags));
-            }
+			HRESULT GetPrivateData(REFGUID guid,
+				UINT* pDataSize,
+				void* pData)
+			{
+				return Self().GetPrivateData(guid, pDataSize, pData);
+			}
 
-            UINT GetExceptionMode() noexcept
-            {
-                return Get().GetExceptionMode();
-            }
+			HRESULT OpenSharedResource(
+				HANDLE hResource,
+				REFIID ReturnedInterface,
+				void** ppResource)
+			{
+				return Self().OpenSharedResource(hResource, ReturnedInterface, ppResource);
+			}
 
-        private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
-        };
-    };
+			HRESULT SetExceptionMode(
+				D3D11_RAISE_FLAG flags)
+			{
+				return Self().SetExceptionMode(flags);
+			}
 
-    template<std::derived_from<ID3D11Device> Ty>
-    struct UntaggedTraits<Ty> : DeviceTraits<Ty>
-    {
-    };
+			HRESULT SetPrivateData(
+				REFGUID    guid,
+				UINT       DataSize,
+				const void* pData)
+			{
+				return Self().SetPrivateData(guid, DataSize, pData);
+			}
 
-    export template<std::derived_from<ID3D11Device> DeviceTy>
-    using Device_t = IUnknownWrapper<DeviceTy, UntaggedTraits>;;
+			HRESULT SetPrivateDataInterface(
+				REFGUID        guid,
+				const IUnknown* pData)
+			{
+				return Self().SetPrivateDataInterface(guid, pData);
+			}
+		private:
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+		};
+	};
+}
 
-    namespace Aliases
-    {
-        export using D3D11Device = Device_t<ID3D11Device>;
-    }
+namespace TypedD3D::D3D11
+{
+	export template<class DeviceTy = ID3D11Device, class DeviceContextTy = ID3D11DeviceContext>
+	auto CreateDevice(
+		IDXGIAdapter* optAdapter,
+		D3D_DRIVER_TYPE DriverType,
+		HMODULE Software,
+		UINT Flags,
+		std::span<const D3D_FEATURE_LEVEL> pFeatureLevels,
+		UINT SDKVersion,
+		D3D_FEATURE_LEVEL* optSelectedFeatureLevel = nullptr)
+	{
+		Wrapper<ID3D11Device> device;
+		Wrapper<ID3D11DeviceContext> deviceContext;
+		ThrowIfFailed(D3D11CreateDevice(
+			optAdapter,
+			DriverType,
+			Software,
+			Flags,
+			pFeatureLevels.data(),
+			static_cast<UINT>(pFeatureLevels.size()),
+			SDKVersion,
+			OutPtr{ device },
+			optSelectedFeatureLevel,
+			OutPtr{ deviceContext }));
 
-    export template<class DeviceTy = ID3D11Device, class DeviceContextTy = ID3D11DeviceContext>
-    auto CreateDevice(
-            IDXGIAdapter* optAdapter,
-            D3D_DRIVER_TYPE DriverType,
-            HMODULE Software,
-            UINT Flags,
-            std::span<const D3D_FEATURE_LEVEL> pFeatureLevels,
-            UINT SDKVersion)
-    {
-        if constexpr(!std::derived_from<DeviceTy, ID3D11Device> && !std::derived_from<DeviceContextTy, ID3D11DeviceContext>)
-        {
-            return CreateDevice<typename DeviceTy::value_type, typename DeviceContextTy::value_type>(
-                optAdapter,
-                DriverType,
-                Software,
-                Flags,
-                pFeatureLevels,
-                SDKVersion);
-        }
-        else if constexpr(!std::derived_from<DeviceTy, ID3D11Device>)
-        {
-            return CreateDevice<typename DeviceTy::value_type, DeviceContextTy>(
-                optAdapter,
-                DriverType,
-                Software,
-                Flags,
-                pFeatureLevels,
-                SDKVersion);
-        }
-        else if constexpr(!std::derived_from<DeviceContextTy, ID3D11DeviceContext>)
-        {
-            return CreateDevice<DeviceTy, typename DeviceContextTy::value_type>(
-                optAdapter,
-                DriverType,
-                Software,
-                Flags,
-                pFeatureLevels,
-                SDKVersion);
-        }
-        else
-        {
-            Microsoft::WRL::ComPtr<ID3D11Device> tempDevice;
-            Microsoft::WRL::ComPtr<ID3D11DeviceContext> tempDeviceContext;
+		if constexpr(std::same_as<DeviceTy, ID3D11Device> && std::same_as<DeviceContextTy, ID3D11DeviceContext>)
+			return std::pair{ device, deviceContext };
+		if constexpr(std::same_as<DeviceTy, ID3D11Device>)
+			return std::pair{ device, Cast<DeviceContextTy>(std::move(deviceContext)) };
+		if constexpr(std::same_as<DeviceContextTy, ID3D11DeviceContext>)
+			return std::pair{ Cast<DeviceTy>(std::move(device)), deviceContext };
 
-            ThrowIfFailed(D3D11CreateDevice(
-                optAdapter,
-                DriverType,
-                Software,
-                Flags,
-                pFeatureLevels.data(),
-                static_cast<UINT>(pFeatureLevels.size()),
-                SDKVersion,
-                &tempDevice,
-                nullptr,
-                &tempDeviceContext));
+		return std::pair{ Cast<DeviceTy>(std::move(device)), Cast<DeviceContextTy>(std::move(deviceContext)) };
+	}
 
-            std::pair<Wrapper<DeviceTy>, Wrapper<DeviceContextTy>> device;
-            device.first = Wrapper<DeviceTy>(Cast<DeviceTy>(tempDevice));
-            device.second = Wrapper<DeviceContextTy>(Cast<DeviceContextTy>(tempDeviceContext));
-
-            return device;
-        }
-    }
-
-    export template<class DeviceTy = ID3D11Device, class DeviceContextTy = ID3D11DeviceContext>
+	export template<class DeviceTy = ID3D11Device, class DeviceContextTy = ID3D11DeviceContext>
     auto CreateDevice(
             IDXGIAdapter* optAdapter,
             D3D_DRIVER_TYPE DriverType,
             HMODULE Software,
             UINT Flags,
             D3D_FEATURE_LEVEL pFeatureLevels,
-            UINT SDKVersion)
+            UINT SDKVersion,
+			D3D_FEATURE_LEVEL* optSelectedFeatureLevel = nullptr)
     {
-        return CreateDevice<DeviceTy, DeviceContextTy>(optAdapter, DriverType, Software, Flags, { &pFeatureLevels, 1 }, SDKVersion);
+        return CreateDevice<DeviceTy, DeviceContextTy>(optAdapter, DriverType, Software, Flags, { &pFeatureLevels, 1 }, SDKVersion, optSelectedFeatureLevel);
     }
 }

--- a/TypedD3D/source/D3D11/D3D11Device.ixx
+++ b/TypedD3D/source/D3D11/D3D11Device.ixx
@@ -146,7 +146,12 @@ namespace TypedD3D::D3D11
 #pragma endregion
 
     template<class Ty>
-    struct DeviceTraits;
+    struct DeviceTraits
+    {
+        using unknown_type = Ty;
+        template<class DerivedSelf>
+        using Interface = Ty*;
+    };
 
     template<>
     struct DeviceTraits<ID3D11Device>
@@ -156,6 +161,8 @@ namespace TypedD3D::D3D11
         using const_pointer = const ID3D11Device*;
         using reference = ID3D11Device&;
         using const_reference = const ID3D11Device&;
+
+        using unknown_type = ID3D11Device;
 
         template<class DerivedSelf>
         class Interface

--- a/TypedD3D/source/D3D11/D3D11Resource.ixx
+++ b/TypedD3D/source/D3D11/D3D11Resource.ixx
@@ -16,33 +16,30 @@ namespace TypedD3D
         using reference = ID3D11Resource&;
         using const_reference = const ID3D11Resource&;
 
-        template<class DerivedSelf>
-        class Interface : public D3D11::DeviceChildInterface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11DeviceChild>
         {
-        private:
-            using derived_self = DerivedSelf;
-
         public:
             D3D11_RESOURCE_DIMENSION GetType()
             {
                 D3D11_RESOURCE_DIMENSION pResourceDimension;
-                Get().GetType(&pResourceDimension);
+                Self().GetType(&pResourceDimension);
                 return pResourceDimension;
             }
 
             void SetEvictionPriority(UINT EvictionPriority)
             {
-                Get().SetEvictionPriority(EvictionPriority);
+                Self().SetEvictionPriority(EvictionPriority);
             }
 
             UINT GetEvictionPriority()
             {
-                return Get().GetEvictionPriority();
+                return Self().GetEvictionPriority();
             }
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -55,23 +52,20 @@ namespace TypedD3D
         using reference = ID3D11Buffer&;
         using const_reference = const ID3D11Buffer&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
-        private:
-            using derived_self = DerivedSelf;
-
         public:
             D3D11_BUFFER_DESC GetDesc()
             {
                 D3D11_BUFFER_DESC pDesc;
-                Get().GetDesc(&pDesc);
+                Self().GetDesc(&pDesc);
                 return pDesc;
             }
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -84,23 +78,23 @@ namespace TypedD3D
         using reference = ID3D11Texture1D&;
         using const_reference = const ID3D11Texture1D&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
         private:
-            using derived_self = DerivedSelf;
+            using derived_self = Derived;
 
         public:
             D3D11_TEXTURE1D_DESC GetDesc()
             {
                 D3D11_TEXTURE1D_DESC pDesc;
-                Get().GetDesc(&pDesc);
+                Self().GetDesc(&pDesc);
                 return pDesc;
             }
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -113,23 +107,23 @@ namespace TypedD3D
         using reference = ID3D11Texture2D&;
         using const_reference = const ID3D11Texture2D&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
         private:
-            using derived_self = DerivedSelf;
+            using derived_self = Derived;
 
         public:
             D3D11_TEXTURE2D_DESC GetDesc()
             {
                 D3D11_TEXTURE2D_DESC pDesc;
-                Get().GetDesc(&pDesc);
+                Self().GetDesc(&pDesc);
                 return pDesc;
             }
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -142,23 +136,22 @@ namespace TypedD3D
         using reference = ID3D11Texture3D&;
         using const_reference = const ID3D11Texture3D&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
         private:
-            using derived_self = DerivedSelf;
 
         public:
             D3D11_TEXTURE3D_DESC GetDesc()
             {
                 D3D11_TEXTURE3D_DESC pDesc;
-                Get().GetDesc(&pDesc);
+                Self().GetDesc(&pDesc);
                 return pDesc;
             }
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 }

--- a/TypedD3D/source/D3D11/D3D11Resource.ixx
+++ b/TypedD3D/source/D3D11/D3D11Resource.ixx
@@ -8,18 +8,20 @@ import TypedD3D.Shared;
 namespace TypedD3D
 {
     export template<>
-    struct UntaggedTraits<ID3D11Resource>
+    struct Trait<Untagged<ID3D11Resource>>
     {
-        using value_type = ID3D11Resource;
-        using pointer = ID3D11Resource*;
-        using const_pointer = const ID3D11Resource*;
-        using reference = ID3D11Resource&;
-        using const_reference = const ID3D11Resource&;
 
         using inner_type = ID3D11Resource;
 
+        using inner_tag = ID3D11Resource;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11DeviceChild>
+        class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
         {
         public:
             D3D11_RESOURCE_DIMENSION GetType()
@@ -40,24 +42,28 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
-    export template<>
-    struct UntaggedTraits<ID3D11Buffer>
-    {
-        using value_type = ID3D11Buffer;
-        using pointer = ID3D11Buffer*;
-        using const_pointer = const ID3D11Buffer*;
-        using reference = ID3D11Buffer&;
-        using const_reference = const ID3D11Buffer&;
+    static_assert(IUnknownTrait<Untagged<ID3D11Resource>>);
 
+    export template<>
+    struct Trait<Untagged<ID3D11Buffer>>
+    {
         using inner_type = ID3D11Buffer;
 
+        using inner_tag = ID3D11Buffer;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
+
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D11Resource>>::Interface<Derived>
         {
         public:
             D3D11_BUFFER_DESC GetDesc()
@@ -68,23 +74,25 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
     export template<>
-    struct UntaggedTraits<ID3D11Texture1D>
+    struct Trait<Untagged<ID3D11Texture1D>>
     {
-        using value_type = ID3D11Texture1D;
-        using pointer = ID3D11Texture1D*;
-        using const_pointer = const ID3D11Texture1D*;
-        using reference = ID3D11Texture1D&;
-        using const_reference = const ID3D11Texture1D&;
 
+        using inner_tag = ID3D11Texture1D;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
         using inner_type = ID3D11Texture1D;
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D11Resource>>::Interface<Derived>
         {
         private:
             using derived_self = Derived;
@@ -98,23 +106,25 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
     export template<>
-    struct UntaggedTraits<ID3D11Texture2D>
+    struct Trait<Untagged<ID3D11Texture2D>>
     {
-        using value_type = ID3D11Texture2D;
-        using pointer = ID3D11Texture2D*;
-        using const_pointer = const ID3D11Texture2D*;
-        using reference = ID3D11Texture2D&;
-        using const_reference = const ID3D11Texture2D&;
 
+        using inner_tag = ID3D11Texture2D;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
         using inner_type = ID3D11Texture2D;
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D11Resource>>::Interface<Derived>
         {
         private:
             using derived_self = Derived;
@@ -128,24 +138,26 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
     export template<>
-    struct UntaggedTraits<ID3D11Texture3D>
+    struct Trait<Untagged<ID3D11Texture3D>>
     {
-        using value_type = ID3D11Texture3D;
-        using pointer = ID3D11Texture3D*;
-        using const_pointer = const ID3D11Texture3D*;
-        using reference = ID3D11Texture3D&;
-        using const_reference = const ID3D11Texture3D&;
+        using inner_tag = ID3D11Texture3D;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
 
         using inner_type = ID3D11Texture3D;
 
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D11Resource>>::Interface<Derived>
         {
         private:
 
@@ -158,8 +170,8 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 }

--- a/TypedD3D/source/D3D11/D3D11Resource.ixx
+++ b/TypedD3D/source/D3D11/D3D11Resource.ixx
@@ -16,6 +16,8 @@ namespace TypedD3D
         using reference = ID3D11Resource&;
         using const_reference = const ID3D11Resource&;
 
+        using inner_type = ID3D11Resource;
+
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11DeviceChild>
         {
@@ -52,6 +54,8 @@ namespace TypedD3D
         using reference = ID3D11Buffer&;
         using const_reference = const ID3D11Buffer&;
 
+        using inner_type = ID3D11Buffer;
+
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
@@ -78,6 +82,7 @@ namespace TypedD3D
         using reference = ID3D11Texture1D&;
         using const_reference = const ID3D11Texture1D&;
 
+        using inner_type = ID3D11Texture1D;
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
@@ -107,6 +112,7 @@ namespace TypedD3D
         using reference = ID3D11Texture2D&;
         using const_reference = const ID3D11Texture2D&;
 
+        using inner_type = ID3D11Texture2D;
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>
         {
@@ -135,6 +141,8 @@ namespace TypedD3D
         using const_pointer = const ID3D11Texture3D*;
         using reference = ID3D11Texture3D&;
         using const_reference = const ID3D11Texture3D&;
+
+        using inner_type = ID3D11Texture3D;
 
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11Resource>::Interface<Derived>

--- a/TypedD3D/source/D3D11/DeviceChild.ixx
+++ b/TypedD3D/source/D3D11/DeviceChild.ixx
@@ -24,6 +24,15 @@ namespace TypedD3D
     Ty>
     struct UntaggedTraits<Ty>
     {
+        using inner_type = Ty;
+        template<class Derived>
+        using Interface = Ty*;
+    };
+
+    template<std::derived_from<ID3D11Debug> Ty>
+    struct UntaggedTraits<Ty>
+    {
+        using inner_type = Ty;
         template<class Derived>
         using Interface = Ty*;
     };
@@ -31,6 +40,7 @@ namespace TypedD3D
     template<>
     struct UntaggedTraits<ID3D11DeviceChild>
     {
+        using inner_type = ID3D11DeviceChild;
         template<class Derived>
         struct Interface : public InterfaceBase<UntaggedTraits<Derived>>
         {

--- a/TypedD3D/source/D3D11/DeviceChild.ixx
+++ b/TypedD3D/source/D3D11/DeviceChild.ixx
@@ -22,27 +22,52 @@ namespace TypedD3D
         ID3D11RasterizerState,
         ID3D11View> 
     Ty>
-    struct UntaggedTraits<Ty>
+    struct Trait<Untagged<Ty>>
     {
         using inner_type = Ty;
+
+        using inner_tag = Ty;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
         template<class Derived>
         using Interface = Ty*;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
     };
 
     template<std::derived_from<ID3D11Debug> Ty>
-    struct UntaggedTraits<Ty>
+    struct Trait<Untagged<Ty>>
     {
+        using inner_tag = Ty;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
         using inner_type = Ty;
         template<class Derived>
         using Interface = Ty*;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
     };
 
     template<>
-    struct UntaggedTraits<ID3D11DeviceChild>
+    struct Trait<Untagged<ID3D11DeviceChild>>
     {
         using inner_type = ID3D11DeviceChild;
+
+        using inner_tag = ID3D11DeviceChild;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
         template<class Derived>
-        struct Interface : public InterfaceBase<UntaggedTraits<Derived>>
+        struct Interface : public InterfaceBase<Untagged<Derived>>
         {
         private:
             using unknown_type = ID3D11DeviceChild;
@@ -86,8 +111,8 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 }

--- a/TypedD3D/source/D3D11/DeviceContext.ixx
+++ b/TypedD3D/source/D3D11/DeviceContext.ixx
@@ -7,7 +7,7 @@ module;
 #include <array>
 #include <vector>
 #include <utility>
-#include <wrl/client.h>
+
 #include <span>
 #include <cassert>
 
@@ -22,7 +22,6 @@ import :ResourceViews;
 
 namespace TypedD3D::D3D11
 {
-	using Microsoft::WRL::ComPtr;
 	export struct IAGetVertexBufferData
 	{
 		Vector<Wrapper<ID3D11Buffer>> buffers;
@@ -54,7 +53,7 @@ namespace TypedD3D::D3D11
 	template<class Ty, class Ty2, size_t Extent>
 	concept BoundedRandomAccessContainer = std::ranges::contiguous_range<Ty> && std::same_as<typename Ty::value_type, Ty2> && (std::extent_v<Ty> == Extent);
 
-	export class IASetVertexBuffersData 
+	export class IASetVertexBuffersData
 	{
 		UINT count;
 		ID3D11Buffer* const* bufferView;
@@ -96,6 +95,28 @@ namespace TypedD3D::D3D11
 			assert(buffers.size() == strides.size() && buffers.size() == offsets.size());
 		}
 
+		template<size_t Count>
+		IASetVertexBuffersData(Span<const WrapperView<ID3D11Buffer>, Count> buffers, std::span<UINT, Count> strides, std::span<UINT, Count> offsets) :
+			count{ static_cast<UINT>(buffers.size()) },
+			bufferView{ buffers.data() },
+			strideView{ strides.data() },
+			offsetView{ offsets.data() }
+		{
+			if constexpr(Count == std::dynamic_extent)
+			{
+				assert(buffers.size() == strides.size() && buffers.size() == offsets.size());
+			}
+		}
+
+		IASetVertexBuffersData(Span<const WrapperView<ID3D11Buffer>> buffers, std::span<UINT> strides, std::span<UINT> offsets) :
+			count{ static_cast<UINT>(buffers.size()) },
+			bufferView{ buffers.data() },
+			strideView{ strides.data() },
+			offsetView{ offsets.data() }
+		{
+			assert(buffers.size() == strides.size() && buffers.size() == offsets.size());
+		}
+
 		IASetVertexBuffersData(const IAGetVertexBufferData& data) :
 			count{ static_cast<UINT>(data.buffers.size()) },
 			bufferView{ data.buffers.data() },
@@ -117,7 +138,7 @@ namespace TypedD3D::D3D11
 		//	//}
 		//}
 
-		IASetVertexBuffersData(UINT count, ID3D11Buffer*const * buffers, const UINT* strides, const UINT* offsets) :
+		IASetVertexBuffersData(UINT count, ID3D11Buffer* const* buffers, const UINT* strides, const UINT* offsets) :
 			count{ count },
 			bufferView{ buffers },
 			strideView{ strides },
@@ -163,7 +184,19 @@ namespace TypedD3D::D3D11
 			}
 		}
 
-		SOSetTargetsData(UINT count, ID3D11Buffer*const * buffers, const UINT* offsets) :
+		template<size_t Count>
+		SOSetTargetsData(Span<const WrapperView<ID3D11Buffer>, Count> buffers, std::span<UINT, Count> offsets) :
+			count{ static_cast<UINT>(buffers.size()) },
+			bufferView{ buffers.data() },
+			offsetView{ offsets.data() }
+		{
+			if constexpr(Count == std::dynamic_extent)
+			{
+				assert(buffers.size() == offsets.size());
+			}
+		}
+
+		SOSetTargetsData(UINT count, ID3D11Buffer* const* buffers, const UINT* offsets) :
 			count{ count },
 			bufferView{ buffers },
 			offsetView{ offsets }
@@ -206,6 +239,18 @@ namespace TypedD3D::D3D11
 			}
 		}
 
+		template<UINT Count>
+		CSSetUnorderedAccessViewsData(Span<const WrapperView<ID3D11UnorderedAccessView>, Count> buffers, std::span<UINT, Count> pUAVInitialCounts) :
+			count{ buffers.size() },
+			bufferView{ buffers.data() },
+			pUAVInitialCounts{ pUAVInitialCounts.data() }
+		{
+			if constexpr(Count == std::dynamic_extent)
+			{
+				assert(buffers.size() == pUAVInitialCounts.size());
+			}
+		}
+
 		CSSetUnorderedAccessViewsData(UINT count, ID3D11UnorderedAccessView* const* buffers, const UINT* pUAVInitialCounts) :
 			count{ count },
 			bufferView{ buffers },
@@ -218,12 +263,12 @@ namespace TypedD3D::D3D11
 		ID3D11UnorderedAccessView* const* GetBuffers() const noexcept { return bufferView; }
 		const UINT* GetInitialCounts() const noexcept { return pUAVInitialCounts; }
 	};
+}
 
-	template<class Ty>
-	struct D3D11DeviceContextTraits;
-
+namespace TypedD3D
+{
 	template<>
-	struct D3D11DeviceContextTraits<ID3D11DeviceContext>
+	struct UntaggedTraits<ID3D11DeviceContext>
 	{
 		using value_type = ID3D11DeviceContext;
 		using pointer = ID3D11DeviceContext*;
@@ -231,76 +276,73 @@ namespace TypedD3D::D3D11
 		using reference = ID3D11DeviceContext&;
 		using const_reference = const ID3D11DeviceContext&;
 
-		template<class DerivedSelf>
-		class Interface : public DeviceChildInterface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
 		public:
 			D3D11_MAPPED_SUBRESOURCE Map(
-				gsl::not_null<Wrapper<ID3D11Resource>> pResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				UINT Subresource,
 				D3D11_MAP MapType,
 				UINT MapFlags)
 			{
 				D3D11_MAPPED_SUBRESOURCE subresource;
 
-				ThrowIfFailed(Get().Map(pResource.get().Get(), Subresource, MapType, MapFlags, &subresource));
+				ThrowIfFailed(Self().Map(pResource.get().Get(), Subresource, MapType, MapFlags, &subresource));
 				return subresource;
 			}
 
 			void Unmap(
-				gsl::not_null<Wrapper<ID3D11Resource>> pResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				UINT Subresource)
 			{
-				Get().Unmap(pResource.get().Get(), Subresource);
+				Self().Unmap(pResource.get().Get(), Subresource);
 			}
 
 			void ClearState()
 			{
-				return Get().ClearState();
+				return Self().ClearState();
 			}
 
 			void Flush()
 			{
-				return Get().Flush();
+				return Self().Flush();
 			}
 
 			D3D11_DEVICE_CONTEXT_TYPE GetType()
 			{
-				return Get().GetType();
+				return Self().GetType();
 			}
 
 			UINT GetContextFlags()
 			{
-				return Get().GetContextFlags();
+				return Self().GetContextFlags();
 			}
 
 			void ExecuteCommandList(
 				ID3D11CommandList& pCommandList,
 				BOOL RestoreContextState)
 			{
-				Get().ExecuteCommandList(&pCommandList, RestoreContextState);
+				Self().ExecuteCommandList(&pCommandList, RestoreContextState);
 			}
 
-			ComPtr<ID3D11CommandList> FinishCommandList(BOOL RestoreDeferredContextState)
+			Wrapper<ID3D11CommandList> FinishCommandList(BOOL RestoreDeferredContextState)
 			{
-				ComPtr<ID3D11CommandList> commandList;
-				ThrowIfFailed(Get().FinishCommandList(RestoreDeferredContextState, &commandList));
+				Wrapper<ID3D11CommandList> commandList;
+				ThrowIfFailed(Self().FinishCommandList(RestoreDeferredContextState, OutPtr{ commandList }));
 				return commandList;
 			}
 
 			void Begin(
 				ID3D11Asynchronous& pAsync)
 			{
-				Get().Begin(&pAsync);
+				Self().Begin(&pAsync);
 			}
 
 			void End(
 				ID3D11Asynchronous& pAsync)
 			{
-				Get().End(&pAsync);
+				Self().End(&pAsync);
 			}
 
 			void* GetData(
@@ -309,22 +351,22 @@ namespace TypedD3D::D3D11
 			{
 				void* data = nullptr;
 
-				ThrowIfFailed(Get().GetData(&pAsync, data, pAsync.GetDataSize(), GetDataFlags));
+				ThrowIfFailed(Self().GetData(&pAsync, data, pAsync.GetDataSize(), GetDataFlags));
 
 				return data;
 			}
 
 			void SetPredication(
-				ID3D11Predicate* pPredicate,
+				WrapperView<ID3D11Predicate> pPredicate,
 				BOOL PredicateValue)
 			{
-				Get().SetPredication(pPredicate, PredicateValue);
+				Self().SetPredication(pPredicate.Get(), PredicateValue);
 			}
 
-			std::pair<Microsoft::WRL::ComPtr<ID3D11Predicate>, BOOL> GetPredication()
+			std::pair<Wrapper<ID3D11Predicate>, BOOL> GetPredication()
 			{
-				std::pair<Microsoft::WRL::ComPtr<ID3D11Predicate>, BOOL> output;
-				Get().GetPredication(&output.first, &output.second);
+				std::pair<Wrapper<ID3D11Predicate>, BOOL> output;
+				Self().GetPredication(OutPtr{ output.first }, &output.second);
 				return output;
 			}
 
@@ -333,14 +375,14 @@ namespace TypedD3D::D3D11
 				UINT StartIndexLocation,
 				INT BaseVertexLocation)
 			{
-				Get().DrawIndexed(IndexCount, StartIndexLocation, BaseVertexLocation);
+				Self().DrawIndexed(IndexCount, StartIndexLocation, BaseVertexLocation);
 			}
 
 			void Draw(
 				UINT VertexCount,
 				UINT StartVertexLocation)
 			{
-				Get().Draw(VertexCount, StartVertexLocation);
+				Self().Draw(VertexCount, StartVertexLocation);
 			}
 
 			void DrawIndexedInstanced(
@@ -350,7 +392,7 @@ namespace TypedD3D::D3D11
 				INT BaseVertexLocation,
 				UINT StartInstanceLocation)
 			{
-				Get().DrawIndexedInstanced(IndexCountPerInstance, InstanceCount, StartIndexLocation, BaseVertexLocation, StartInstanceLocation);
+				Self().DrawIndexedInstanced(IndexCountPerInstance, InstanceCount, StartIndexLocation, BaseVertexLocation, StartInstanceLocation);
 			}
 
 			void DrawInstanced(
@@ -359,26 +401,26 @@ namespace TypedD3D::D3D11
 				UINT StartVertexLocation,
 				UINT StartInstanceLocation)
 			{
-				Get().DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
+				Self().DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
 			}
 
 			void DrawAuto()
 			{
-				Get().DrawAuto();
+				Self().DrawAuto();
 			}
 
 			void DrawIndexedInstancedIndirect(
-				gsl::not_null<Wrapper<ID3D11Buffer>> pBufferForArgs,
+				gsl::not_null<WrapperView<ID3D11Buffer>> pBufferForArgs,
 				UINT AlignedByteOffsetForArgs)
 			{
-				Get().DrawIndexedInstancedIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
+				Self().DrawIndexedInstancedIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
 			}
 
 			void DrawInstancedIndirect(
-				gsl::not_null<Wrapper<ID3D11Buffer>> pBufferForArgs,
+				gsl::not_null<WrapperView<ID3D11Buffer>> pBufferForArgs,
 				UINT AlignedByteOffsetForArgs)
 			{
-				Get().DrawInstancedIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
+				Self().DrawInstancedIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
 			}
 
 			void Dispatch(
@@ -386,56 +428,56 @@ namespace TypedD3D::D3D11
 				UINT ThreadGroupCountY,
 				UINT ThreadGroupCountZ)
 			{
-				Get().Dispatch(ThreadGroupCountX, ThreadGroupCountY, ThreadGroupCountZ);
+				Self().Dispatch(ThreadGroupCountX, ThreadGroupCountY, ThreadGroupCountZ);
 			}
 
 			void DispatchIndirect(
-				gsl::not_null<Wrapper<ID3D11Buffer>> pBufferForArgs,
+				gsl::not_null<WrapperView<ID3D11Buffer>> pBufferForArgs,
 				UINT AlignedByteOffsetForArgs)
 			{
-				Get().DispatchIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
+				Self().DispatchIndirect(pBufferForArgs.get().Get(), AlignedByteOffsetForArgs);
 			}
 
 			void GenerateMips(
-				gsl::not_null<Wrapper<ID3D11ShaderResourceView>> pShaderResourceView)
+				gsl::not_null<WrapperView<ID3D11ShaderResourceView>> pShaderResourceView)
 			{
-				Get().GenerateMips(pShaderResourceView.get().Get());
+				Self().GenerateMips(pShaderResourceView.get().Get());
 			}
 
 			void SetResourceMinLOD(
-				gsl::not_null<Wrapper<ID3D11Resource>> pResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource,
 				FLOAT MinLOD)
 			{
-				Get().SetResourceMinLOD(pResource.get().Get(), MinLOD);
+				Self().SetResourceMinLOD(pResource.get().Get(), MinLOD);
 			}
 
 			FLOAT GetResourceMinLOD(
-				gsl::not_null<Wrapper<ID3D11Resource>> pResource)
+				gsl::not_null<WrapperView<ID3D11Resource>> pResource)
 			{
-				return Get().GetResourceMinLOD(pResource.get().Get());
+				return Self().GetResourceMinLOD(pResource.get().Get());
 			}
 
 			void ResolveSubresource(
-				gsl::not_null<Wrapper<ID3D11Resource>> pDstResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pDstResource,
 				UINT DstSubresource,
-				gsl::not_null<Wrapper<ID3D11Resource>> pSrcResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pSrcResource,
 				UINT SrcSubresource,
 				DXGI_FORMAT Format)
 			{
-				Get().ResolveSubresource(pDstResource.get().Get(), DstSubresource, pSrcResource.get().Get(), SrcSubresource, Format);
+				Self().ResolveSubresource(pDstResource.get().Get(), DstSubresource, pSrcResource.get().Get(), SrcSubresource, Format);
 			}
 
 			void CopySubresourceRegion(
-				gsl::not_null<Wrapper<ID3D11Resource>> pDstResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pDstResource,
 				UINT DstSubresource,
 				UINT DstX,
 				UINT DstY,
 				UINT DstZ,
-				gsl::not_null<Wrapper<ID3D11Resource>>  pSrcResource,
+				gsl::not_null<WrapperView<ID3D11Resource>>  pSrcResource,
 				UINT SrcSubresource,
 				const D3D11_BOX* pSrcBox)
 			{
-				Get().CopySubresourceRegion(
+				Self().CopySubresourceRegion(
 					pDstResource.get().Get(),
 					DstSubresource,
 					DstX,
@@ -447,23 +489,23 @@ namespace TypedD3D::D3D11
 			}
 
 			void CopyResource(
-				gsl::not_null<Wrapper<ID3D11Resource>>  pDstResource,
-				gsl::not_null<Wrapper<ID3D11Resource>>  pSrcResource)
+				gsl::not_null<WrapperView<ID3D11Resource>>  pDstResource,
+				gsl::not_null<WrapperView<ID3D11Resource>>  pSrcResource)
 			{
-				Get().CopyResource(
+				Self().CopyResource(
 					pDstResource.get().Get(),
 					pSrcResource.get().Get());
 			}
 
 			void UpdateSubresource(
-				gsl::not_null<Wrapper<ID3D11Resource>> pDstResource,
+				gsl::not_null<WrapperView<ID3D11Resource>> pDstResource,
 				UINT DstSubresource,
 				const D3D11_BOX* pDstBox,
 				const void* pSrcData,
 				UINT SrcRowPitch,
 				UINT SrcDepthPitch)
 			{
-				Get().UpdateSubresource(
+				Self().UpdateSubresource(
 					pDstResource.get().Get(),
 					DstSubresource,
 					pDstBox,
@@ -473,100 +515,101 @@ namespace TypedD3D::D3D11
 			}
 
 			void CopyStructureCount(
-				gsl::not_null<Wrapper<ID3D11Buffer>> pDstBuffer,
+				gsl::not_null<WrapperView<ID3D11Buffer>> pDstBuffer,
 				UINT DstAlignedByteOffset,
-				gsl::not_null<Wrapper<ID3D11UnorderedAccessView>> pSrcView)
+				gsl::not_null<WrapperView<ID3D11UnorderedAccessView>> pSrcView)
 			{
-				Get().CopyStructureCount(pDstBuffer.get().Get(), DstAlignedByteOffset, pSrcView.get().Get());
+				Self().CopyStructureCount(pDstBuffer.get().Get(), DstAlignedByteOffset, pSrcView.get().Get());
 			}
 
 			void ClearRenderTargetView(
-				gsl::not_null<Wrapper<ID3D11RenderTargetView>> pRenderTargetView,
+				gsl::not_null<WrapperView<ID3D11RenderTargetView>> pRenderTargetView,
 				std::span<const FLOAT, 4> ColorRGBA)
 			{
-				Get().ClearRenderTargetView(pRenderTargetView.get().Get(), ColorRGBA.data());
+				Self().ClearRenderTargetView(pRenderTargetView.get().Get(), ColorRGBA.data());
 			}
 
 			void ClearRenderTargetView(
-				gsl::not_null<Wrapper<ID3D11RenderTargetView>> pRenderTargetView,
+				gsl::not_null<WrapperView<ID3D11RenderTargetView>> pRenderTargetView,
 				std::array<const FLOAT, 4> ColorRGBA)
 			{
 				ClearRenderTargetView(pRenderTargetView, std::span{ ColorRGBA });
 			}
 
 			void ClearUnorderedAccessViewUint(
-				gsl::not_null<Wrapper<ID3D11UnorderedAccessView>> pUnorderedAccessView,
+				gsl::not_null<WrapperView<ID3D11UnorderedAccessView>> pUnorderedAccessView,
 				std::span<const UINT, 4> Values)
 			{
-				Get().ClearUnorderedAccessViewUint(pUnorderedAccessView.get().Get(), Values.data());
+				Self().ClearUnorderedAccessViewUint(pUnorderedAccessView.get().Get(), Values.data());
 			}
 
 			void ClearUnorderedAccessViewUint(
-				gsl::not_null<Wrapper<ID3D11UnorderedAccessView>> pUnorderedAccessView,
+				gsl::not_null<WrapperView<ID3D11UnorderedAccessView>> pUnorderedAccessView,
 				std::array<const UINT, 4> Values)
 			{
 				ClearUnorderedAccessViewUint(pUnorderedAccessView, std::span{ Values });
 			}
 
 			void ClearUnorderedAccessViewFloat(
-				gsl::not_null<Wrapper<ID3D11UnorderedAccessView>> pUnorderedAccessView,
+				gsl::not_null<WrapperView<ID3D11UnorderedAccessView>> pUnorderedAccessView,
 				std::span<const FLOAT, 4> Values)
 			{
-				Get().ClearUnorderedAccessViewFloat(pUnorderedAccessView.get().Get(), Values.data());
+				Self().ClearUnorderedAccessViewFloat(pUnorderedAccessView.get().Get(), Values.data());
 			}
 
 			void ClearUnorderedAccessViewFloat(
-				gsl::not_null<Wrapper<ID3D11UnorderedAccessView>> pUnorderedAccessView,
+				gsl::not_null<WrapperView<ID3D11UnorderedAccessView>> pUnorderedAccessView,
 				std::array<const FLOAT, 4> Values)
 			{
 				ClearUnorderedAccessViewFloat(pUnorderedAccessView, std::span{ Values });
 			}
 
 			void ClearDepthStencilView(
-				gsl::not_null<Wrapper<ID3D11DepthStencilView>> pDepthStencilView,
+				gsl::not_null<WrapperView<ID3D11DepthStencilView>> pDepthStencilView,
 				UINT ClearFlags,
 				FLOAT Depth,
 				UINT8 Stencil)
 			{
-				Get().ClearDepthStencilView(pDepthStencilView.get().Get(), ClearFlags, Depth, Stencil);
+				Self().ClearDepthStencilView(pDepthStencilView.get().Get(), ClearFlags, Depth, Stencil);
 			}
 
-			void SOSetTargets(SOSetTargetsData ppSOTargets)
+			void SOSetTargets(D3D11::SOSetTargetsData ppSOTargets)
 			{
-				Get().SOSetTargets(ppSOTargets.GetCount(), ppSOTargets.GetBuffers(), ppSOTargets.GetOffsets());
+				Self().SOSetTargets(ppSOTargets.GetCount(), ppSOTargets.GetBuffers(), ppSOTargets.GetOffsets());
 			}
 
 			Vector<Wrapper<ID3D11Buffer>> SOGetTargets(UINT NumBuffers)
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().SOGetTargets(NumBuffers, buffers.data());
+				Self().SOGetTargets(NumBuffers, buffers.data());
 
 				return buffers;
 			}
 
 			void IASetInputLayout(
-				Wrapper<ID3D11InputLayout> pInputLayout)
+				WrapperView<ID3D11InputLayout> pInputLayout)
 			{
-				Get().IASetInputLayout(pInputLayout.Get());
+				Self().IASetInputLayout(pInputLayout.Get());
 			}
 
 			void IASetVertexBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> buffer,
+				WrapperView<ID3D11Buffer> buffer,
 				UINT stride,
 				UINT offset)
 			{
+				ID3D11Buffer* temp = buffer.Get();
 				IASetVertexBuffers(
 					StartSlot,
-					{ 1, buffer.GetAddressOf(), &stride, &offset });
+					{ 1, &temp, &stride, &offset });
 			}
 
 			void IASetVertexBuffers(
 				UINT StartSlot,
-				IASetVertexBuffersData data)
+				D3D11::IASetVertexBuffersData data)
 			{
-				Get().IASetVertexBuffers(
+				Self().IASetVertexBuffers(
 					StartSlot,
 					data.GetCount(),
 					data.GetBuffers(),
@@ -575,65 +618,63 @@ namespace TypedD3D::D3D11
 			}
 
 			void IASetIndexBuffer(
-				Wrapper<ID3D11Buffer> pIndexBuffer,
+				WrapperView<ID3D11Buffer> pIndexBuffer,
 				DXGI_FORMAT Format,
 				UINT Offset)
 			{
-				Get().IASetIndexBuffer(pIndexBuffer.Get(), Format, Offset);
+				Self().IASetIndexBuffer(pIndexBuffer.Get(), Format, Offset);
 			}
 
 			void IASetPrimitiveTopology(
 				D3D11_PRIMITIVE_TOPOLOGY Topology)
 			{
-				Get().IASetPrimitiveTopology(Topology);
+				Self().IASetPrimitiveTopology(Topology);
 			}
 
 			Wrapper<ID3D11InputLayout> IAGetInputLayout()
 			{
-				Microsoft::WRL::ComPtr<ID3D11InputLayout> layout;
-				Get().IAGetInputLayout(&layout);
-				return Wrapper<ID3D11InputLayout>(std::move(layout));
+				Wrapper<ID3D11InputLayout> layout;
+				Self().IAGetInputLayout(OutPtr{ layout });
+				return layout;
 			}
 
-			IAGetVertexBufferData IAGetVertexBuffers(
+			D3D11::IAGetVertexBufferData IAGetVertexBuffers(
 				UINT StartSlot,
 				UINT NumBuffers)
 			{
-				IAGetVertexBufferData output;
+				D3D11::IAGetVertexBufferData output;
 				output.buffers.resize(NumBuffers);
 				output.strides.resize(NumBuffers);
 				output.offsets.resize(NumBuffers);
-				Get().IAGetVertexBuffers(StartSlot, NumBuffers, output.buffers.data(), output.strides.data(), output.offsets.data());
+				Self().IAGetVertexBuffers(StartSlot, NumBuffers, output.buffers.data(), output.strides.data(), output.offsets.data());
 
 				return output;
 			}
 
-			IAGetIndexBufferData IAGetIndexBuffer()
+			D3D11::IAGetIndexBufferData IAGetIndexBuffer()
 			{
-				IAGetIndexBufferData output;
-				Microsoft::WRL::ComPtr<ID3D11Buffer> temp;
-				Get().IAGetIndexBuffer(&temp, &output.format, &output.offset);
-				output.buffer.Attach(temp.Detach());
+				D3D11::IAGetIndexBufferData output;
+				Self().IAGetIndexBuffer(OutPtr{ output.buffer }, &output.format, &output.offset);
 				return output;
 			}
 
 			D3D11_PRIMITIVE_TOPOLOGY IAGetPrimitiveTopology()
 			{
 				D3D11_PRIMITIVE_TOPOLOGY topology;
-				Get().IAGetPrimitiveTopology(&topology);
+				Self().IAGetPrimitiveTopology(&topology);
 				return topology;
 			}
 
 			void RSSetState(
-				Wrapper<ID3D11RasterizerState> optRasterizerState)
+				WrapperView<ID3D11RasterizerState> optRasterizerState)
 			{
-				Get().RSSetState(optRasterizerState.Get());
+				Self().RSSetState(optRasterizerState.Get());
 			}
 
 			void RSSetViewports(
 				std::span<const D3D11_VIEWPORT> pViewports)
 			{
-				Get().RSSetViewports(static_cast<UINT>(pViewports.size()), pViewports.data());
+				Self().RSSetViewports(static_cast<UINT>(pViewports.size()), pViewports.data());
 			}
 
 			void RSSetViewports(
@@ -645,7 +686,7 @@ namespace TypedD3D::D3D11
 			void RSSetScissorRects(
 				std::span<const D3D11_RECT> pRects)
 			{
-				Get().RSSetScissorRects(static_cast<UINT>(pRects.size()), pRects.data());
+				Self().RSSetScissorRects(static_cast<UINT>(pRects.size()), pRects.data());
 			}
 
 			void RSSetScissorRects(
@@ -656,18 +697,18 @@ namespace TypedD3D::D3D11
 
 			Wrapper<ID3D11RasterizerState> RSGetState()
 			{
-				Microsoft::WRL::ComPtr<ID3D11RasterizerState> state;
-				Get().RSGetState(&state);
-				return Wrapper<ID3D11RasterizerState>(std::move(state));
+				Wrapper<ID3D11RasterizerState> state;
+				Self().RSGetState(OutPtr{ state });
+				return state;
 			}
 
 			std::vector<D3D11_VIEWPORT> RSGetViewports()
 			{
 				UINT numViewports = 0;
-				Get().RSGetViewports(&numViewports, nullptr);
+				Self().RSGetViewports(&numViewports, nullptr);
 
 				std::vector<D3D11_VIEWPORT> output(numViewports);
-				Get().RSGetViewports(&numViewports, output.data());
+				Self().RSGetViewports(&numViewports, output.data());
 
 				return output;
 			}
@@ -675,36 +716,37 @@ namespace TypedD3D::D3D11
 			std::vector<D3D11_RECT> RSGetScissorRects()
 			{
 				UINT numRects = 0;
-				Get().RSGetScissorRects(&numRects, nullptr);
+				Self().RSGetScissorRects(&numRects, nullptr);
 
 				std::vector<D3D11_RECT> output(numRects);
-				Get().RSGetScissorRects(&numRects, output.data());
+				Self().RSGetScissorRects(&numRects, output.data());
 
 				return output;
 			}
 
 			void OMSetRenderTargets(
-				Span<const Wrapper<ID3D11RenderTargetView>> optRenderTargetViews,
-				Wrapper<ID3D11DepthStencilView> optDepthStencilView)
+				Span<const WrapperView<ID3D11RenderTargetView>> optRenderTargetViews,
+				WrapperView<ID3D11DepthStencilView> optDepthStencilView)
 			{
-				Get().OMSetRenderTargets(static_cast<UINT>(optRenderTargetViews.size()), optRenderTargetViews.data(), optDepthStencilView.Get());
+				Self().OMSetRenderTargets(static_cast<UINT>(optRenderTargetViews.size()), optRenderTargetViews.data(), optDepthStencilView.Get());
 			}
 
 			void OMSetRenderTargets(
-				Wrapper<ID3D11RenderTargetView> optRenderTargetViews,
-				Wrapper<ID3D11DepthStencilView> optDepthStencilView)
+				WrapperView<ID3D11RenderTargetView> optRenderTargetViews,
+				WrapperView<ID3D11DepthStencilView> optDepthStencilView)
 			{
-				OMSetRenderTargets(Span<const Wrapper<ID3D11RenderTargetView>>{ optRenderTargetViews.GetAddressOf(), optRenderTargetViews.Get() ? size_t{ 1 } : size_t{ 0 } }, optDepthStencilView);
+				auto temp = optRenderTargetViews.Get();
+				OMSetRenderTargets(Span<const WrapperView<ID3D11RenderTargetView>>{ &temp, temp ? size_t{ 1 } : size_t{ 0 } }, optDepthStencilView);
 			}
 
 			void OMSetRenderTargetsAndUnorderedAccessViews(
-				Span<const Wrapper<ID3D11RenderTargetView>> optRenderTargetViews,
-				Wrapper<ID3D11DepthStencilView> optDepthStencilView,
+				Span<const WrapperView<ID3D11RenderTargetView>> optRenderTargetViews,
+				WrapperView<ID3D11DepthStencilView> optDepthStencilView,
 				UINT UAVStartSlot,
-				Span<const Wrapper<ID3D11UnorderedAccessView>> ppUnorderedAccessViews,
+				Span<const WrapperView<ID3D11UnorderedAccessView>> ppUnorderedAccessViews,
 				const UINT* pUAVInitialCounts)
 			{
-				Get().OMSetRenderTargetsAndUnorderedAccessViews(
+				Self().OMSetRenderTargetsAndUnorderedAccessViews(
 					static_cast<UINT>(optRenderTargetViews.size()),
 					optRenderTargetViews.data(),
 					optDepthStencilView.Get(),
@@ -715,21 +757,21 @@ namespace TypedD3D::D3D11
 			}
 
 			void OMSetBlendState(
-				Wrapper<ID3D11BlendState> optBlendState,
+				WrapperView<ID3D11BlendState> optBlendState,
 				std::optional<std::span<const FLOAT, 4>> BlendFactor,
 				UINT SampleMask)
 			{
 				if(BlendFactor.has_value())
-					Get().OMSetBlendState(optBlendState.Get(), BlendFactor.value().data(), SampleMask);
+					Self().OMSetBlendState(optBlendState.Get(), BlendFactor.value().data(), SampleMask);
 				else
-					Get().OMSetBlendState(optBlendState.Get(), nullptr, SampleMask);
+					Self().OMSetBlendState(optBlendState.Get(), nullptr, SampleMask);
 			}
 
 			void OMSetDepthStencilState(
-				Wrapper<ID3D11DepthStencilState> optDepthStencilState,
+				WrapperView<ID3D11DepthStencilState> optDepthStencilState,
 				UINT StencilRef)
 			{
-				Get().OMSetDepthStencilState(optDepthStencilState.Get(), StencilRef);
+				Self().OMSetDepthStencilState(optDepthStencilState.Get(), StencilRef);
 			}
 
 			std::pair<Vector<Wrapper<ID3D11RenderTargetView>>, Wrapper<ID3D11DepthStencilView>>  OMGetRenderTargets(
@@ -737,98 +779,97 @@ namespace TypedD3D::D3D11
 			{
 				std::pair<Vector<Wrapper<ID3D11RenderTargetView>>, Wrapper<ID3D11DepthStencilView>> output;
 				output.first.resize(NumViews);
-				Get().OMGetRenderTargets(NumViews, output.first.data(), output.second.GetAddressOf());
+				Self().OMGetRenderTargets(NumViews, output.first.data(), OutPtr{ output.second });
 
 				return output;
 			}
 
-			OMGetRenderTargetsAndUnorderedAccessViewsData OMGetRenderTargetsAndUnorderedAccessViews(
+			D3D11::OMGetRenderTargetsAndUnorderedAccessViewsData OMGetRenderTargetsAndUnorderedAccessViews(
 				UINT NumRTVs,
 				UINT UAVStartSlot,
 				UINT NumUAVs)
 			{
-				OMGetRenderTargetsAndUnorderedAccessViewsData data;
+				D3D11::OMGetRenderTargetsAndUnorderedAccessViewsData data;
 
 				data.renderTargetViews.resize(NumRTVs);
 				data.unorderedAccessViews.resize(NumUAVs);
 
-				Get().OMGetRenderTargetsAndUnorderedAccessViews(NumRTVs, data.renderTargetViews.data(), data.depthStencilView.GetAddressOf(), UAVStartSlot, NumUAVs, data.unorderedAccessViews.data());
+				Self().OMGetRenderTargetsAndUnorderedAccessViews(NumRTVs, data.renderTargetViews.data(), OutPtr{ data.depthStencilView }, UAVStartSlot, NumUAVs, data.unorderedAccessViews.data());
 				return data;
 			}
 
-			OMGetBlendStateData OMGetBlendState()
+			D3D11::OMGetBlendStateData OMGetBlendState()
 			{
-				OMGetBlendStateData data;
-				Microsoft::WRL::ComPtr<ID3D11BlendState> blendState;
-				Get().OMGetBlendState(&blendState, data.blendFactor.data(), &data.sampleMask);
-				data.blendState.Attach(blendState.Detach());
+				D3D11::OMGetBlendStateData data;
+				Self().OMGetBlendState(OutPtr{ data.blendState }, data.blendFactor.data(), &data.sampleMask);
 				return data;
 			}
 
 			std::pair<Wrapper<ID3D11DepthStencilState>, UINT> OMGetDepthStencilState()
 			{
 				std::pair<Wrapper<ID3D11DepthStencilState>, UINT> state;
-				ID3D11DepthStencilState* temp;
-				Get().OMGetDepthStencilState(&temp, &state.second);
-				state.first.Attach(temp);
+				Self().OMGetDepthStencilState(OutPtr{ state.first }, &state.second);
 				return state;
-
 			}
 
 			void VSSetShader(
-				Wrapper<ID3D11VertexShader> optVertexShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11VertexShader> optVertexShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().VSSetShader(optVertexShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().VSSetShader(optVertexShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void VSSetShader(
-				Wrapper<ID3D11VertexShader> optVertexShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11VertexShader> optVertexShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				VSSetShader(optVertexShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				VSSetShader(optVertexShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void VSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().VSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().VSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void VSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				VSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				VSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			void VSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().VSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().VSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void VSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				VSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				VSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void VSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().VSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().VSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void VSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				VSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				VSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11Buffer>> VSGetConstantBuffers(
@@ -837,7 +878,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().VSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().VSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 				return buffers;
 			}
 
@@ -847,7 +888,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().VSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().VSGetShaderResources(StartSlot, NumViews, views.data());
 
 				return views;
 			}
@@ -858,81 +899,84 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().VSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().VSGetSamplers(StartSlot, NumSamplers, samplers.data());
 				return samplers;
 			}
 
-			std::pair<Wrapper<ID3D11VertexShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> VSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11VertexShader>, Vector<Wrapper<ID3D11ClassInstance>>> VSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11VertexShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11VertexShader> shader;
-
-				Get().VSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11VertexShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().VSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11VertexShader>, UINT> VSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11VertexShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().VSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
 			void HSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().HSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().HSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void HSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				HSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				HSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void HSSetShader(
-				Wrapper<ID3D11HullShader> optHullShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11HullShader> optHullShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().HSSetShader(optHullShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().HSSetShader(optHullShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void HSSetShader(
-				Wrapper<ID3D11HullShader> optHullShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11HullShader> optHullShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				HSSetShader(optHullShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				HSSetShader(optHullShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void HSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().HSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().HSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void HSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				HSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				HSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			void HSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().HSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().HSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void HSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				HSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				HSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11ShaderResourceView>> HSGetShaderResources(
@@ -941,24 +985,23 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().HSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().HSGetShaderResources(StartSlot, NumViews, views.data());
 				return views;
 			}
 
-			std::pair<Wrapper<ID3D11HullShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> HSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11HullShader>, Vector<Wrapper<ID3D11ClassInstance>>> HSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11HullShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11HullShader> shader;
-
-				Get().HSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11HullShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().HSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11HullShader>, UINT> HSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11HullShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().HSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
@@ -968,7 +1011,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().HSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().HSGetSamplers(StartSlot, NumSamplers, samplers.data());
 				return samplers;
 			}
 
@@ -978,64 +1021,68 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().HSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().HSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 				return buffers;
 			}
 
 			void DSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().DSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().DSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void DSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				DSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				DSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void DSSetShader(
-				Wrapper<ID3D11DomainShader> optDomainShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11DomainShader> optDomainShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().DSSetShader(optDomainShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().DSSetShader(optDomainShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void DSSetShader(
-				Wrapper<ID3D11DomainShader> optDomainShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11DomainShader> optDomainShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				DSSetShader(optDomainShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				DSSetShader(optDomainShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void DSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().DSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().DSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void DSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				DSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				DSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			void DSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().DSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().DSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void DSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				DSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				DSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11ShaderResourceView>> DSGetShaderResources(
@@ -1044,24 +1091,23 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().DSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().DSGetShaderResources(StartSlot, NumViews, views.data());
 				return views;
 			}
 
-			std::pair<Wrapper<ID3D11DomainShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> DSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11DomainShader>, Vector<Wrapper<ID3D11ClassInstance>>> DSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11DomainShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11DomainShader> shader;
-
-				Get().DSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11DomainShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().DSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11DomainShader>, UINT> DSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11DomainShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().DSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
@@ -1071,7 +1117,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().DSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().DSGetSamplers(StartSlot, NumSamplers, samplers.data());
 
 				return samplers;
 			}
@@ -1082,64 +1128,68 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().DSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().DSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 				return buffers;
 			}
 
 			void GSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().GSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().GSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void GSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				GSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				GSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			void GSSetShader(
-				Wrapper<ID3D11GeometryShader> optGeometryShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11GeometryShader> optGeometryShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().GSSetShader(optGeometryShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().GSSetShader(optGeometryShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void GSSetShader(
-				Wrapper<ID3D11GeometryShader> optGeometryShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11GeometryShader> optGeometryShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				GSSetShader(optGeometryShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				GSSetShader(optGeometryShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void GSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().GSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().GSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void GSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				GSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				GSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void GSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().GSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().GSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void GSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				GSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				GSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11Buffer>> GSGetConstantBuffers(
@@ -1148,24 +1198,23 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().GSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().GSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 				return buffers;
 			}
 
-			std::pair<Wrapper<ID3D11GeometryShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> GSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11GeometryShader>, Vector<Wrapper<ID3D11ClassInstance>>> GSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11GeometryShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11GeometryShader> shader;
-
-				Get().GSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11GeometryShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().GSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11GeometryShader>, UINT> GSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11GeometryShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().GSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
@@ -1175,7 +1224,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().GSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().GSGetShaderResources(StartSlot, NumViews, views.data());
 				return views;
 			}
 
@@ -1185,64 +1234,68 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().GSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().GSGetSamplers(StartSlot, NumSamplers, samplers.data());
 				return samplers;
 			}
 
 			void PSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().PSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().PSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void PSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				PSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				PSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void PSSetShader(
-				Wrapper<ID3D11PixelShader> optPixelShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11PixelShader> optPixelShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().PSSetShader(optPixelShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().PSSetShader(optPixelShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void PSSetShader(
-				Wrapper<ID3D11PixelShader> optPixelShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11PixelShader> optPixelShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				PSSetShader(optPixelShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				PSSetShader(optPixelShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void PSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().PSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().PSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void PSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				PSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				PSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			void PSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().PSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().PSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void PSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				PSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				PSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11ShaderResourceView>> PSGetShaderResources(
@@ -1251,24 +1304,23 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().PSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().PSGetShaderResources(StartSlot, NumViews, views.data());
 				return views;
 			}
 
-			std::pair<Wrapper<ID3D11PixelShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> PSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11PixelShader>, Vector<Wrapper<ID3D11ClassInstance>>> PSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11PixelShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11PixelShader> shader;
-
-				Get().PSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11PixelShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().PSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11PixelShader>, UINT> PSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11PixelShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().PSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
@@ -1278,7 +1330,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().PSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().PSGetSamplers(StartSlot, NumSamplers, samplers.data());
 				return samplers;
 			}
 
@@ -1288,29 +1340,30 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().PSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().PSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 				return buffers;
 			}
 
 			void CSSetShaderResources(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11ShaderResourceView>> ppShaderResourceViews)
+				Span<const WrapperView<ID3D11ShaderResourceView>> ppShaderResourceViews)
 			{
-				Get().CSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
+				Self().CSSetShaderResources(StartSlot, static_cast<UINT>(ppShaderResourceViews.size()), ppShaderResourceViews.data());
 			}
 
 			void CSSetShaderResources(
 				UINT StartSlot,
-				Wrapper<ID3D11ShaderResourceView> ppShaderResourceViews)
+				WrapperView<ID3D11ShaderResourceView> ppShaderResourceViews)
 			{
-				CSSetShaderResources(StartSlot, Span<const Wrapper<ID3D11ShaderResourceView>>{ ppShaderResourceViews.GetAddressOf(), 1 });
+				auto temp = ppShaderResourceViews.Get();
+				CSSetShaderResources(StartSlot, Span<const WrapperView<ID3D11ShaderResourceView>>{ &temp, 1 });
 			}
 
 			void CSSetUnorderedAccessViews(
 				UINT StartSlot,
-				CSSetUnorderedAccessViewsData data)
+				D3D11::CSSetUnorderedAccessViewsData data)
 			{
-				Get().CSSetUnorderedAccessViews(StartSlot, data.GetCount(), data.GetBuffers(), data.GetInitialCounts());
+				Self().CSSetUnorderedAccessViews(StartSlot, data.GetCount(), data.GetBuffers(), data.GetInitialCounts());
 			}
 
 			void CSSetUnorderedAccessViews(
@@ -1323,52 +1376,56 @@ namespace TypedD3D::D3D11
 
 			void CSSetUnorderedAccessViews(
 				UINT StartSlot,
-				Wrapper<ID3D11UnorderedAccessView> data,
+				WrapperView<ID3D11UnorderedAccessView> data,
 				UINT initialCounts)
 			{
-				CSSetUnorderedAccessViews(StartSlot, { 1, data.GetAddressOf(), &initialCounts });
+				auto temp = data.Get();
+				CSSetUnorderedAccessViews(StartSlot, { 1, &temp, &initialCounts });
 			}
 
 			void CSSetShader(
-				Wrapper<ID3D11ComputeShader> optComputeShader,
-				std::span<ID3D11ClassInstance*> optClassInstances)
+				WrapperView<ID3D11ComputeShader> optComputeShader,
+				Span<const WrapperView<ID3D11ClassInstance>> optClassInstances)
 			{
-				Get().CSSetShader(optComputeShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
+				Self().CSSetShader(optComputeShader.Get(), optClassInstances.data(), static_cast<UINT>(optClassInstances.size()));
 			}
 
 			void CSSetShader(
-				Wrapper<ID3D11ComputeShader> optComputeShader,
-				ID3D11ClassInstance* optClassInstances)
+				WrapperView<ID3D11ComputeShader> optComputeShader,
+				WrapperView<ID3D11ClassInstance> optClassInstances)
 			{
-				CSSetShader(optComputeShader.Get(), std::span{ &optClassInstances, optClassInstances ? size_t{1} : size_t{0} });
+				Array temp{ optClassInstances };
+				CSSetShader(optComputeShader.Get(), optClassInstances ? Span<const WrapperView<ID3D11ClassInstance>>{ temp } : Span<const WrapperView<ID3D11ClassInstance>>{});
 			}
 
 			void CSSetSamplers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11SamplerState>> ppSamplers)
+				Span<const WrapperView<ID3D11SamplerState>> ppSamplers)
 			{
-				Get().CSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
+				Self().CSSetSamplers(StartSlot, static_cast<UINT>(ppSamplers.size()), ppSamplers.data());
 			}
 
 			void CSSetSamplers(
 				UINT StartSlot,
-				Wrapper<ID3D11SamplerState> ppSamplers)
+				WrapperView<ID3D11SamplerState> ppSamplers)
 			{
-				CSSetSamplers(StartSlot, Span<const Wrapper<ID3D11SamplerState>>{ ppSamplers.GetAddressOf(), 1 });
+				auto temp = ppSamplers.Get();
+				CSSetSamplers(StartSlot, Span<const WrapperView<ID3D11SamplerState>>{ &temp, 1 });
 			}
 
 			void CSSetConstantBuffers(
 				UINT StartSlot,
-				Span<const Wrapper<ID3D11Buffer>> ppConstantBuffers)
+				Span<const WrapperView<ID3D11Buffer>> ppConstantBuffers)
 			{
-				Get().CSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
+				Self().CSSetConstantBuffers(StartSlot, static_cast<UINT>(ppConstantBuffers.size()), ppConstantBuffers.data());
 			}
 
 			void CSSetConstantBuffers(
 				UINT StartSlot,
-				Wrapper<ID3D11Buffer> ppConstantBuffers)
+				WrapperView<ID3D11Buffer> ppConstantBuffers)
 			{
-				CSSetConstantBuffers(StartSlot, Span<const Wrapper<ID3D11Buffer>>{ ppConstantBuffers.GetAddressOf(), 1 });
+				auto temp = ppConstantBuffers.Get();
+				CSSetConstantBuffers(StartSlot, Span<const WrapperView<ID3D11Buffer>>{ &temp, 1 });
 			}
 
 			Vector<Wrapper<ID3D11ShaderResourceView>> CSGetShaderResources(
@@ -1377,7 +1434,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11ShaderResourceView>> views;
 				views.resize(NumViews);
-				Get().CSGetShaderResources(StartSlot, NumViews, views.data());
+				Self().CSGetShaderResources(StartSlot, NumViews, views.data());
 				return views;
 			}
 
@@ -1387,24 +1444,23 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11UnorderedAccessView>> views;
 				views.resize(NumViews);
-				Get().CSGetUnorderedAccessViews(StartSlot, NumViews, views.data());
+				Self().CSGetUnorderedAccessViews(StartSlot, NumViews, views.data());
 				return views;
 			}
 
-			std::pair<Wrapper<ID3D11ComputeShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> CSGetShader(UINT numInstances = 0)
+			std::pair<Wrapper<ID3D11ComputeShader>, Vector<Wrapper<ID3D11ClassInstance>>> CSGetShader(UINT& numInstances)
 			{
-				std::pair<Wrapper<ID3D11ComputeShader>, std::vector<Microsoft::WRL::ComPtr<ID3D11ClassInstance>>> output;
-				std::array<ID3D11ClassInstance*, TypedD3D::D3D11::Constants::Shader::g_maxClassInstances> tempInstances;
-				Microsoft::WRL::ComPtr<ID3D11ComputeShader> shader;
-
-				Get().CSGetShader(&shader, tempInstances.data(), &numInstances);
-				output.first.Attach(shader.Detach());
+				std::pair<Wrapper<ID3D11ComputeShader>, Vector<Wrapper<ID3D11ClassInstance>>> output;
 				output.second.resize(numInstances);
-				for(UINT i = 0; i < numInstances; i++)
-				{
-					output.second[i].Attach(tempInstances[i]);
-				}
+				Self().CSGetShader(OutPtr{ output.first }, output.second.data(), &numInstances);
+				return output;
+			}
 
+			std::pair<Wrapper<ID3D11ComputeShader>, UINT> CSGetShader(Span<Wrapper<ID3D11ClassInstance>> classIntances)
+			{
+				std::pair<Wrapper<ID3D11ComputeShader>, UINT> output;
+				output.second = classIntances.size();
+				Self().CSGetShader(OutPtr{ output.first }, classIntances.data(), &output.second);
 				return output;
 			}
 
@@ -1414,7 +1470,7 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11SamplerState>> samplers;
 				samplers.resize(NumSamplers);
-				Get().CSGetSamplers(StartSlot, NumSamplers, samplers.data());
+				Self().CSGetSamplers(StartSlot, NumSamplers, samplers.data());
 
 				return samplers;
 			}
@@ -1425,27 +1481,14 @@ namespace TypedD3D::D3D11
 			{
 				Vector<Wrapper<ID3D11Buffer>> buffers;
 				buffers.resize(NumBuffers);
-				Get().CSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
+				Self().CSGetConstantBuffers(StartSlot, NumBuffers, buffers.data());
 
 				return buffers;
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
-
-	template<std::derived_from<ID3D11DeviceContext> Ty>
-	struct UntaggedTraits<Ty> : D3D11DeviceContextTraits<Ty>
-	{
-	};
-
-	export template<std::derived_from<ID3D11DeviceContext> DeviceContextTy>
-	using DeviceContext_t = IUnknownWrapper<DeviceContextTy, UntaggedTraits>;
-
-	namespace Aliases
-	{
-		export using DeviceContext = DeviceContext_t<ID3D11DeviceContext>;
-	}
 }

--- a/TypedD3D/source/D3D11/DeviceContext.ixx
+++ b/TypedD3D/source/D3D11/DeviceContext.ixx
@@ -276,6 +276,8 @@ namespace TypedD3D
 		using reference = ID3D11DeviceContext&;
 		using const_reference = const ID3D11DeviceContext&;
 
+		using inner_type = ID3D11DeviceContext;
+
 		template<class Derived>
 		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
 		{

--- a/TypedD3D/source/D3D11/DeviceContext.ixx
+++ b/TypedD3D/source/D3D11/DeviceContext.ixx
@@ -268,18 +268,21 @@ namespace TypedD3D::D3D11
 namespace TypedD3D
 {
 	template<>
-	struct UntaggedTraits<ID3D11DeviceContext>
+	struct Trait<Untagged<ID3D11DeviceContext>>
 	{
-		using value_type = ID3D11DeviceContext;
-		using pointer = ID3D11DeviceContext*;
-		using const_pointer = const ID3D11DeviceContext*;
-		using reference = ID3D11DeviceContext&;
-		using const_reference = const ID3D11DeviceContext&;
 
 		using inner_type = ID3D11DeviceContext;
 
+
+		using inner_tag = ID3D11DeviceContext;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
+		class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
 		{
 		public:
 			D3D11_MAPPED_SUBRESOURCE Map(
@@ -322,10 +325,10 @@ namespace TypedD3D
 			}
 
 			void ExecuteCommandList(
-				ID3D11CommandList& pCommandList,
+				gsl::not_null<WrapperView<ID3D11CommandList>> pCommandList,
 				BOOL RestoreContextState)
 			{
-				Self().ExecuteCommandList(&pCommandList, RestoreContextState);
+				Self().ExecuteCommandList(pCommandList.get().Get(), RestoreContextState);
 			}
 
 			Wrapper<ID3D11CommandList> FinishCommandList(BOOL RestoreDeferredContextState)
@@ -336,24 +339,24 @@ namespace TypedD3D
 			}
 
 			void Begin(
-				ID3D11Asynchronous& pAsync)
+				gsl::not_null<WrapperView<ID3D11Asynchronous>> pAsync)
 			{
-				Self().Begin(&pAsync);
+				Self().Begin(pAsync.get().Get());
 			}
 
 			void End(
-				ID3D11Asynchronous& pAsync)
+				gsl::not_null<WrapperView<ID3D11Asynchronous>> pAsync)
 			{
-				Self().End(&pAsync);
+				Self().End(pAsync.get().Get());
 			}
 
 			void* GetData(
-				ID3D11Asynchronous& pAsync,
+				gsl::not_null<WrapperView<ID3D11Asynchronous>> pAsync,
 				UINT GetDataFlags)
 			{
 				void* data = nullptr;
 
-				ThrowIfFailed(Self().GetData(&pAsync, data, pAsync.GetDataSize(), GetDataFlags));
+				ThrowIfFailed(Self().GetData(pAsync.get().Get(), data, pAsync->GetDataSize(), GetDataFlags));
 
 				return data;
 			}
@@ -1489,8 +1492,8 @@ namespace TypedD3D
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/InputLayout.ixx
+++ b/TypedD3D/source/D3D11/InputLayout.ixx
@@ -9,17 +9,21 @@ import TypedD3D.Shared;
 namespace TypedD3D
 {
     template<>
-    struct UntaggedTraits<ID3D11InputLayout>
+    struct Trait<Untagged<ID3D11InputLayout>>
     {
-        using value_type = ID3D11InputLayout;
-        using pointer = ID3D11InputLayout*;
-        using const_pointer = const ID3D11InputLayout*;
-        using reference = ID3D11InputLayout&;
-        using const_reference = const ID3D11InputLayout&;
+
         using inner_type = ID3D11InputLayout;
 
+        using inner_tag = ID3D11InputLayout;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
+
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
         {
 
         };

--- a/TypedD3D/source/D3D11/InputLayout.ixx
+++ b/TypedD3D/source/D3D11/InputLayout.ixx
@@ -16,6 +16,7 @@ namespace TypedD3D
         using const_pointer = const ID3D11InputLayout*;
         using reference = ID3D11InputLayout&;
         using const_reference = const ID3D11InputLayout&;
+        using inner_type = ID3D11InputLayout;
 
         template<class Derived>
         class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>

--- a/TypedD3D/source/D3D11/InputLayout.ixx
+++ b/TypedD3D/source/D3D11/InputLayout.ixx
@@ -17,8 +17,8 @@ namespace TypedD3D
         using reference = ID3D11InputLayout&;
         using const_reference = const ID3D11InputLayout&;
 
-        template<class DerivedSelf>
-        class Interface : public D3D11::DeviceChildInterface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
         {
 
         };

--- a/TypedD3D/source/D3D11/ResourceViews.ixx
+++ b/TypedD3D/source/D3D11/ResourceViews.ixx
@@ -43,19 +43,20 @@ namespace TypedD3D
 {
 
 	template<>
-	struct UntaggedTraits<ID3D11View>
+	struct Trait<Untagged<ID3D11View>>
 	{
-		using value_type = ID3D11View;
-		using pointer = ID3D11View*;
-		using const_pointer = const ID3D11View*;
-		using reference = ID3D11View&;
-		using const_reference = const ID3D11View&;
-
-
 		using inner_type = ID3D11View;
 
+		using inner_tag = ID3D11View;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
+		class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
 		{
 		private:
 			using derived_self = Derived;
@@ -70,40 +71,42 @@ namespace TypedD3D
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 
 	export template<class Ty>
 		requires (std::derived_from<Ty, ID3D11View> && (!std::same_as<ID3D11View, Ty>))
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
-		using value_type = Ty;
-		using pointer = Ty*;
-		using const_pointer = const Ty*;
-		using reference = Ty&;
-		using const_reference = const Ty&;
-
 		using inner_type = Ty;
 
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11View>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>
+		class Interface : public Trait<Untagged<ID3D11View>>::Interface<Derived>
 		{
 		private:
 			using derived_self = Derived;
 
 		public:
-			typename D3D11::ViewToResourceDesc<value_type>::type GetDesc()
+			typename D3D11::ViewToResourceDesc<inner_type>::type GetDesc()
 			{
-				typename D3D11::ViewToResourceDesc<value_type>::type description;
+				typename D3D11::ViewToResourceDesc<inner_type>::type description;
 				Self().GetDesc(&description);
 				return description;
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/ResourceViews.ixx
+++ b/TypedD3D/source/D3D11/ResourceViews.ixx
@@ -51,6 +51,9 @@ namespace TypedD3D
 		using reference = ID3D11View&;
 		using const_reference = const ID3D11View&;
 
+
+		using inner_type = ID3D11View;
+
 		template<class Derived>
 		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
 		{
@@ -81,6 +84,8 @@ namespace TypedD3D
 		using const_pointer = const Ty*;
 		using reference = Ty&;
 		using const_reference = const Ty&;
+
+		using inner_type = Ty;
 
 		template<class Derived>
 		class Interface : public UntaggedTraits<ID3D11View>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>

--- a/TypedD3D/source/D3D11/ResourceViews.ixx
+++ b/TypedD3D/source/D3D11/ResourceViews.ixx
@@ -2,7 +2,7 @@ module;
 
 #include <d3d11_4.h>
 #include <concepts>
-#include <wrl/client.h>
+
 
 export module TypedD3D11:ResourceViews;
 import :DeviceChild;
@@ -51,27 +51,24 @@ namespace TypedD3D
 		using reference = ID3D11View&;
 		using const_reference = const ID3D11View&;
 
-		template<class DerivedSelf>
-		class Interface : public D3D11::DeviceChildInterface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
 		{
 		private:
-			using derived_self = DerivedSelf;
+			using derived_self = Derived;
 
 		public:
 			template<std::derived_from<ID3D11Resource> Ty = ID3D11Resource>
 			Wrapper<Ty> GetResource() const
 			{
-				Microsoft::WRL::ComPtr<ID3D11Resource> resource;
-				Get().GetResource(&resource);
-				return Wrapper<Ty>(TypedD3D::Cast<Ty>(resource));
+				Wrapper<ID3D11Resource> resource;
+				Self().GetResource(OutPtr{ resource });
+				return Cast<Ty>(std::move(resource));
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-
-			const derived_self& ToDerived() const { return static_cast<const derived_self&>(*this); }
-			reference Get() const { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
 
@@ -85,23 +82,23 @@ namespace TypedD3D
 		using reference = Ty&;
 		using const_reference = const Ty&;
 
-		template<class DerivedSelf>
-		class Interface : public UntaggedTraits<ID3D11View>::Interface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11View>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>
 		{
 		private:
-			using derived_self = DerivedSelf;
+			using derived_self = Derived;
 
 		public:
 			typename D3D11::ViewToResourceDesc<value_type>::type GetDesc()
 			{
 				typename D3D11::ViewToResourceDesc<value_type>::type description;
-				Get().GetDesc(&description);
+				Self().GetDesc(&description);
 				return description;
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/ResourceViews.ixx
+++ b/TypedD3D/source/D3D11/ResourceViews.ixx
@@ -76,7 +76,7 @@ namespace TypedD3D
 	};
 
 	export template<class Ty>
-		requires std::derived_from<Ty, ID3D11View> && (!std::same_as<ID3D11View, Ty>)
+		requires (std::derived_from<Ty, ID3D11View> && (!std::same_as<ID3D11View, Ty>))
 	struct UntaggedTraits<Ty>
 	{
 		using value_type = Ty;

--- a/TypedD3D/source/D3D11/Shaders.ixx
+++ b/TypedD3D/source/D3D11/Shaders.ixx
@@ -21,18 +21,20 @@ namespace TypedD3D::D3D11
 namespace TypedD3D
 {
 	template<D3D11::ShaderConcept Ty>
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
-		using value_type = Ty;
-		using pointer = Ty*;
-		using const_pointer = const Ty*;
-		using reference = Ty&;
-		using const_reference = const Ty&;
-
 		using inner_type = Ty;
 
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
+		class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
 		{
 
 		};

--- a/TypedD3D/source/D3D11/Shaders.ixx
+++ b/TypedD3D/source/D3D11/Shaders.ixx
@@ -16,16 +16,6 @@ namespace TypedD3D::D3D11
 		std::same_as<Ty, ID3D11GeometryShader> ||
 		std::same_as<Ty, ID3D11PixelShader> ||
 		std::same_as<Ty, ID3D11ComputeShader>;
-
-	namespace Aliases
-	{
-		export using D3D11VertexShader = Wrapper<ID3D11VertexShader>;
-		export using D3D11DomainShader = Wrapper<ID3D11DomainShader>;
-		export using D3D11HullShader = Wrapper<ID3D11HullShader>;
-		export using D3D11GeometryShader = Wrapper<ID3D11GeometryShader>;
-		export using D3D11PixelShader = Wrapper<ID3D11PixelShader>;
-		export using D3D11ComputeShader = Wrapper<ID3D11ComputeShader>;
-	}
 }
 
 namespace TypedD3D
@@ -39,8 +29,24 @@ namespace TypedD3D
 		using reference = Ty&;
 		using const_reference = const Ty&;
 
-		template<class DerivedSelf>
-		class Interface : public D3D11::DeviceChildInterface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
+		{
+
+		};
+	};
+
+	template<>
+	struct UntaggedTraits<ID3D11VertexShader>
+	{
+		using value_type = ID3D11VertexShader;
+		using pointer = ID3D11VertexShader*;
+		using const_pointer = const ID3D11VertexShader*;
+		using reference = ID3D11VertexShader&;
+		using const_reference = const ID3D11VertexShader&;
+
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
 		{
 
 		};

--- a/TypedD3D/source/D3D11/Shaders.ixx
+++ b/TypedD3D/source/D3D11/Shaders.ixx
@@ -29,21 +29,7 @@ namespace TypedD3D
 		using reference = Ty&;
 		using const_reference = const Ty&;
 
-		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>
-		{
-
-		};
-	};
-
-	template<>
-	struct UntaggedTraits<ID3D11VertexShader>
-	{
-		using value_type = ID3D11VertexShader;
-		using pointer = ID3D11VertexShader*;
-		using const_pointer = const ID3D11VertexShader*;
-		using reference = ID3D11VertexShader&;
-		using const_reference = const ID3D11VertexShader&;
+		using inner_type = Ty;
 
 		template<class Derived>
 		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>

--- a/TypedD3D/source/D3D11/States.ixx
+++ b/TypedD3D/source/D3D11/States.ixx
@@ -47,30 +47,31 @@ namespace TypedD3D::D3D11
 namespace TypedD3D
 {
 	template<D3D11::StateObject Ty>
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
-		using value_type = Ty;
-		using pointer = Ty*;
-		using const_pointer = const Ty*;
-		using reference = Ty&;
-		using const_reference = const Ty&;
-
 		using inner_type = Ty;
 
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>
+		class Interface : public Trait<Untagged<ID3D11DeviceChild>>::Interface<Derived>
 		{
 		public:
-			typename D3D11::ViewToStateDesc<value_type>::type GetDesc()
+			typename D3D11::ViewToStateDesc<inner_type>::type GetDesc()
 			{
-				typename D3D11::ViewToStateDesc<value_type>::type description;
+				typename D3D11::ViewToStateDesc<inner_type>::type description;
 				Self().GetDesc(&description);
 				return description;
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/States.ixx
+++ b/TypedD3D/source/D3D11/States.ixx
@@ -37,7 +37,8 @@ namespace TypedD3D::D3D11
 	};
 
 	template<class Ty>
-	concept StateObject = std::same_as<Ty, ID3D11DepthStencilState> ||
+	concept StateObject = 
+		std::same_as<Ty, ID3D11DepthStencilState> ||
 		std::same_as<Ty, ID3D11SamplerState> ||
 		std::same_as<Ty, ID3D11BlendState> ||
 		std::same_as<Ty, ID3D11RasterizerState>;
@@ -54,23 +55,20 @@ namespace TypedD3D
 		using reference = Ty&;
 		using const_reference = const Ty&;
 
-		template<class DerivedSelf>
-		class Interface : public D3D11::DeviceChildInterface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
 		public:
 			typename D3D11::ViewToStateDesc<value_type>::type GetDesc()
 			{
 				typename D3D11::ViewToStateDesc<value_type>::type description;
-				Get().GetDesc(&description);
+				Self().GetDesc(&description);
 				return description;
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D11/States.ixx
+++ b/TypedD3D/source/D3D11/States.ixx
@@ -55,6 +55,8 @@ namespace TypedD3D
 		using reference = Ty&;
 		using const_reference = const Ty&;
 
+		using inner_type = Ty;
+
 		template<class Derived>
 		class Interface : public UntaggedTraits<ID3D11DeviceChild>::Interface<Derived>, public InterfaceBase<UntaggedTraits<Derived>>
 		{

--- a/TypedD3D/source/D3D12/CommandAllocator.ixx
+++ b/TypedD3D/source/D3D12/CommandAllocator.ixx
@@ -1,7 +1,7 @@
 module;
 
 #include <d3d12.h>
-#include <wrl/client.h>
+
 #include <assert.h>
 
 export module TypedD3D12:CommandAllocator;
@@ -10,38 +10,18 @@ import :Wrappers;
 
 namespace TypedD3D::D3D12
 {
-	export template<D3D12_COMMAND_LIST_TYPE Type>
-	struct CommandListTypeToTrait;
+	template<D3D12_COMMAND_LIST_TYPE Type>
+	struct CommandListTypeToTraitMap;
 
 	template<>
-	struct CommandListTypeToTrait<D3D12_COMMAND_LIST_TYPE_DIRECT> { template<class Ty> using type = DirectTraits<Ty>; };
+	struct CommandListTypeToTraitMap<D3D12_COMMAND_LIST_TYPE::D3D12_COMMAND_LIST_TYPE_DIRECT>
+	{
+		template<class Ty>
+		using type = DirectTraits<Ty>;
+	};
 
-	template<>
-	struct CommandListTypeToTrait<D3D12_COMMAND_LIST_TYPE_COMPUTE> { template<class Ty> using type = ComputeTraits<Ty>; };
-
-	template<>
-	struct CommandListTypeToTrait<D3D12_COMMAND_LIST_TYPE_COPY> { template<class Ty> using type = CopyTraits<Ty>; };
-
-	template<>
-	struct CommandListTypeToTrait<D3D12_COMMAND_LIST_TYPE_BUNDLE> { template<class Ty> using type = BundleTraits<Ty>; };
-
-	export template<template<class> class Trait>
-	constexpr D3D12_COMMAND_LIST_TYPE TraitToCommandListType;
-
-	template<>
-	constexpr D3D12_COMMAND_LIST_TYPE TraitToCommandListType<DirectTraits> = D3D12_COMMAND_LIST_TYPE_DIRECT;
-
-	template<>
-	constexpr D3D12_COMMAND_LIST_TYPE TraitToCommandListType<ComputeTraits> = D3D12_COMMAND_LIST_TYPE_COMPUTE;
-
-	template<>
-	constexpr D3D12_COMMAND_LIST_TYPE TraitToCommandListType<CopyTraits> = D3D12_COMMAND_LIST_TYPE_COPY;
-
-	template<>
-	constexpr D3D12_COMMAND_LIST_TYPE TraitToCommandListType<BundleTraits> = D3D12_COMMAND_LIST_TYPE_BUNDLE;
-
-	export template<D3D12_COMMAND_LIST_TYPE Type>
-	using CommandAllocator_t = IUnknownWrapper<ID3D12CommandAllocator, CommandListTypeToTrait<Type>::template type>;
+	template<D3D12_COMMAND_LIST_TYPE Type, class IUnknown>
+	using CommandListTypeToTrait = typename CommandListTypeToTraitMap<Type>::template type<IUnknown>;
 
 	template<D3D12_COMMAND_LIST_TYPE Type>
 	struct CommandAllocatorTraits
@@ -54,38 +34,53 @@ namespace TypedD3D::D3D12
 		using reference = ID3D12CommandAllocator&;
 		using const_reference = const ID3D12CommandAllocator&;
 
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		class Interface : public InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
 		public:
-			HRESULT Reset() { return Get().Reset(); }
+			HRESULT Reset() { return Self().Reset(); }
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::Self;
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::ToDerived;
 		};
+	};
+}
+
+namespace TypedD3D
+{
+	template<>
+	struct DirectTraits<ID3D12CommandAllocator> : public D3D12::CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_DIRECT> 
+	{
 	};
 
 	template<>
-	struct DirectTraits<ID3D12CommandAllocator> : public CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_DIRECT> {};
-
-	template<>
-	struct ComputeTraits<ID3D12CommandAllocator> : public CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_COMPUTE> {};
-
-	template<>
-	struct CopyTraits<ID3D12CommandAllocator> : public CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_COPY> {};
-
-	template<>
-	struct BundleTraits<ID3D12CommandAllocator> : public CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_BUNDLE> {};
-
-	namespace Aliases
+	struct ComputeTraits<ID3D12CommandAllocator> : public D3D12::CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_COMPUTE> 
 	{
-		export using D3D12DirectCommandAllocator = CommandAllocator_t<D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		export using D3D12BundleCommandAllocator = CommandAllocator_t<D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-		export using D3D12ComputeCommandAllocator = CommandAllocator_t<D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		export using D3D12CopyCommandAllocator = CommandAllocator_t<D3D12_COMMAND_LIST_TYPE_COPY>;
-	}
+	};
+
+	template<>
+	struct CopyTraits<ID3D12CommandAllocator> : public D3D12::CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_COPY> 
+	{
+	};
+
+	template<>
+	struct BundleTraits<ID3D12CommandAllocator> : public D3D12::CommandAllocatorTraits<D3D12_COMMAND_LIST_TYPE_BUNDLE> 
+	{
+	};
 }
+
+//namespace TypedD3D::D3D12
+//{
+//	export template<D3D12_COMMAND_LIST_TYPE Type, class UnknownType>
+//	using CommandAllocator_t = StrongWrapper<CommandListTypeToTrait<type, UnknownType>>;
+//
+//	export template<D3D12_COMMAND_LIST_TYPE Type, class UnknownType>
+//	using CommandAllocatorView_t = WeakWrapper<CommandListTypeToTrait<type, UnknownType>>;
+//
+//	export template<D3D12_COMMAND_LIST_TYPE Type>
+//	using CommandAllocator = CommandAllocator_t<Type, ID3D12CommandAllocator>;
+//
+//	export template<D3D12_COMMAND_LIST_TYPE Type>
+//	using CommandAllocatorView_t = CommandAllocatorView_t<Type, ID3D12CommandAllocator>;
+//}

--- a/TypedD3D/source/D3D12/CommandAllocator.ixx
+++ b/TypedD3D/source/D3D12/CommandAllocator.ixx
@@ -34,6 +34,8 @@ namespace TypedD3D::D3D12
 		using reference = ID3D12CommandAllocator&;
 		using const_reference = const ID3D12CommandAllocator&;
 
+		using inner_type = ID3D12CommandAllocator;
+
 		template<class Derived>
 		class Interface : public InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{

--- a/TypedD3D/source/D3D12/CommandList.ixx
+++ b/TypedD3D/source/D3D12/CommandList.ixx
@@ -95,8 +95,8 @@ namespace TypedD3D::D3D12
 			}
 
 			void ClearUnorderedAccessViewFloat(
-				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
-				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+				CBV_SRV_UAV<D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+				CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
 				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
 				std::span<const float, 4> values,
 				std::span<const D3D12_RECT> rects)
@@ -105,8 +105,8 @@ namespace TypedD3D::D3D12
 			}
 
 			void ClearUnorderedAccessViewUint(
-				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
-				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+				CBV_SRV_UAV<D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+				CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
 				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
 				std::span<const UINT, 4> values,
 				std::span<const D3D12_RECT> rects)
@@ -270,31 +270,14 @@ namespace TypedD3D::D3D12
 				Self().OMSetBlendFactor(BlendFactor.data());
 			}
 			
-			//void OMSetRenderTargets(
-			//	Span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
-			//	BOOL RTsSingleHandleToDescriptorRange,
-			//	const DSV<::D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
-			//{
-			//	const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Raw() : nullptr;
-			//
-			//	Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), pRenderTargetDescriptors.data(), RTsSingleHandleToDescriptorRange, depthStencil);
-			//}
-			 
 			void OMSetRenderTargets(
-				std::span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
+				Span<const RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
 				BOOL RTsSingleHandleToDescriptorRange,
-				const DSV<::D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+				const DSV<D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
 			{
-				std::unique_ptr<::D3D12_CPU_DESCRIPTOR_HANDLE[]> renderTargets = std::make_unique<::D3D12_CPU_DESCRIPTOR_HANDLE[]>(pRenderTargetDescriptors.size());
-
-				for(size_t i = 0; i < pRenderTargetDescriptors.size(); i++)
-				{
-					renderTargets[i] = pRenderTargetDescriptors[i].Raw();
-				}
-
-				const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Raw() : nullptr;
-
-				Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), renderTargets.get(), RTsSingleHandleToDescriptorRange, depthStencil);
+				const D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Raw() : nullptr;
+			
+				Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), pRenderTargetDescriptors.data(), RTsSingleHandleToDescriptorRange, depthStencil);
 			}
 			
 			void OMSetStencilRef(UINT StencilRef)
@@ -379,7 +362,7 @@ namespace TypedD3D::D3D12
 				Self().SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
 			}
 			
-			void SetComputeRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+			void SetComputeRootDescriptorTable(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 			{
 				Self().SetComputeRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 			}
@@ -442,7 +425,7 @@ namespace TypedD3D::D3D12
 				Self().SetGraphicsRootConstantBufferView(RootParameterIndex, BufferLocation);
 			}
 			
-			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 			{
 				Self().SetGraphicsRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 			}
@@ -721,7 +704,7 @@ namespace TypedD3D
 //			}
 //
 //			void ClearDepthStencilView(
-//				DSV<::D3D12_CPU_DESCRIPTOR_HANDLE> DepthStencilView,
+//				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DepthStencilView,
 //				D3D12_CLEAR_FLAGS ClearFlags,
 //				FLOAT Depth,
 //				UINT8 Stencil,
@@ -731,7 +714,7 @@ namespace TypedD3D
 //			}
 //
 //			void ClearRenderTargetView(
-//				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
 //				std::span<const float, 4> colorRGBA,
 //				std::span<const D3D12_RECT> rects)
 //			{
@@ -739,7 +722,7 @@ namespace TypedD3D
 //			}
 //
 //			void ClearRenderTargetView(
-//				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
 //				std::array<const float, 4> colorRGBA)
 //			{
 //				ClearRenderTargetView(RenderTargetView.Get(), std::span<const float, 4>{ colorRGBA }, std::span<const D3D12_RECT>{});
@@ -751,8 +734,8 @@ namespace TypedD3D
 //			}
 //
 //			void ClearUnorderedAccessViewFloat(
-//				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
-//				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+//				CBV_SRV_UAV<D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+//				CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
 //				ID3D12Resource& pResource,
 //				std::span<const float, 4> values,
 //				std::span<const D3D12_RECT> rects)
@@ -761,8 +744,8 @@ namespace TypedD3D
 //			}
 //
 //			void ClearUnorderedAccessViewUint(
-//				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
-//				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+//				CBV_SRV_UAV<D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+//				CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
 //				ID3D12Resource& pResource,
 //				std::span<const UINT, 4> values,
 //				std::span<const D3D12_RECT> rects)
@@ -924,18 +907,18 @@ namespace TypedD3D
 //			}
 //
 //			void OMSetRenderTargets(
-//				std::span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
+//				std::span<const RTV<D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
 //				BOOL RTsSingleHandleToDescriptorRange,
-//				const DSV<::D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+//				const DSV<D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
 //			{
-//				std::unique_ptr<::D3D12_CPU_DESCRIPTOR_HANDLE[]> renderTargets = std::make_unique<::D3D12_CPU_DESCRIPTOR_HANDLE[]>(pRenderTargetDescriptors.size());
+//				std::unique_ptr<D3D12_CPU_DESCRIPTOR_HANDLE[]> renderTargets = std::make_unique<D3D12_CPU_DESCRIPTOR_HANDLE[]>(pRenderTargetDescriptors.size());
 //
 //				for(size_t i = 0; i < pRenderTargetDescriptors.size(); i++)
 //				{
 //					renderTargets[i] = pRenderTargetDescriptors[i].Get();
 //				}
 //
-//				const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Get() : nullptr;
+//				const D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Get() : nullptr;
 //
 //				Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), renderTargets.get(), RTsSingleHandleToDescriptorRange, depthStencil);
 //			}
@@ -1009,7 +992,7 @@ namespace TypedD3D
 //				Self().SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
 //			}
 //
-//			void SetComputeRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+//			void SetComputeRootDescriptorTable(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 //			{
 //				Self().SetComputeRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 //			}
@@ -1072,7 +1055,7 @@ namespace TypedD3D
 //				Self().SetGraphicsRootConstantBufferView(RootParameterIndex, BufferLocation);
 //			}
 //
-//			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+//			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 //			{
 //				Self().SetGraphicsRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 //			}

--- a/TypedD3D/source/D3D12/CommandList.ixx
+++ b/TypedD3D/source/D3D12/CommandList.ixx
@@ -148,12 +148,14 @@ namespace TypedD3D
 				ClearRenderTargetView(RenderTargetView, colorRGBA, {});
 			}
 
-			void ClearState(GraphicsView<ID3D12PipelineState> pPipelineState) requires D3D12::DisableFunction<Tag, CopyTag, BundleTag, RenderPassTag>
+			void ClearState(std::nullptr_t) requires D3D12::DisableFunction<Tag, CopyTag, BundleTag, RenderPassTag>
 			{
-				Self().ClearState(pPipelineState.Get());
+				Self().ClearState(nullptr);
 			}
 
-			void ClearState(ComputeView<ID3D12PipelineState> pPipelineState) requires D3D12::DisableFunction<Tag, CopyTag, BundleTag, RenderPassTag>
+			template<template<class> class Tag>
+				requires D3D12::PipelineStateEnabledTag<Tag>
+			void ClearState(WeakWrapper<Tag<ID3D12PipelineState>> pPipelineState) requires D3D12::DisableFunction<Tag, CopyTag, BundleTag, RenderPassTag>
 			{
 				Self().ClearState(pPipelineState.Get());
 			}

--- a/TypedD3D/source/D3D12/CommandList.ixx
+++ b/TypedD3D/source/D3D12/CommandList.ixx
@@ -28,7 +28,8 @@ namespace TypedD3D::D3D12
 		|| SameTagAs<Tag, ComputeTag>
 		|| SameTagAs<Tag, CopyTag>
 		|| SameTagAs<Tag, BundleTag>
-		|| SameTagAs<Tag, RenderPassTag>;
+		|| SameTagAs<Tag, RenderPassTag>
+		|| SameTagAs<Tag, Untagged>;
 
 	template<template<class> class Tag, template<class> class... Compare>
 	concept DisableFunction = !(SameTagAs<Tag, Compare> || ...);
@@ -66,6 +67,24 @@ namespace TypedD3D::D3D12
 
 namespace TypedD3D
 {
+	template<template<class> class Tag, std::derived_from<ID3D12GraphicsCommandList8> Ty>
+		requires D3D12::CommandListEnabledTag<Tag>
+	struct Trait<Tag<Ty>>
+	{
+		using inner_type = Ty;
+
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Tag<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Tag<NewInner>;
+
+		template<class Derived>
+		using Interface = Ty*;
+	};
+
 	template<template<class> class Tag>
 		requires D3D12::CommandListEnabledTag<Tag>
 	struct Trait<Tag<ID3D12CommandList>>

--- a/TypedD3D/source/D3D12/CommandList.ixx
+++ b/TypedD3D/source/D3D12/CommandList.ixx
@@ -5,7 +5,7 @@ module;
 #include <d3d12.h>
 #include <array>
 #include <span>
-#include <wrl/client.h>
+#include "gsl/pointers"
 #include <assert.h>
 #include <optional>
 
@@ -15,232 +15,130 @@ module;
 export module TypedD3D12:CommandList;
 import :CommandAllocator;
 import :DescriptorHeap;
-import :DeviceChild;
+//import :DeviceChild;
 import TypedD3D.Shared;
-
+import :Wrappers;
 
 namespace TypedD3D::D3D12
 {
-	//Used for meta-programming internally
-	template<std::derived_from<ID3D12CommandList> Ty, template<class> class Trait>
-	using GenericCommandList = IUnknownWrapper<Ty, Trait>;
+	template<std::derived_from<ID3D12CommandList> Ty, D3D12_COMMAND_LIST_TYPE Type>
+	struct CommandListTrait;
 
-	//Used for public APIs
-	export template<std::derived_from<ID3D12CommandList> Ty, D3D12_COMMAND_LIST_TYPE Type>
-	using CommandList_t = GenericCommandList<Ty, CommandListTypeToTrait<Type>::template type>;
-	template<std::derived_from<ID3D12CommandList> Ty>
-	using RenderPass_t = GenericCommandList<Ty, RenderPassTraits>;
-	namespace Aliases
+	template<D3D12_COMMAND_LIST_TYPE Type>
+	struct CommandListTrait<ID3D12CommandList, Type>
 	{
-		template<class ListTy>
-		using Direct_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-
-		export using D3D12DirectCommandListBase = Direct_t<ID3D12CommandList>;
-		export using D3D12DirectCommandList = Direct_t<ID3D12GraphicsCommandList>;
-		export using D3D12DirectCommandList1 = Direct_t<ID3D12GraphicsCommandList1>;
-		export using D3D12DirectCommandList2 = Direct_t<ID3D12GraphicsCommandList2>;
-		export using D3D12DirectCommandList3 = Direct_t<ID3D12GraphicsCommandList3>;
-		export using D3D12DirectCommandList4 = Direct_t<ID3D12GraphicsCommandList4>;
-		export using D3D12DirectCommandList5 = Direct_t<ID3D12GraphicsCommandList5>;
-		export using D3D12DirectCommandList6 = Direct_t<ID3D12GraphicsCommandList6>;
-		export using D3D12DirectCommandList7 = Direct_t<ID3D12GraphicsCommandList7>;
-
-		template<class ListTy>
-		using Bundle_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		export using D3D12BundleCommandListBase = Bundle_t<ID3D12CommandList>;
-		export using D3D12BundleCommandList = Bundle_t<ID3D12GraphicsCommandList>;
-		export using D3D12BundleCommandList1 = Bundle_t<ID3D12GraphicsCommandList1>;
-		export using D3D12BundleCommandList2 = Bundle_t<ID3D12GraphicsCommandList2>;
-		export using D3D12BundleCommandList3 = Bundle_t<ID3D12GraphicsCommandList3>;
-		export using D3D12BundleCommandList4 = Bundle_t<ID3D12GraphicsCommandList4>;
-		export using D3D12BundleCommandList5 = Bundle_t<ID3D12GraphicsCommandList5>;
-		export using D3D12BundleCommandList6 = Bundle_t<ID3D12GraphicsCommandList6>;
-		export using D3D12BundleCommandList7 = Bundle_t<ID3D12GraphicsCommandList7>;
-
-		template<class ListTy>
-		using Compute_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-
-		export using D3D12ComputeCommandListBase = Compute_t<ID3D12CommandList>;
-		export using D3D12ComputeCommandList = Compute_t<ID3D12GraphicsCommandList>;
-		export using D3D12ComputeCommandList1 = Compute_t<ID3D12GraphicsCommandList1>;
-		export using D3D12ComputeCommandList2 = Compute_t<ID3D12GraphicsCommandList2>;
-		export using D3D12ComputeCommandList3 = Compute_t<ID3D12GraphicsCommandList3>;
-		export using D3D12ComputeCommandList4 = Compute_t<ID3D12GraphicsCommandList4>;
-		export using D3D12ComputeCommandList5 = Compute_t<ID3D12GraphicsCommandList5>;
-		export using D3D12ComputeCommandList6 = Compute_t<ID3D12GraphicsCommandList6>;
-		export using D3D12ComputeCommandList7 = Compute_t<ID3D12GraphicsCommandList7>;
-
-		export template<class ListTy>
-		using Copy_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		export using D3D12CopyCommandListBase = Copy_t<ID3D12CommandList>;
-		export using D3D12CopyCommandList = Copy_t<ID3D12GraphicsCommandList>;
-		export using D3D12CopyCommandList1 = Copy_t<ID3D12GraphicsCommandList1>;
-		export using D3D12CopyCommandList2 = Copy_t<ID3D12GraphicsCommandList2>;
-		export using D3D12CopyCommandList3 = Copy_t<ID3D12GraphicsCommandList3>;
-		export using D3D12CopyCommandList4 = Copy_t<ID3D12GraphicsCommandList4>;
-		export using D3D12CopyCommandList5 = Copy_t<ID3D12GraphicsCommandList5>;
-		export using D3D12CopyCommandList6 = Copy_t<ID3D12GraphicsCommandList6>;
-		export using D3D12CopyCommandList7 = Copy_t<ID3D12GraphicsCommandList7>;
-
-
-		export using RenderPass4 = RenderPass_t<ID3D12GraphicsCommandList4>;
-		export using RenderPass5 = RenderPass_t<ID3D12GraphicsCommandList5>;
-		export using RenderPass6 = RenderPass_t<ID3D12GraphicsCommandList6>;
-		export using RenderPass7 = RenderPass_t<ID3D12GraphicsCommandList7>;
-	}
-
-#pragma region Untagged Traits
-	template<class Ty>
-	struct CommandListTraits;
-
-	template<>
-	struct CommandListTraits<ID3D12CommandList>
-	{
-		using value_type = ID3D12CommandList;
-		using pointer = ID3D12CommandList*;
-		using const_pointer = const ID3D12CommandList*;
-		using reference = ID3D12CommandList&;
-		using const_reference = const ID3D12CommandList&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceChildTraits::Interface<DerivedSelf>
+		template<class Derived>
+		struct Interface : InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
+			D3D12_COMMAND_LIST_TYPE GetType() { return Self().GetType(); }
 		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			D3D12_COMMAND_LIST_TYPE GetType() { return Get().GetType(); }
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::Self;
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::ToDerived;
 		};
 	};
 
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList>
+	template<D3D12_COMMAND_LIST_TYPE Type>
+	struct CommandListTrait<ID3D12GraphicsCommandList, Type>
 	{
-		using base_value_type = ID3D12CommandList;
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		struct Interface : InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-
 			void BeginEvent(
 				UINT Metadata,
 				const void* pData,
 				UINT Size)
 			{
-				Get().BeginEvent(Metadata, pData, Size);
+				Self().BeginEvent(Metadata, pData, Size);
 			}
 
 			void BeginQuery(
-				ID3D12QueryHeap& pQueryHeap,
+				gsl::not_null<WrapperView<ID3D12QueryHeap>> pQueryHeap,
 				D3D12_QUERY_TYPE Type,
 				UINT Index)
 			{
-				Get().BeginQuery(&pQueryHeap, Type, Index);
+				Self().BeginQuery(pQueryHeap.get().Get(), Type, Index);
 			}
 
 			void ClearDepthStencilView(
-				DSV<::D3D12_CPU_DESCRIPTOR_HANDLE> DepthStencilView,
+				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DepthStencilView,
 				D3D12_CLEAR_FLAGS ClearFlags,
 				FLOAT Depth,
 				UINT8 Stencil,
 				std::span<const D3D12_RECT> rects)
 			{
-				Get().ClearDepthStencilView(DepthStencilView.Get(), ClearFlags, Depth, Stencil, static_cast<UINT>(rects.size()), rects.data());
+				Self().ClearDepthStencilView(DepthStencilView.Raw(), ClearFlags, Depth, Stencil, static_cast<UINT>(rects.size()), rects.data());
 			}
 
 			void ClearRenderTargetView(
-				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
 				std::span<const float, 4> colorRGBA,
 				std::span<const D3D12_RECT> rects)
 			{
-				Get().ClearRenderTargetView(RenderTargetView.Get(), colorRGBA.data(), static_cast<UINT>(rects.size()), rects.data());
+				Self().ClearRenderTargetView(RenderTargetView.Raw(), colorRGBA.data(), static_cast<UINT>(rects.size()), rects.data());
 			}
 
 			void ClearRenderTargetView(
-				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
-				std::array<const float, 4> colorRGBA)
+				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+				const std::array<float, 4>& colorRGBA)
 			{
-				ClearRenderTargetView(RenderTargetView.Get(), std::span<const float, 4>{ colorRGBA }, std::span<const D3D12_RECT>{});
+				ClearRenderTargetView(RenderTargetView, colorRGBA, {});
 			}
 
-			void ClearState(ID3D12PipelineState* pPipelineState)
+			void ClearState(GraphicsView<ID3D12PipelineState> pPipelineState)
 			{
-				Get().ClearState(pPipelineState);
+				Self().ClearState(pPipelineState.Get());
+			}
+
+			void ClearState(ComputeView<ID3D12PipelineState> pPipelineState)
+			{
+				Self().ClearState(pPipelineState.Get());
 			}
 
 			void ClearUnorderedAccessViewFloat(
 				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
 				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
-				ID3D12Resource& pResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
 				std::span<const float, 4> values,
 				std::span<const D3D12_RECT> rects)
 			{
-				Get().ClearUnorderedAccessViewFloat(ViewGPUHandleInCurrentHeap, ViewCPUHandle, &pResource, values.data(), static_cast<UINT>(rects.size()), rects.data());
+				Self().ClearUnorderedAccessViewFloat(ViewGPUHandleInCurrentHeap, ViewCPUHandle, pResource.get().Get(), values.data(), static_cast<UINT>(rects.size()), rects.data());
 			}
 
 			void ClearUnorderedAccessViewUint(
 				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
 				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
-				ID3D12Resource& pResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
 				std::span<const UINT, 4> values,
 				std::span<const D3D12_RECT> rects)
 			{
-				Get().ClearUnorderedAccessViewUint(ViewGPUHandleInCurrentHeap, ViewCPUHandle, &pResource, values.data(), static_cast<UINT>(rects.size()), rects.data());
+				Self().ClearUnorderedAccessViewUint(ViewGPUHandleInCurrentHeap, ViewCPUHandle, pResource.get().Get(), values.data(), static_cast<UINT>(rects.size()), rects.data());
 			}
 
 			HRESULT Close()
 			{
-				return Get().Close();
+				return Self().Close();
 			}
 
 			void CopyBufferRegion(
-				ID3D12Resource& pDstBuffer,
+				gsl::not_null<WrapperView<ID3D12Resource>> pDstBuffer,
 				UINT64 DstOffset,
-				ID3D12Resource& pSrcBuffer,
+				gsl::not_null<WrapperView<ID3D12Resource>> pSrcBuffer,
 				UINT64 SrcOffset,
 				UINT64 NumBytes)
 			{
-				Get().CopyBufferRegion(
-					&pDstBuffer,
+				Self().CopyBufferRegion(
+					pDstBuffer.get().Get(),
 					DstOffset,
-					&pSrcBuffer,
+					pSrcBuffer.get().Get(),
 					SrcOffset,
 					NumBytes);
 			}
 
 			void CopyResource(
-				ID3D12Resource& pDstResource,
-				ID3D12Resource& pSrcResource)
+				gsl::not_null<WrapperView<ID3D12Resource>> pDstResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pSrcResource)
 			{
-				Get().CopyResource(&pDstResource, &pSrcResource);
+				Self().CopyResource(pDstResource.get().Get(), &pSrcResource.get().Get());
 			}
 
 			void CopyTextureRegion(
@@ -249,39 +147,39 @@ namespace TypedD3D::D3D12
 				UINT DstY,
 				UINT DstZ,
 				const D3D12_TEXTURE_COPY_LOCATION& pSrc,
-				const D3D12_BOX* pSrcBox)
+				const D3D12_BOX* pOptSrcBox)
 			{
-				Get().CopyTextureRegion(
+				Self().CopyTextureRegion(
 					&pDst,
 					DstX,
 					DstY,
 					DstZ,
 					&pSrc,
-					pSrcBox);
+					pOptSrcBox);
 			}
 
 			void CopyTiles(
-				ID3D12Resource& pTiledResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pTiledResource,
 				const D3D12_TILED_RESOURCE_COORDINATE& pTileRegionStartCoordinate,
 				const D3D12_TILE_REGION_SIZE& pTileRegionSize,
-				ID3D12Resource& pBuffer,
+				gsl::not_null<WrapperView<ID3D12Resource>> pBuffer,
 				UINT64 BufferStartOffsetInBytes,
 				D3D12_TILE_COPY_FLAGS Flags)
 			{
-				Get().CopyTiles(
-					&pTiledResource,
+				Self().CopyTiles(
+					pTiledResource.get().Get(),
 					&pTileRegionStartCoordinate,
 					&pTileRegionSize,
-					&pBuffer,
+					pBuffer.get().Get(),
 					BufferStartOffsetInBytes,
 					Flags);
 			}
-
+				
 			void DiscardResource(
-				ID3D12Resource& pResource,
-				const D3D12_DISCARD_REGION* pRegion)
+				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
+				const D3D12_DISCARD_REGION* pOptRegion)
 			{
-				Get().DiscardResource(&pResource, pRegion);
+				Self().DiscardResource(pResource.get().Get(), pOptRegion);
 			}
 
 			void Dispatch(
@@ -289,7 +187,7 @@ namespace TypedD3D::D3D12
 				UINT ThreadGroupCountY,
 				UINT ThreadGroupCountZ)
 			{
-				Get().Dispatch(
+				Self().Dispatch(
 					ThreadGroupCountX,
 					ThreadGroupCountY,
 					ThreadGroupCountZ);
@@ -302,7 +200,7 @@ namespace TypedD3D::D3D12
 				INT BaseVertexLocation,
 				UINT StartInstanceLocation)
 			{
-				Get().DrawIndexedInstanced(
+				Self().DrawIndexedInstanced(
 					IndexCountPerInstance,
 					InstanceCount,
 					StartIndexLocation,
@@ -316,59 +214,72 @@ namespace TypedD3D::D3D12
 				UINT StartVertexLocation,
 				UINT StartInstanceLocation)
 			{
-				Get().DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
+				Self().DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
 			}
 
 			void EndEvent()
 			{
-				Get().EndEvent();
+				Self().EndEvent();
 			}
 
 			void EndQuery(
-				ID3D12QueryHeap& pQueryHeap,
+				gsl::not_null<WrapperView<ID3D12QueryHeap>> pQueryHeap,
 				D3D12_QUERY_TYPE Type,
 				UINT Index)
 			{
-				Get().EndQuery(&pQueryHeap, Type, Index);
+				Self().EndQuery(pQueryHeap.get().Get(), Type, Index);
 			}
 
-			void ExecuteBundle(CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> pCommandList);
+			void ExecuteBundle(gsl::not_null<WeakWrapper<CommandListTypeToTrait<Type, ID3D12GraphicsCommandList>>> commandList)
+			{
+				Self().ExecuteBundle(commandList.get().Get());
+			}
 
 			void ExecuteIndirect(
-				ID3D12CommandSignature& commandSignature,
+				gsl::not_null<WrapperView<ID3D12CommandSignature>> commandSignature,
 				UINT maxCommandCount,
-				ID3D12Resource& argumentBuffer,
+				gsl::not_null<WrapperView<ID3D12Resource>> argumentBuffer,
 				UINT64 argumentBufferOffset,
-				ID3D12Resource* optCountBuffer = nullptr,
+				WrapperView<ID3D12Resource> optCountBuffer = nullptr,
 				UINT64 optCountBufferOffset = 0)
 			{
-				Get().ExecuteIndirect(&commandSignature, maxCommandCount, &argumentBuffer, argumentBufferOffset, optCountBuffer, optCountBufferOffset);
+				Self().ExecuteIndirect(commandSignature.get().Get(), maxCommandCount, argumentBuffer.get().Get(), argumentBufferOffset, optCountBuffer.Get(), optCountBufferOffset);
 			}
 
 			void IASetIndexBuffer(
 				const D3D12_INDEX_BUFFER_VIEW* pView)
 			{
-				Get().IASetIndexBuffer(pView);
+				Self().IASetIndexBuffer(pView);
 			}
-
+			
 			void IASetPrimitiveTopology(
 				D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology)
 			{
-				Get().IASetPrimitiveTopology(PrimitiveTopology);
+				Self().IASetPrimitiveTopology(PrimitiveTopology);
 			}
-
+			
 			void IASetVertexBuffers(
 				UINT StartSlot,
 				std::span<const D3D12_VERTEX_BUFFER_VIEW> views)
 			{
-				Get().IASetVertexBuffers(StartSlot, static_cast<UINT>(views.size()), views.data());
+				Self().IASetVertexBuffers(StartSlot, static_cast<UINT>(views.size()), views.data());
 			}
-
+			
 			void OMSetBlendFactor(std::span<const float, 4> BlendFactor)
 			{
-				Get().OMSetBlendFactor(BlendFactor.data());
+				Self().OMSetBlendFactor(BlendFactor.data());
 			}
-
+			
+			//void OMSetRenderTargets(
+			//	Span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
+			//	BOOL RTsSingleHandleToDescriptorRange,
+			//	const DSV<::D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+			//{
+			//	const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Raw() : nullptr;
+			//
+			//	Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), pRenderTargetDescriptors.data(), RTsSingleHandleToDescriptorRange, depthStencil);
+			//}
+			 
 			void OMSetRenderTargets(
 				std::span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
 				BOOL RTsSingleHandleToDescriptorRange,
@@ -378,1899 +289,2542 @@ namespace TypedD3D::D3D12
 
 				for(size_t i = 0; i < pRenderTargetDescriptors.size(); i++)
 				{
-					renderTargets[i] = pRenderTargetDescriptors[i].Get();
+					renderTargets[i] = pRenderTargetDescriptors[i].Raw();
 				}
 
-				const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Get() : nullptr;
+				const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Raw() : nullptr;
 
-				Get().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), renderTargets.get(), RTsSingleHandleToDescriptorRange, depthStencil);
+				Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), renderTargets.get(), RTsSingleHandleToDescriptorRange, depthStencil);
 			}
-
+			
 			void OMSetStencilRef(UINT StencilRef)
 			{
-				Get().OMSetStencilRef(StencilRef);
+				Self().OMSetStencilRef(StencilRef);
 			}
 
+			void RSSetScissorRects(
+				std::span<D3D12_RECT> rects)
+			{
+				Self().RSSetScissorRects(static_cast<UINT>(rects.size()), rects.data());
+			}
+
+			void RSSetViewports(
+				std::span<D3D12_VIEWPORT> viewports)
+			{
+				Self().RSSetViewports(static_cast<UINT>(viewports.size()), viewports.data());
+			}
+
+			HRESULT Reset(gsl::not_null<WeakWrapper<CommandListTypeToTrait<Type, ID3D12CommandAllocator>>> allocator,
+				ID3D12PipelineState* optPipelineState)
+			{
+				return Self().Reset(allocator.get().Get(), optPipelineState);
+			}
+			
 			void ResolveQueryData(
-				ID3D12QueryHeap& pQueryHeap,
+				gsl::not_null<WrapperView<ID3D12QueryHeap>> pQueryHeap,
 				D3D12_QUERY_TYPE Type,
 				UINT StartIndex,
 				UINT NumQueries,
 				ID3D12Resource& pDestinationBuffer,
 				UINT64 AlignedDestinationBufferOffset)
 			{
-				Get().ResolveQueryData(&pQueryHeap, Type, StartIndex, NumQueries, &pDestinationBuffer, AlignedDestinationBufferOffset);
+				Self().ResolveQueryData(pQueryHeap.get().Get(), Type, StartIndex, NumQueries, &pDestinationBuffer, AlignedDestinationBufferOffset);
 			}
-
+			
 			void ResolveSubresource(
-				ID3D12Resource& pDstResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pDstResource,
 				UINT DstSubresource,
-				ID3D12Resource& pSrcResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pSrcResource,
 				UINT SrcSubresource,
 				DXGI_FORMAT Format)
 			{
-				Get().ResolveSubresource(
-					&pDstResource,
+				Self().ResolveSubresource(
+					pDstResource.get().Get(),
 					DstSubresource,
-					&pSrcResource,
+					pSrcResource.get().Get(),
 					SrcSubresource,
 					Format);
 			}
-
+			
 			void ResourceBarrier(std::span<const D3D12_RESOURCE_BARRIER> Barriers)
 			{
-				Get().ResourceBarrier(static_cast<UINT>(Barriers.size()), Barriers.data());
+				Self().ResourceBarrier(static_cast<UINT>(Barriers.size()), Barriers.data());
 			}
-
-			void RSSetScissorRects(
-				std::span<D3D12_RECT> rects)
+			
+			void SOSetTargets(
+				UINT StartSlot,
+				std::span<const D3D12_STREAM_OUTPUT_BUFFER_VIEW> views)
 			{
-				Get().RSSetScissorRects(static_cast<UINT>(rects.size()), rects.data());
+				Self().SOSetTargets(StartSlot, static_cast<UINT>(views.size()), views.data());
 			}
-
-			void RSSetViewports(
-				std::span<D3D12_VIEWPORT> viewports)
-			{
-				Get().RSSetViewports(static_cast<UINT>(viewports.size()), viewports.data());
-			}
-
+			
 			void SetComputeRoot32BitConstant(UINT RootParameterIndex, UINT SrcData, UINT DestOffsetIn32BitValues)
 			{
-				Get().SetComputeRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
+				Self().SetComputeRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
 			}
-
+			
 			void SetComputeRoot32BitConstants(
 				UINT RootParameterIndex,
 				UINT Num32BitValuesToSet,
 				const void* pSrcData,
 				UINT DestOffsetIn32BitValues)
 			{
-				Get().SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
+				Self().SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
 			}
-
+			
 			void SetComputeRootConstantBufferView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
+				Self().SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
 			}
-
+			
 			void SetComputeRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 			{
-				Get().SetComputeRootDescriptorTable(RootParameterIndex, BaseDescriptor);
+				Self().SetComputeRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 			}
-
+			
 			void SetComputeRootShaderResourceView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetComputeRootShaderResourceView(RootParameterIndex, BufferLocation);
+				Self().SetComputeRootShaderResourceView(RootParameterIndex, BufferLocation);
 			}
 
 			void SetComputeRootSignature(ID3D12RootSignature* pRootSignature)
 			{
-				Get().SetComputeRootSignature(pRootSignature);
+				Self().SetComputeRootSignature(pRootSignature);
 			}
-
+			
 			void SetComputeRootUnorderedAccessView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetComputeRootUnorderedAccessView(RootParameterIndex, BufferLocation);
+				Self().SetComputeRootUnorderedAccessView(RootParameterIndex, BufferLocation);
 			}
-
+			
 			void SetDescriptorHeaps(ShaderVisible<CBV_SRV_UAV<ID3D12DescriptorHeap>> descriptorHeap)
 			{
 				ID3D12DescriptorHeap* heaps[] = { descriptorHeap.Get() };
-				Get().SetDescriptorHeaps(1, heaps);
+				Self().SetDescriptorHeaps(1, heaps);
 			}
-
+			
 			void SetDescriptorHeaps(ShaderVisible<Sampler<ID3D12DescriptorHeap>> descriptorHeap)
 			{
 				ID3D12DescriptorHeap* heaps[] = { descriptorHeap.Get() };
-				Get().SetDescriptorHeaps(1, heaps);
+				Self().SetDescriptorHeaps(1, heaps);
 			}
-
+			
 			void SetDescriptorHeaps(ShaderVisible<CBV_SRV_UAV<ID3D12DescriptorHeap>> cbv_srv_uavHeap, ShaderVisible<Sampler<ID3D12DescriptorHeap>> samplerHeap)
 			{
 				ID3D12DescriptorHeap* heaps[] = { cbv_srv_uavHeap.Get(), samplerHeap.Get() };
-				Get().SetDescriptorHeaps(2, heaps);
+				Self().SetDescriptorHeaps(2, heaps);
 			}
-
+			
 			void SetGraphicsRoot32BitConstant(UINT RootParameterIndex, UINT SrcData, UINT DestOffsetIn32BitValues)
 			{
-				Get().SetGraphicsRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
+				Self().SetGraphicsRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
 			}
-
+			
 			void SetGraphicsRoot32BitConstants(
 				UINT RootParameterIndex,
 				UINT Num32BitValuesToSet,
 				const void* pSrcData,
 				UINT DestOffsetIn32BitValues)
 			{
-				Get().SetGraphicsRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
+				Self().SetGraphicsRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
 			}
-
+			
 			void SetGraphicsRootConstantBufferView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetGraphicsRootConstantBufferView(RootParameterIndex, BufferLocation);
+				Self().SetGraphicsRootConstantBufferView(RootParameterIndex, BufferLocation);
 			}
-
+			
 			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
 			{
-				Get().SetGraphicsRootDescriptorTable(RootParameterIndex, BaseDescriptor);
+				Self().SetGraphicsRootDescriptorTable(RootParameterIndex, BaseDescriptor);
 			}
-
+			
 			void SetGraphicsRootShaderResourceView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetGraphicsRootShaderResourceView(RootParameterIndex, BufferLocation);
+				Self().SetGraphicsRootShaderResourceView(RootParameterIndex, BufferLocation);
 			}
-
+			
 			void SetGraphicsRootSignature(ID3D12RootSignature* pRootSignature)
 			{
-				Get().SetGraphicsRootSignature(pRootSignature);
+				Self().SetGraphicsRootSignature(pRootSignature);
 			}
-
+			
 			void SetGraphicsRootUnorderedAccessView(
 				UINT RootParameterIndex,
 				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
 			{
-				Get().SetGraphicsRootUnorderedAccessView(RootParameterIndex, BufferLocation);
+				Self().SetGraphicsRootUnorderedAccessView(RootParameterIndex, BufferLocation);
 			}
-
+			
 			void SetMarker(
 				UINT Metadata,
 				const void* pData,
 				UINT Size)
 			{
-				Get().SetMarker(Metadata, pData, Size);
+				Self().SetMarker(Metadata, pData, Size);
 			}
-
-			void SetPipelineState(ID3D12PipelineState* pPipelineState)
+			
+			void SetPipelineState(GraphicsView<ID3D12PipelineState> pPipelineState)
 			{
-				Get().SetPipelineState(pPipelineState);
+				Self().SetPipelineState(pPipelineState.Get());
 			}
-
+			
+			void SetPipelineState(ComputeView<ID3D12PipelineState> pPipelineState)
+			{
+				Self().SetPipelineState(pPipelineState.Get());
+			}
+			
 			void SetPredication(
-				ID3D12Resource* pBuffer,
+				WrapperView<ID3D12Resource> pBuffer,
 				UINT64 AlignedBufferOffset,
 				D3D12_PREDICATION_OP Operation)
 			{
-				Get().SetPredication(pBuffer, AlignedBufferOffset, Operation);
+				Self().SetPredication(pBuffer.Get(), AlignedBufferOffset, Operation);
 			}
-
-			void SOSetTargets(
-				UINT StartSlot,
-				std::span<const D3D12_STREAM_OUTPUT_BUFFER_VIEW> views)
-			{
-				Get().SOSetTargets(StartSlot, static_cast<UINT>(views.size()), views.data());
-			}
-
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::Self;
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::ToDerived;
 		};
+	};
+};
 
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
+namespace TypedD3D
+{
+	template<std::derived_from<ID3D12CommandList> Ty>
+	struct DirectTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
 
-		public:
-			HRESULT Reset(
-				allocator_value_type pAllocator,
-				ID3D12PipelineState* pInitialState)
-			{
-				return Get().Reset(pAllocator.Get(), pInitialState);
-			}
+	template<std::derived_from<ID3D12CommandList> Ty>
+	struct ComputeTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
 
-		  ////Alphabetical order
-		  //using Base::BeginEvent;
-		  //using Base::BeginQuery;
-		  //using Base::ClearDepthStencilView;
-		  //using Base::ClearRenderTargetView;
-		  //using Base::ClearState;
-		  //using Base::ClearUnorderedAccessViewFloat;
-		  //using Base::ClearUnorderedAccessViewUint;
-		  //using Base::Close;
-		  //using Base::CopyBufferRegion;
-		  //using Base::CopyResource;
-		  //using Base::CopyTextureRegion;
-		  //using Base::CopyTiles;
-		  //using Base::DiscardResource;
-		  //using Base::Dispatch;
-		  //using Base::DrawIndexedInstanced;
-		  //using Base::DrawInstanced;
-		  //using Base::EndEvent;
-		  //using Base::EndQuery;
-		  //using Base::ExecuteBundle;
-		  //using Base::ExecuteIndirect;
-		  //using Base::IASetIndexBuffer;
-		  //using Base::IASetPrimitiveTopology;
-		  //using Base::IASetVertexBuffers;
-		  //using Base::OMSetBlendFactor;
-		  //using Base::OMSetRenderTargets;
-		  //using Base::OMSetStencilRef;
-		  //using Base::Reset;
-		  //using Base::ResolveQueryData;
-		  //using Base::ResolveSubresource;
-		  //using Base::ResourceBarrier;
-		  //using Base::RSSetScissorRects;
-		  //using Base::RSSetViewports;
-		  //using Base::SetComputeRoot32BitConstant;
-		  //using Base::SetComputeRoot32BitConstants;
-		  //using Base::SetComputeRootConstantBufferView;
-		  //using Base::SetComputeRootDescriptorTable;
-		  //using Base::SetComputeRootShaderResourceView;
-		  //using Base::SetComputeRootSignature;
-		  //using Base::SetComputeRootUnorderedAccessView;
-		  //using Base::SetDescriptorHeaps;
-		  //using Base::SetGraphicsRoot32BitConstant;
-		  //using Base::SetGraphicsRoot32BitConstants;
-		  //using Base::SetGraphicsRootConstantBufferView;
-		  //using Base::SetGraphicsRootDescriptorTable;
-		  //using Base::SetGraphicsRootShaderResourceView;
-		  //using Base::SetGraphicsRootSignature;
-		  //using Base::SetGraphicsRootUnorderedAccessView;
-		  //using Base::SetMarker;
-		  //using Base::SetPipelineState;
-		  //using Base::SetPredication;
-		  //using Base::SOSetTargets;
+	template<std::derived_from<ID3D12CommandList> Ty>
+	struct CopyTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
 
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
+	template<std::derived_from<ID3D12CommandList> Ty>
+	struct BundleTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
+
+	template<std::derived_from<ID3D12CommandList> Ty>
+	struct RenderPassTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
 	};
 
 	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList1>
+	struct DirectTraits<ID3D12GraphicsCommandList>
 	{
-		using base_value_type = ID3D12GraphicsCommandList;
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_DIRECT>::Interface<Derived>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void AtomicCopyBufferUINT(
-				ID3D12Resource& pDstBuffer,
-				UINT64 DstOffset,
-				ID3D12Resource& pSrcBuffer,
-				UINT64 SrcOffset,
-				UINT Dependencies,
-				ID3D12Resource* const* ppDependentResources,
-				const D3D12_SUBRESOURCE_RANGE_UINT64* pDependentSubresourceRanges)
-			{
-				Get().AtomicCopyBufferUINT(
-					&pDstBuffer,
-					DstOffset,
-					&pSrcBuffer,
-					SrcOffset,
-					Dependencies,
-					ppDependentResources,
-					pDependentSubresourceRanges);
-			}
-
-			void AtomicCopyBufferUINT64(
-				ID3D12Resource& pDstBuffer,
-				UINT64 DstOffset,
-				ID3D12Resource& pSrcBuffer,
-				UINT64 SrcOffset,
-				UINT Dependencies,
-				ID3D12Resource* const* ppDependentResources,
-				const D3D12_SUBRESOURCE_RANGE_UINT64* pDependentSubresourceRanges)
-			{
-				Get().AtomicCopyBufferUINT64(
-					&pDstBuffer,
-					DstOffset,
-					&pSrcBuffer,
-					SrcOffset,
-					Dependencies,
-					ppDependentResources,
-					pDependentSubresourceRanges);
-			}
-
-			void OMSetDepthBounds(
-				FLOAT Min,
-				FLOAT Max)
-			{
-				Get().OMSetDepthBounds(Min, Max);
-			}
-
-			void ResolveSubresourceRegion(
-				ID3D12Resource& pDstResource,
-				UINT DstSubresource,
-				UINT DstX,
-				UINT DstY,
-				ID3D12Resource& pSrcResource,
-				UINT SrcSubresource,
-				D3D12_RECT* pSrcRect,
-				DXGI_FORMAT Format,
-				D3D12_RESOLVE_MODE ResolveMode)
-			{
-				Get().ResolveSubresourceRegion(
-					&pDstResource,
-					DstSubresource,
-					DstX,
-					DstY,
-					&pSrcResource,
-					SrcSubresource,
-					pSrcRect,
-					Format,
-					ResolveMode
-				);
-			}
-
-			void SetSamplePositions(
-				UINT NumSamplesPerPixel,
-				UINT NumPixels,
-				D3D12_SAMPLE_POSITION* pSamplePositions)
-			{
-				Get().SetSamplePositions(
-					NumSamplesPerPixel,
-					NumPixels,
-					pSamplePositions);
-			}
-
-			void SetViewInstanceMask(
-				UINT Mask)
-			{
-				Get().SetViewInstanceMask(Mask);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::AtomicCopyBufferUINT;
-			//using Base::AtomicCopyBufferUINT64;
-			//using Base::OMSetDepthBounds;
-			//using Base::ResolveSubresourceRegion;
-			//using Base::SetSamplePositions;
-			//using Base::SetViewInstanceMask;     
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
 		};
 	};
-
-	export class WriteBufferImmediateData
-	{
-		UINT count;
-		D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* parameters;
-		D3D12_WRITEBUFFERIMMEDIATE_MODE* modes = nullptr;
-
-	public:
-		template<UINT Count>
-		WriteBufferImmediateData(std::span<D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, Count> parameters, std::optional<std::span<D3D12_WRITEBUFFERIMMEDIATE_MODE, Count>> modes) :
-			count{ Count },
-			parameters{ parameters.data() },
-			modes{ modes.value_or({}).data() }
-		{
-
-		}
-
-		WriteBufferImmediateData(UINT count, D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* parameters, D3D12_WRITEBUFFERIMMEDIATE_MODE* optionalModes) :
-			count{ count },
-			parameters{ parameters },
-			modes{ optionalModes }
-		{
-
-		}
-
-	public:
-		UINT GetCount() const noexcept { return count; }
-		const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* GetParameters() const noexcept { return parameters; }
-		const D3D12_WRITEBUFFERIMMEDIATE_MODE* GetModes() const noexcept { return modes; }
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList2>
-	{
-		using base_value_type = ID3D12GraphicsCommandList1;
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void WriteBufferImmediate(WriteBufferImmediateData data)
-			{
-				Get().WriteBufferImmediate(data.GetCount(), data.GetParameters(), data.GetModes());
-			}
-
-			void WriteBufferImmediate(D3D12_WRITEBUFFERIMMEDIATE_PARAMETER parameters, std::optional<D3D12_WRITEBUFFERIMMEDIATE_MODE> modes)
-			{
-				Get().WriteBufferImmediate({ 1, &parameters, modes ? std::optional{ std::span{1, &modes.value()} } : std::optional{ std::nullopt } });
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::WriteBufferImmediate;
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList3>
-	{
-		using base_value_type = ID3D12GraphicsCommandList2;
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void SetProtectedResourceSession(
-				ID3D12ProtectedResourceSession* pProtectedResourceSession)
-			{
-				Get().SetProtectedResourceSession(pProtectedResourceSession);
-			}
-
-			//In code order                                                          //Alphabetical order
-			//using Base::SetProtectedResourceSession;                               using Base::SetProtectedResourceSession;
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			//In code order                                                          //Alphabetical order
-			//using Base::SetProtectedResourceSession;                               using Base::SetProtectedResourceSession;
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList4>
-	{
-		using base_value_type = ID3D12GraphicsCommandList3;
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			RenderPass_t<ID3D12GraphicsCommandList4> BeginRenderPass(
-				std::span<const D3D12_RENDER_PASS_RENDER_TARGET_DESC> renderTargets,
-				const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* pDepthStencil,
-				D3D12_RENDER_PASS_FLAGS Flags);
-
-			void BuildRaytracingAccelerationStructure(
-				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& pDesc,
-				std::span<const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC> pPostbuildInfoDescs)
-			{
-				Get().BuildRaytracingAccelerationStructure(
-					&pDesc,
-					static_cast<UINT>(pPostbuildInfoDescs.size()),
-					pPostbuildInfoDescs.data());
-			}
-
-			void CopyRaytracingAccelerationStructure(
-				D3D12_GPU_VIRTUAL_ADDRESS DestAccelerationStructureData,
-				D3D12_GPU_VIRTUAL_ADDRESS SourceAccelerationStructureData,
-				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode)
-			{
-				Get().CopyRaytracingAccelerationStructure(
-					DestAccelerationStructureData,
-					SourceAccelerationStructureData,
-					Mode);
-			}
-
-			void DispatchRays(
-				const D3D12_DISPATCH_RAYS_DESC& pDesc)
-			{
-				Get().DispatchRays(&pDesc);
-			}
-
-			void EmitRaytracingAccelerationStructurePostbuildInfo(
-				const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC& pDesc,
-				std::span<const D3D12_GPU_VIRTUAL_ADDRESS> pSourceAccelerationStructureData)
-			{
-				Get().EmitRaytracingAccelerationStructurePostbuildInfo(
-					&pDesc,
-					static_cast<UINT>(pSourceAccelerationStructureData.size()),
-					pSourceAccelerationStructureData.data());
-			}
-
-			void EndRenderPass()
-			{
-				Get().EndRenderPass();
-			}
-
-			void InitializeMetaCommand(
-				ID3D12MetaCommand& pMetaCommand,
-				const void* pInitializationParametersData,
-				SIZE_T InitializationParametersDataSizeInBytes)
-			{
-				Get().InitializeMetaCommand(&pMetaCommand, pInitializationParametersData, InitializationParametersDataSizeInBytes);
-			}
-
-			void ExecuteMetaCommand(
-				ID3D12MetaCommand& pMetaCommand,
-				const void* pExecutionParametersData,
-				SIZE_T ExecutionParametersDataSizeInBytes)
-			{
-				Get().ExecuteMetaCommand(&pMetaCommand, pExecutionParametersData, ExecutionParametersDataSizeInBytes);
-			}
-
-			void ExecuteMetaCommand(
-				ID3D12MetaCommand& pMetaCommand)
-			{
-				ExecuteMetaCommand(pMetaCommand, nullptr, 0);
-			}
-
-			template<class T>
-			void ExecuteMetaCommand(
-				ID3D12MetaCommand& pMetaCommand,
-				const T& pExecutionParametersData)
-			{
-				ExecuteMetaCommand(pMetaCommand, &pExecutionParametersData, sizeof(T));
-			}
-
-			void InitializeMetaCommand(
-				ID3D12MetaCommand& pMetaCommand)
-			{
-				InitializeMetaCommand(pMetaCommand, nullptr, 0);
-			}
-
-			template<class T>
-			void InitializeMetaCommand(
-				ID3D12MetaCommand& pMetaCommand,
-				const T& pInitializationParametersData)
-			{
-				InitializeMetaCommand(pMetaCommand, &pInitializationParametersData, sizeof(T));
-			}
-
-			void SetPipelineState1(
-				ID3D12StateObject* pStateObject)
-			{
-				Get().SetPipelineState1(pStateObject);
-			}
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::BeginRenderPass;
-			//using Base::BuildRaytracingAccelerationStructure;
-			//using Base::CopyRaytracingAccelerationStructure;
-			//using Base::DispatchRays;
-			//using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
-			//using Base::EndRenderPass;
-			//using Base::ExecuteMetaCommand;
-			//using Base::InitializeMetaCommand;
-			//using Base::SetPipelineState1;
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList5>
-	{
-		using base_value_type = ID3D12GraphicsCommandList4;
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void RSSetShadingRate(
-				D3D12_SHADING_RATE baseShadingRate,
-				const D3D12_SHADING_RATE_COMBINER* combiners)
-			{
-				Get().RSSetShadingRate(
-					baseShadingRate,
-					combiners);
-			}
-
-			void RSSetShadingRateImage(
-				ID3D12Resource* shadingRateImage)
-			{
-				Get().RSSetShadingRateImage(
-					shadingRateImage);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::RSSetShadingRate;
-			//using Base::RSSetShadingRateImage;
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList6>
-	{
-		using base_value_type = ID3D12GraphicsCommandList5;
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void DispatchMesh(
-				UINT ThreadGroupCountX,
-				UINT ThreadGroupCountY,
-				UINT ThreadGroupCountZ)
-			{
-				Get().DispatchMesh(
-					ThreadGroupCountX,
-					ThreadGroupCountY,
-					ThreadGroupCountZ);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::DispatchMesh;
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct CommandListTraits<ID3D12GraphicsCommandList7>
-	{
-		using base_value_type = ID3D12GraphicsCommandList6;
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-		template<class DerivedSelf>
-		class Interface
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			void Barrier(
-				std::span<const D3D12_BARRIER_GROUP> pBarrierGroups)
-			{
-				Get().Barrier(static_cast<UINT32>(pBarrierGroups.size()), pBarrierGroups.data());
-			}
-
-			template<std::size_t Size>
-			void Barrier(
-				std::array<const D3D12_BARRIER_GROUP, Size> pBarrierGroups)
-			{
-				Barrier(std::span{ pBarrierGroups });
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-
-		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
-		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
-			public Interface<DerivedSelf>
-		{
-		private:
-			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-			using derived_self = DerivedSelf;
-			using allocator_value_type = CommandAllocator_t<Type>;
-
-		public:
-			////Alphabetical order
-			//using Base::DispatchMesh;
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-#pragma endregion
-
-#pragma region Direct Traits
-	template<>
-	struct DirectTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
-
-	template<>	
-	struct DirectTraits<ID3D12GraphicsCommandList> 
-	{
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList1>
-	{
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList2>
-	{
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList3>
-	{
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList4>
-	{
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList5>
-	{
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList6>
-	{
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-
-	template<>
-	struct DirectTraits<ID3D12GraphicsCommandList7>
-	{
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-
-		};
-	};
-#pragma endregion
-
-#pragma region Compute Traits
-	template<>
-	struct ComputeTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
 
 	template<>
 	struct ComputeTraits<ID3D12GraphicsCommandList>
 	{
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+		template<class Derived>
+		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_COMPUTE>::Interface<Derived>
 		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		private:
-			using Base::BeginEvent;
-			using Base::BeginQuery;
-			using Base::ClearDepthStencilView;
-			using Base::ClearRenderTargetView;
-			//using Base::ClearState;
-			//using Base::ClearUnorderedAccessViewFloat;
-			//using Base::ClearUnorderedAccessViewUint;
-			//using Base::Close;
-			//using Base::CopyBufferRegion;
-			//using Base::CopyResource;
-			//using Base::CopyTextureRegion;
-			//using Base::CopyTiles;
-			//using Base::DiscardResource;
-			//using Base::Dispatch;
-			using Base::DrawIndexedInstanced;
-			using Base::DrawInstanced;
-			using Base::EndEvent;
-			//using Base::EndQuery;
-			using Base::ExecuteBundle;
-			//using Base::ExecuteIndirect;
-			using Base::IASetIndexBuffer;
-			using Base::IASetPrimitiveTopology;
-			using Base::IASetVertexBuffers;
-			using Base::OMSetBlendFactor;
-			using Base::OMSetRenderTargets;
-			using Base::OMSetStencilRef;
-			//using Base::Reset;
-			//using Base::ResolveQueryData;
-			using Base::ResolveSubresource;
-			//using Base::ResourceBarrier;
-			//using Base::RSSetScissorRects;
-			//using Base::RSSetViewports;
-			//using Base::SetComputeRoot32BitConstant;
-			//using Base::SetComputeRoot32BitConstants;
-			//using Base::SetComputeRootConstantBufferView;
-			//using Base::SetComputeRootDescriptorTable;
-			//using Base::SetComputeRootShaderResourceView;
-			//using Base::SetComputeRootSignature;
-			//using Base::SetComputeRootUnorderedAccessView;
-			//using Base::SetDescriptorHeaps;
-			using Base::SetGraphicsRoot32BitConstant;
-			using Base::SetGraphicsRoot32BitConstants;
-			using Base::SetGraphicsRootConstantBufferView;
-			using Base::SetGraphicsRootDescriptorTable;
-			using Base::SetGraphicsRootShaderResourceView;
-			using Base::SetGraphicsRootSignature;
-			using Base::SetGraphicsRootUnorderedAccessView;
-			using Base::SetMarker;
-			//using Base::SetPipelineState;
-			//using Base::SetPredication;
-			using Base::SOSetTargets;
 		};
 	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList1>
-	{
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-
-		private:
-			//using Base::AtomicCopyBufferUINT;
-			//using Base::AtomicCopyBufferUINT64;
-			using Base::OMSetDepthBounds;
-			using Base::ResolveSubresourceRegion;
-			using Base::SetSamplePositions;
-			using Base::SetViewInstanceMask;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList2>
-	{
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-
-		private:
-			//using Base::WriteBufferImmediate;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList3>
-	{
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-
-		private:
-			//using Base::SetProtectedResourceSession;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList4>
-	{
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		private:
-			using Base::BeginRenderPass;
-			using Base::BuildRaytracingAccelerationStructure;
-			using Base::CopyRaytracingAccelerationStructure;
-			//using Base::DispatchRays;
-			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
-			using Base::EndRenderPass;
-			using Base::ExecuteMetaCommand;
-			using Base::InitializeMetaCommand;
-			//using Base::SetPipelineState1;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList5>
-	{
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		private:
-			using Base::RSSetShadingRate;
-			using Base::RSSetShadingRateImage;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList6>
-	{
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-		//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		private:
-			//using Base::DispatchMesh;
-		};
-	};
-
-	template<>
-	struct ComputeTraits<ID3D12GraphicsCommandList7>
-	{
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-		//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		private:
-			//using Base::Barrier;
-		};
-	};
-#pragma endregion
-
-#pragma region Copy Traits	
-	template<>
-	struct CopyTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
 
 	template<>
 	struct CopyTraits<ID3D12GraphicsCommandList>
 	{
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+		template<class Derived>
+		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_COPY>::Interface<Derived>
 		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		private:
-			using Base::BeginEvent;
-			using Base::BeginQuery;
-			using Base::ClearDepthStencilView;
-			using Base::ClearRenderTargetView;
-			using Base::ClearState;
-			using Base::ClearUnorderedAccessViewFloat;
-			using Base::ClearUnorderedAccessViewUint;
-			//using Base::Close;
-			//using Base::CopyBufferRegion;
-			//using Base::CopyResource;
-			//using Base::CopyTextureRegion;
-			//using Base::CopyTiles;
-			//using Base::DiscardResource;
-			//using Base::Dispatch;
-			using Base::DrawIndexedInstanced;
-			using Base::DrawInstanced;
-			using Base::EndEvent;
-			//using Base::EndQuery;
-			using Base::ExecuteBundle;
-			using Base::ExecuteIndirect;
-			using Base::IASetIndexBuffer;
-			using Base::IASetPrimitiveTopology;
-			using Base::IASetVertexBuffers;
-			using Base::OMSetBlendFactor;
-			using Base::OMSetRenderTargets;
-			using Base::OMSetStencilRef;
-			//using Base::Reset;
-			//using Base::ResolveQueryData;
-			using Base::ResolveSubresource;
-			//using Base::ResourceBarrier;
-			using Base::RSSetScissorRects;
-			using Base::RSSetViewports;
-			using Base::SetComputeRoot32BitConstant;
-			using Base::SetComputeRoot32BitConstants;
-			using Base::SetComputeRootConstantBufferView;
-			using Base::SetComputeRootDescriptorTable;
-			using Base::SetComputeRootShaderResourceView;
-			using Base::SetComputeRootSignature;
-			using Base::SetComputeRootUnorderedAccessView;
-			using Base::SetDescriptorHeaps;
-			using Base::SetGraphicsRoot32BitConstant;
-			using Base::SetGraphicsRoot32BitConstants;
-			using Base::SetGraphicsRootConstantBufferView;
-			using Base::SetGraphicsRootDescriptorTable;
-			using Base::SetGraphicsRootShaderResourceView;
-			using Base::SetGraphicsRootSignature;
-			using Base::SetGraphicsRootUnorderedAccessView;
-			using Base::SetMarker;
-			using Base::SetPipelineState;
-			using Base::SetPredication;
-			using Base::SOSetTargets;
 		};
 	};
-
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList1>
-	{
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		private:
-			//using Base::AtomicCopyBufferUINT;
-			//using Base::AtomicCopyBufferUINT64;
-			using Base::OMSetDepthBounds;
-			using Base::ResolveSubresourceRegion;
-			using Base::SetSamplePositions;
-			using Base::SetViewInstanceMask;
-		};
-	};
-
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList2>
-	{
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		private:
-			//using Base::WriteBufferImmediate;
-		};
-	};
-
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList3>
-	{
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		private:
-			//using Base::SetProtectedResourceSession;
-		};
-	};
-
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList4>
-	{
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-
-		private:
-			using Base::BeginRenderPass;
-			using Base::BuildRaytracingAccelerationStructure;
-			using Base::CopyRaytracingAccelerationStructure;
-			//using Base::DispatchRays;
-			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
-			using Base::EndRenderPass;
-			using Base::ExecuteMetaCommand;
-			using Base::InitializeMetaCommand;
-			//using Base::SetPipelineState1;
-		};
-	};
-
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList5>
-	{
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-		private:
-			using Base::RSSetShadingRate;
-			using Base::RSSetShadingRateImage;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList6>
-	{
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-		private:
-			//using Base::DispatchMesh;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct CopyTraits<ID3D12GraphicsCommandList7>
-	{
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
-		private:
-			//using Base::Barrier;
-		};
-	};
-
-#pragma endregion
-
-#pragma region Bundle Traits
-	template<>
-	struct BundleTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
 
 	template<>
 	struct BundleTraits<ID3D12GraphicsCommandList>
 	{
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+		template<class Derived>
+		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE>::Interface<Derived>
 		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		private:
-			using Base::BeginEvent;
-			using Base::BeginQuery;
-			using Base::ClearDepthStencilView;
-			using Base::ClearRenderTargetView;
-			using Base::ClearState;
-			using Base::ClearUnorderedAccessViewFloat;
-			using Base::ClearUnorderedAccessViewUint;
-			//using Base::Close;
-			using Base::CopyBufferRegion;
-			using Base::CopyResource;
-			using Base::CopyTextureRegion;
-			using Base::CopyTiles;
-			using Base::DiscardResource;
-			//using Base::Dispatch;
-			//using Base::DrawIndexedInstanced;
-			//using Base::DrawInstanced;
-			using Base::EndEvent;
-			using Base::EndQuery;
-			using Base::ExecuteBundle;
-			//using Base::ExecuteIndirect;
-			//using Base::IASetIndexBuffer;
-			//using Base::IASetPrimitiveTopology;
-			//using Base::IASetVertexBuffers;
-			//using Base::OMSetBlendFactor;
-			using Base::OMSetRenderTargets;
-			//using Base::OMSetStencilRef;
-			//using Base::Reset;
-			using Base::ResolveQueryData;
-			using Base::ResolveSubresource;
-			using Base::ResourceBarrier;
-			using Base::RSSetScissorRects;
-			using Base::RSSetViewports;
-			//using Base::SetComputeRoot32BitConstant;
-			//using Base::SetComputeRoot32BitConstants;
-			//using Base::SetComputeRootConstantBufferView;
-			//using Base::SetComputeRootDescriptorTable;
-			//using Base::SetComputeRootShaderResourceView;
-			//using Base::SetComputeRootSignature;
-			//using Base::SetComputeRootUnorderedAccessView;
-			//using Base::SetDescriptorHeaps;
-			//using Base::SetGraphicsRoot32BitConstant;
-			//using Base::SetGraphicsRoot32BitConstants;
-			//using Base::SetGraphicsRootConstantBufferView;
-			//using Base::SetGraphicsRootDescriptorTable;
-			//using Base::SetGraphicsRootShaderResourceView;
-			//using Base::SetGraphicsRootSignature;
-			//using Base::SetGraphicsRootUnorderedAccessView;
-			//using Base::SetMarker;
-			//using Base::SetPipelineState;
-			using Base::SetPredication;
-			using Base::SOSetTargets;
 		};
 	};
-
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList1>
-	{
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		private:
-			using Base::AtomicCopyBufferUINT;
-			using Base::AtomicCopyBufferUINT64;
-			//using Base::OMSetDepthBounds;
-			using Base::ResolveSubresourceRegion;
-			//using Base::SetSamplePositions;
-			//using Base::SetViewInstanceMask;
-		};
-	};
-
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList2>
-	{
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		private:
-			//using Base::WriteBufferImmediate;
-		};
-	};
-
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList3>
-	{
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		private:
-			using Base::SetProtectedResourceSession;
-		};
-	};
-
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList4>
-	{
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-
-		private:
-			using Base::BeginRenderPass;
-			//using Base::BuildRaytracingAccelerationStructure;
-			//using Base::CopyRaytracingAccelerationStructure;
-			//using Base::DispatchRays;
-			//using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
-			using Base::EndRenderPass;
-			//using Base::ExecuteMetaCommand;
-			//using Base::InitializeMetaCommand;
-			//using Base::SetPipelineState1;
-		};
-	};
-
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList5>
-	{
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-		private:
-			//using Base::RSSetShadingRate;
-			//using Base::RSSetShadingRateImage;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList6>
-	{
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-		private:
-			//using Base::DispatchMesh;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct BundleTraits<ID3D12GraphicsCommandList7>
-	{
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
-		private:
-			//using Base::Barrier;
-		};
-	};
-#pragma endregion
-
-#pragma region RenderPass Traits
-	template<>
-	struct RenderPassTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList>
-	{
-		using value_type = ID3D12GraphicsCommandList;
-		using pointer = ID3D12GraphicsCommandList*;
-		using const_pointer = const ID3D12GraphicsCommandList*;
-		using reference = ID3D12GraphicsCommandList&;
-		using const_reference = const ID3D12GraphicsCommandList&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-
-		private:
-			using Base::BeginEvent;
-			//using Base::BeginQuery;
-			using Base::ClearDepthStencilView;
-			using Base::ClearRenderTargetView;
-			using Base::ClearState;
-			using Base::ClearUnorderedAccessViewFloat;
-			using Base::ClearUnorderedAccessViewUint;
-			//using Base::Close;
-			using Base::CopyBufferRegion;
-			using Base::CopyResource;
-			using Base::CopyTextureRegion;
-			using Base::CopyTiles;
-			using Base::DiscardResource;
-			using Base::Dispatch;
-			//using Base::DrawIndexedInstanced;
-			//using Base::DrawInstanced;
-			//using Base::EndEvent;
-			//using Base::EndQuery;
-			//using Base::ExecuteBundle;
-			//using Base::ExecuteIndirect;
-			//using Base::IASetIndexBuffer;
-			//using Base::IASetPrimitiveTopology;
-			//using Base::IASetVertexBuffers;
-			//using Base::OMSetBlendFactor;
-			using Base::OMSetRenderTargets;
-			//using Base::OMSetStencilRef;
-			//using Base::Reset;
-			using Base::ResolveQueryData;
-			using Base::ResolveSubresource;
-			//using Base::ResourceBarrier;
-			//using Base::RSSetScissorRects;
-			//using Base::RSSetViewports;
-			//using Base::SetComputeRoot32BitConstant;
-			//using Base::SetComputeRoot32BitConstants;
-			//using Base::SetComputeRootConstantBufferView;
-			//using Base::SetComputeRootDescriptorTable;
-			//using Base::SetComputeRootShaderResourceView;
-			//using Base::SetComputeRootSignature;
-			//using Base::SetComputeRootUnorderedAccessView;
-			//using Base::SetDescriptorHeaps;
-			//using Base::SetGraphicsRoot32BitConstant;
-			//using Base::SetGraphicsRoot32BitConstants;
-			//using Base::SetGraphicsRootConstantBufferView;
-			//using Base::SetGraphicsRootDescriptorTable;
-			//using Base::SetGraphicsRootShaderResourceView;
-			//using Base::SetGraphicsRootSignature;
-			//using Base::SetGraphicsRootUnorderedAccessView;
-			//using Base::SetMarker;
-			//using Base::SetPipelineState;
-			//using Base::SetPredication;
-			//using Base::SOSetTargets;
-		};
-	};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList1>
-	{
-		using value_type = ID3D12GraphicsCommandList1;
-		using pointer = ID3D12GraphicsCommandList1*;
-		using const_pointer = const ID3D12GraphicsCommandList1*;
-		using reference = ID3D12GraphicsCommandList1&;
-		using const_reference = const ID3D12GraphicsCommandList1&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-
-		private:
-			using Base::AtomicCopyBufferUINT;
-			using Base::AtomicCopyBufferUINT64;
-			//using Base::OMSetDepthBounds;
-			using Base::ResolveSubresourceRegion;
-			//using Base::SetSamplePositions;
-			//using Base::SetViewInstanceMask;
-		};
-	};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList2>
-	{
-		using value_type = ID3D12GraphicsCommandList2;
-		using pointer = ID3D12GraphicsCommandList2*;
-		using const_pointer = const ID3D12GraphicsCommandList2*;
-		using reference = ID3D12GraphicsCommandList2&;
-		using const_reference = const ID3D12GraphicsCommandList2&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-
-		private:
-			//using Base::WriteBufferImmediate;
-		};
-	};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList3>
-	{
-		using value_type = ID3D12GraphicsCommandList3;
-		using pointer = ID3D12GraphicsCommandList3*;
-		using const_pointer = const ID3D12GraphicsCommandList3*;
-		using reference = ID3D12GraphicsCommandList3&;
-		using const_reference = const ID3D12GraphicsCommandList3&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		};
-	};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList4>
-	{
-		using value_type = ID3D12GraphicsCommandList4;
-		using pointer = ID3D12GraphicsCommandList4*;
-		using const_pointer = const ID3D12GraphicsCommandList4*;
-		using reference = ID3D12GraphicsCommandList4&;
-		using const_reference = const ID3D12GraphicsCommandList4&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-
-		private:
-			using Base::BeginRenderPass;
-			using Base::BuildRaytracingAccelerationStructure;
-			using Base::CopyRaytracingAccelerationStructure;
-			using Base::DispatchRays;
-			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
-			//using Base::EndRenderPass;
-			using Base::ExecuteMetaCommand;
-			using Base::InitializeMetaCommand;
-			using Base::SetPipelineState1;
-		};
-	};
-
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList5>
-	{
-		using value_type = ID3D12GraphicsCommandList5;
-		using pointer = ID3D12GraphicsCommandList5*;
-		using const_pointer = const ID3D12GraphicsCommandList5*;
-		using reference = ID3D12GraphicsCommandList5&;
-		using const_reference = const ID3D12GraphicsCommandList5&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		private:
-			//using Base::RSSetShadingRate;
-			//using Base::RSSetShadingRateImage;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList6>
-	{
-		using value_type = ID3D12GraphicsCommandList6;
-		using pointer = ID3D12GraphicsCommandList6*;
-		using const_pointer = const ID3D12GraphicsCommandList6*;
-		using reference = ID3D12GraphicsCommandList6&;
-		using const_reference = const ID3D12GraphicsCommandList6&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		private:
-			//using Base::DispatchMesh;
-		};
-	};
-
-	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
-	template<>
-	struct RenderPassTraits<ID3D12GraphicsCommandList7>
-	{
-		using value_type = ID3D12GraphicsCommandList7;
-		using pointer = ID3D12GraphicsCommandList7*;
-		using const_pointer = const ID3D12GraphicsCommandList7*;
-		using reference = ID3D12GraphicsCommandList7&;
-		using const_reference = const ID3D12GraphicsCommandList7&;
-
-		template<class DerivedSelf>
-		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
-		{
-			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		private:
-			//using Base::Barrier;
-		};
-	};
-#pragma endregion
-
-	template<class DerivedSelf>
-	void CommandListTraits<ID3D12GraphicsCommandList>::Interface<DerivedSelf>::ExecuteBundle(CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> pCommandList)
-	{
-		Get().ExecuteBundle(pCommandList.Get());
-	}
-
-	template<class DerivedSelf>
-	RenderPass_t<ID3D12GraphicsCommandList4> CommandListTraits<ID3D12GraphicsCommandList4>::Interface<DerivedSelf>::BeginRenderPass(std::span<const D3D12_RENDER_PASS_RENDER_TARGET_DESC> renderTargets, const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* pDepthStencil, D3D12_RENDER_PASS_FLAGS Flags)
-	{
-		Get().BeginRenderPass(static_cast<UINT>(renderTargets.size()), renderTargets.data(), pDepthStencil, Flags);
-		return RenderPass_t<ID3D12GraphicsCommandList4>(&Get());
-	}
 }
 
-#pragma warning(pop)
+
+//namespace TypedD3D::D3D12
+//{
+//	//Used for meta-programming internally
+//	template<std::derived_from<ID3D12CommandList> Ty, template<class> class Trait>
+//	using GenericCommandList = IUnknownWrapper<Ty, Trait>;
+//
+//	//Used for public APIs
+//	export template<std::derived_from<ID3D12CommandList> Ty, D3D12_COMMAND_LIST_TYPE Type>
+//	using CommandList_t = GenericCommandList<Ty, CommandListTypeToTrait<Type>::template type>;
+//	template<std::derived_from<ID3D12CommandList> Ty>
+//	using RenderPass_t = GenericCommandList<Ty, RenderPassTraits>;
+//	namespace Aliases
+//	{
+//		template<class ListTy>
+//		using Direct_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//
+//		export using D3D12DirectCommandListBase = Direct_t<ID3D12CommandList>;
+//		export using D3D12DirectCommandList = Direct_t<ID3D12GraphicsCommandList>;
+//		export using D3D12DirectCommandList1 = Direct_t<ID3D12GraphicsCommandList1>;
+//		export using D3D12DirectCommandList2 = Direct_t<ID3D12GraphicsCommandList2>;
+//		export using D3D12DirectCommandList3 = Direct_t<ID3D12GraphicsCommandList3>;
+//		export using D3D12DirectCommandList4 = Direct_t<ID3D12GraphicsCommandList4>;
+//		export using D3D12DirectCommandList5 = Direct_t<ID3D12GraphicsCommandList5>;
+//		export using D3D12DirectCommandList6 = Direct_t<ID3D12GraphicsCommandList6>;
+//		export using D3D12DirectCommandList7 = Direct_t<ID3D12GraphicsCommandList7>;
+//
+//		template<class ListTy>
+//		using Bundle_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		export using D3D12BundleCommandListBase = Bundle_t<ID3D12CommandList>;
+//		export using D3D12BundleCommandList = Bundle_t<ID3D12GraphicsCommandList>;
+//		export using D3D12BundleCommandList1 = Bundle_t<ID3D12GraphicsCommandList1>;
+//		export using D3D12BundleCommandList2 = Bundle_t<ID3D12GraphicsCommandList2>;
+//		export using D3D12BundleCommandList3 = Bundle_t<ID3D12GraphicsCommandList3>;
+//		export using D3D12BundleCommandList4 = Bundle_t<ID3D12GraphicsCommandList4>;
+//		export using D3D12BundleCommandList5 = Bundle_t<ID3D12GraphicsCommandList5>;
+//		export using D3D12BundleCommandList6 = Bundle_t<ID3D12GraphicsCommandList6>;
+//		export using D3D12BundleCommandList7 = Bundle_t<ID3D12GraphicsCommandList7>;
+//
+//		template<class ListTy>
+//		using Compute_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//
+//		export using D3D12ComputeCommandListBase = Compute_t<ID3D12CommandList>;
+//		export using D3D12ComputeCommandList = Compute_t<ID3D12GraphicsCommandList>;
+//		export using D3D12ComputeCommandList1 = Compute_t<ID3D12GraphicsCommandList1>;
+//		export using D3D12ComputeCommandList2 = Compute_t<ID3D12GraphicsCommandList2>;
+//		export using D3D12ComputeCommandList3 = Compute_t<ID3D12GraphicsCommandList3>;
+//		export using D3D12ComputeCommandList4 = Compute_t<ID3D12GraphicsCommandList4>;
+//		export using D3D12ComputeCommandList5 = Compute_t<ID3D12GraphicsCommandList5>;
+//		export using D3D12ComputeCommandList6 = Compute_t<ID3D12GraphicsCommandList6>;
+//		export using D3D12ComputeCommandList7 = Compute_t<ID3D12GraphicsCommandList7>;
+//
+//		export template<class ListTy>
+//		using Copy_t = CommandList_t<ListTy, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		export using D3D12CopyCommandListBase = Copy_t<ID3D12CommandList>;
+//		export using D3D12CopyCommandList = Copy_t<ID3D12GraphicsCommandList>;
+//		export using D3D12CopyCommandList1 = Copy_t<ID3D12GraphicsCommandList1>;
+//		export using D3D12CopyCommandList2 = Copy_t<ID3D12GraphicsCommandList2>;
+//		export using D3D12CopyCommandList3 = Copy_t<ID3D12GraphicsCommandList3>;
+//		export using D3D12CopyCommandList4 = Copy_t<ID3D12GraphicsCommandList4>;
+//		export using D3D12CopyCommandList5 = Copy_t<ID3D12GraphicsCommandList5>;
+//		export using D3D12CopyCommandList6 = Copy_t<ID3D12GraphicsCommandList6>;
+//		export using D3D12CopyCommandList7 = Copy_t<ID3D12GraphicsCommandList7>;
+//
+//
+//		export using RenderPass4 = RenderPass_t<ID3D12GraphicsCommandList4>;
+//		export using RenderPass5 = RenderPass_t<ID3D12GraphicsCommandList5>;
+//		export using RenderPass6 = RenderPass_t<ID3D12GraphicsCommandList6>;
+//		export using RenderPass7 = RenderPass_t<ID3D12GraphicsCommandList7>;
+//	}
+//
+//#pragma region Untagged Traits
+//	template<class Ty>
+//	struct CommandListTraits;
+//
+//	template<>
+//	struct CommandListTraits<ID3D12CommandList>
+//	{
+//		using value_type = ID3D12CommandList;
+//		using pointer = ID3D12CommandList*;
+//		using const_pointer = const ID3D12CommandList*;
+//		using reference = ID3D12CommandList&;
+//		using const_reference = const ID3D12CommandList&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceChildTraits::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			D3D12_COMMAND_LIST_TYPE GetType() { return Self().GetType(); }
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList>
+//	{
+//		using base_value_type = ID3D12CommandList;
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//
+//			void BeginEvent(
+//				UINT Metadata,
+//				const void* pData,
+//				UINT Size)
+//			{
+//				Self().BeginEvent(Metadata, pData, Size);
+//			}
+//
+//			void BeginQuery(
+//				ID3D12QueryHeap& pQueryHeap,
+//				D3D12_QUERY_TYPE Type,
+//				UINT Index)
+//			{
+//				Self().BeginQuery(&pQueryHeap, Type, Index);
+//			}
+//
+//			void ClearDepthStencilView(
+//				DSV<::D3D12_CPU_DESCRIPTOR_HANDLE> DepthStencilView,
+//				D3D12_CLEAR_FLAGS ClearFlags,
+//				FLOAT Depth,
+//				UINT8 Stencil,
+//				std::span<const D3D12_RECT> rects)
+//			{
+//				Self().ClearDepthStencilView(DepthStencilView.Get(), ClearFlags, Depth, Stencil, static_cast<UINT>(rects.size()), rects.data());
+//			}
+//
+//			void ClearRenderTargetView(
+//				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+//				std::span<const float, 4> colorRGBA,
+//				std::span<const D3D12_RECT> rects)
+//			{
+//				Self().ClearRenderTargetView(RenderTargetView.Get(), colorRGBA.data(), static_cast<UINT>(rects.size()), rects.data());
+//			}
+//
+//			void ClearRenderTargetView(
+//				RTV<::D3D12_CPU_DESCRIPTOR_HANDLE> RenderTargetView,
+//				std::array<const float, 4> colorRGBA)
+//			{
+//				ClearRenderTargetView(RenderTargetView.Get(), std::span<const float, 4>{ colorRGBA }, std::span<const D3D12_RECT>{});
+//			}
+//
+//			void ClearState(ID3D12PipelineState* pPipelineState)
+//			{
+//				Self().ClearState(pPipelineState);
+//			}
+//
+//			void ClearUnorderedAccessViewFloat(
+//				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+//				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+//				ID3D12Resource& pResource,
+//				std::span<const float, 4> values,
+//				std::span<const D3D12_RECT> rects)
+//			{
+//				Self().ClearUnorderedAccessViewFloat(ViewGPUHandleInCurrentHeap, ViewCPUHandle, &pResource, values.data(), static_cast<UINT>(rects.size()), rects.data());
+//			}
+//
+//			void ClearUnorderedAccessViewUint(
+//				CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE> ViewGPUHandleInCurrentHeap,
+//				CBV_SRV_UAV<::D3D12_CPU_DESCRIPTOR_HANDLE> ViewCPUHandle,
+//				ID3D12Resource& pResource,
+//				std::span<const UINT, 4> values,
+//				std::span<const D3D12_RECT> rects)
+//			{
+//				Self().ClearUnorderedAccessViewUint(ViewGPUHandleInCurrentHeap, ViewCPUHandle, &pResource, values.data(), static_cast<UINT>(rects.size()), rects.data());
+//			}
+//
+//			HRESULT Close()
+//			{
+//				return Self().Close();
+//			}
+//
+//			void CopyBufferRegion(
+//				ID3D12Resource& pDstBuffer,
+//				UINT64 DstOffset,
+//				ID3D12Resource& pSrcBuffer,
+//				UINT64 SrcOffset,
+//				UINT64 NumBytes)
+//			{
+//				Self().CopyBufferRegion(
+//					&pDstBuffer,
+//					DstOffset,
+//					&pSrcBuffer,
+//					SrcOffset,
+//					NumBytes);
+//			}
+//
+//			void CopyResource(
+//				ID3D12Resource& pDstResource,
+//				ID3D12Resource& pSrcResource)
+//			{
+//				Self().CopyResource(&pDstResource, &pSrcResource);
+//			}
+//
+//			void CopyTextureRegion(
+//				const D3D12_TEXTURE_COPY_LOCATION& pDst,
+//				UINT DstX,
+//				UINT DstY,
+//				UINT DstZ,
+//				const D3D12_TEXTURE_COPY_LOCATION& pSrc,
+//				const D3D12_BOX* pSrcBox)
+//			{
+//				Self().CopyTextureRegion(
+//					&pDst,
+//					DstX,
+//					DstY,
+//					DstZ,
+//					&pSrc,
+//					pSrcBox);
+//			}
+//
+//			void CopyTiles(
+//				ID3D12Resource& pTiledResource,
+//				const D3D12_TILED_RESOURCE_COORDINATE& pTileRegionStartCoordinate,
+//				const D3D12_TILE_REGION_SIZE& pTileRegionSize,
+//				ID3D12Resource& pBuffer,
+//				UINT64 BufferStartOffsetInBytes,
+//				D3D12_TILE_COPY_FLAGS Flags)
+//			{
+//				Self().CopyTiles(
+//					&pTiledResource,
+//					&pTileRegionStartCoordinate,
+//					&pTileRegionSize,
+//					&pBuffer,
+//					BufferStartOffsetInBytes,
+//					Flags);
+//			}
+//
+//			void DiscardResource(
+//				ID3D12Resource& pResource,
+//				const D3D12_DISCARD_REGION* pRegion)
+//			{
+//				Self().DiscardResource(&pResource, pRegion);
+//			}
+//
+//			void Dispatch(
+//				UINT ThreadGroupCountX,
+//				UINT ThreadGroupCountY,
+//				UINT ThreadGroupCountZ)
+//			{
+//				Self().Dispatch(
+//					ThreadGroupCountX,
+//					ThreadGroupCountY,
+//					ThreadGroupCountZ);
+//			}
+//
+//			void DrawIndexedInstanced(
+//				UINT IndexCountPerInstance,
+//				UINT InstanceCount,
+//				UINT StartIndexLocation,
+//				INT BaseVertexLocation,
+//				UINT StartInstanceLocation)
+//			{
+//				Self().DrawIndexedInstanced(
+//					IndexCountPerInstance,
+//					InstanceCount,
+//					StartIndexLocation,
+//					BaseVertexLocation,
+//					StartInstanceLocation);
+//			}
+//
+//			void DrawInstanced(
+//				UINT VertexCountPerInstance,
+//				UINT InstanceCount,
+//				UINT StartVertexLocation,
+//				UINT StartInstanceLocation)
+//			{
+//				Self().DrawInstanced(VertexCountPerInstance, InstanceCount, StartVertexLocation, StartInstanceLocation);
+//			}
+//
+//			void EndEvent()
+//			{
+//				Self().EndEvent();
+//			}
+//
+//			void EndQuery(
+//				ID3D12QueryHeap& pQueryHeap,
+//				D3D12_QUERY_TYPE Type,
+//				UINT Index)
+//			{
+//				Self().EndQuery(&pQueryHeap, Type, Index);
+//			}
+//
+//			void ExecuteBundle(CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> pCommandList);
+//
+//			void ExecuteIndirect(
+//				ID3D12CommandSignature& commandSignature,
+//				UINT maxCommandCount,
+//				ID3D12Resource& argumentBuffer,
+//				UINT64 argumentBufferOffset,
+//				ID3D12Resource* optCountBuffer = nullptr,
+//				UINT64 optCountBufferOffset = 0)
+//			{
+//				Self().ExecuteIndirect(&commandSignature, maxCommandCount, &argumentBuffer, argumentBufferOffset, optCountBuffer, optCountBufferOffset);
+//			}
+//
+//			void IASetIndexBuffer(
+//				const D3D12_INDEX_BUFFER_VIEW* pView)
+//			{
+//				Self().IASetIndexBuffer(pView);
+//			}
+//
+//			void IASetPrimitiveTopology(
+//				D3D12_PRIMITIVE_TOPOLOGY PrimitiveTopology)
+//			{
+//				Self().IASetPrimitiveTopology(PrimitiveTopology);
+//			}
+//
+//			void IASetVertexBuffers(
+//				UINT StartSlot,
+//				std::span<const D3D12_VERTEX_BUFFER_VIEW> views)
+//			{
+//				Self().IASetVertexBuffers(StartSlot, static_cast<UINT>(views.size()), views.data());
+//			}
+//
+//			void OMSetBlendFactor(std::span<const float, 4> BlendFactor)
+//			{
+//				Self().OMSetBlendFactor(BlendFactor.data());
+//			}
+//
+//			void OMSetRenderTargets(
+//				std::span<const RTV<::D3D12_CPU_DESCRIPTOR_HANDLE>> pRenderTargetDescriptors,
+//				BOOL RTsSingleHandleToDescriptorRange,
+//				const DSV<::D3D12_CPU_DESCRIPTOR_HANDLE>* pDepthStencilDescriptor)
+//			{
+//				std::unique_ptr<::D3D12_CPU_DESCRIPTOR_HANDLE[]> renderTargets = std::make_unique<::D3D12_CPU_DESCRIPTOR_HANDLE[]>(pRenderTargetDescriptors.size());
+//
+//				for(size_t i = 0; i < pRenderTargetDescriptors.size(); i++)
+//				{
+//					renderTargets[i] = pRenderTargetDescriptors[i].Get();
+//				}
+//
+//				const ::D3D12_CPU_DESCRIPTOR_HANDLE* depthStencil = (pDepthStencilDescriptor) ? &pDepthStencilDescriptor->Get() : nullptr;
+//
+//				Self().OMSetRenderTargets(static_cast<UINT>(pRenderTargetDescriptors.size()), renderTargets.get(), RTsSingleHandleToDescriptorRange, depthStencil);
+//			}
+//
+//			void OMSetStencilRef(UINT StencilRef)
+//			{
+//				Self().OMSetStencilRef(StencilRef);
+//			}
+//
+//			void ResolveQueryData(
+//				ID3D12QueryHeap& pQueryHeap,
+//				D3D12_QUERY_TYPE Type,
+//				UINT StartIndex,
+//				UINT NumQueries,
+//				ID3D12Resource& pDestinationBuffer,
+//				UINT64 AlignedDestinationBufferOffset)
+//			{
+//				Self().ResolveQueryData(&pQueryHeap, Type, StartIndex, NumQueries, &pDestinationBuffer, AlignedDestinationBufferOffset);
+//			}
+//
+//			void ResolveSubresource(
+//				ID3D12Resource& pDstResource,
+//				UINT DstSubresource,
+//				ID3D12Resource& pSrcResource,
+//				UINT SrcSubresource,
+//				DXGI_FORMAT Format)
+//			{
+//				Self().ResolveSubresource(
+//					&pDstResource,
+//					DstSubresource,
+//					&pSrcResource,
+//					SrcSubresource,
+//					Format);
+//			}
+//
+//			void ResourceBarrier(std::span<const D3D12_RESOURCE_BARRIER> Barriers)
+//			{
+//				Self().ResourceBarrier(static_cast<UINT>(Barriers.size()), Barriers.data());
+//			}
+//
+//			void RSSetScissorRects(
+//				std::span<D3D12_RECT> rects)
+//			{
+//				Self().RSSetScissorRects(static_cast<UINT>(rects.size()), rects.data());
+//			}
+//
+//			void RSSetViewports(
+//				std::span<D3D12_VIEWPORT> viewports)
+//			{
+//				Self().RSSetViewports(static_cast<UINT>(viewports.size()), viewports.data());
+//			}
+//
+//			void SetComputeRoot32BitConstant(UINT RootParameterIndex, UINT SrcData, UINT DestOffsetIn32BitValues)
+//			{
+//				Self().SetComputeRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
+//			}
+//
+//			void SetComputeRoot32BitConstants(
+//				UINT RootParameterIndex,
+//				UINT Num32BitValuesToSet,
+//				const void* pSrcData,
+//				UINT DestOffsetIn32BitValues)
+//			{
+//				Self().SetComputeRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
+//			}
+//
+//			void SetComputeRootConstantBufferView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetComputeRootConstantBufferView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetComputeRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+//			{
+//				Self().SetComputeRootDescriptorTable(RootParameterIndex, BaseDescriptor);
+//			}
+//
+//			void SetComputeRootShaderResourceView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetComputeRootShaderResourceView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetComputeRootSignature(ID3D12RootSignature* pRootSignature)
+//			{
+//				Self().SetComputeRootSignature(pRootSignature);
+//			}
+//
+//			void SetComputeRootUnorderedAccessView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetComputeRootUnorderedAccessView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetDescriptorHeaps(ShaderVisible<CBV_SRV_UAV<ID3D12DescriptorHeap>> descriptorHeap)
+//			{
+//				ID3D12DescriptorHeap* heaps[] = { descriptorHeap.Get() };
+//				Self().SetDescriptorHeaps(1, heaps);
+//			}
+//
+//			void SetDescriptorHeaps(ShaderVisible<Sampler<ID3D12DescriptorHeap>> descriptorHeap)
+//			{
+//				ID3D12DescriptorHeap* heaps[] = { descriptorHeap.Get() };
+//				Self().SetDescriptorHeaps(1, heaps);
+//			}
+//
+//			void SetDescriptorHeaps(ShaderVisible<CBV_SRV_UAV<ID3D12DescriptorHeap>> cbv_srv_uavHeap, ShaderVisible<Sampler<ID3D12DescriptorHeap>> samplerHeap)
+//			{
+//				ID3D12DescriptorHeap* heaps[] = { cbv_srv_uavHeap.Get(), samplerHeap.Get() };
+//				Self().SetDescriptorHeaps(2, heaps);
+//			}
+//
+//			void SetGraphicsRoot32BitConstant(UINT RootParameterIndex, UINT SrcData, UINT DestOffsetIn32BitValues)
+//			{
+//				Self().SetGraphicsRoot32BitConstant(RootParameterIndex, SrcData, DestOffsetIn32BitValues);
+//			}
+//
+//			void SetGraphicsRoot32BitConstants(
+//				UINT RootParameterIndex,
+//				UINT Num32BitValuesToSet,
+//				const void* pSrcData,
+//				UINT DestOffsetIn32BitValues)
+//			{
+//				Self().SetGraphicsRoot32BitConstants(RootParameterIndex, Num32BitValuesToSet, pSrcData, DestOffsetIn32BitValues);
+//			}
+//
+//			void SetGraphicsRootConstantBufferView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetGraphicsRootConstantBufferView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetGraphicsRootDescriptorTable(UINT RootParameterIndex, ::D3D12_GPU_DESCRIPTOR_HANDLE BaseDescriptor)
+//			{
+//				Self().SetGraphicsRootDescriptorTable(RootParameterIndex, BaseDescriptor);
+//			}
+//
+//			void SetGraphicsRootShaderResourceView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetGraphicsRootShaderResourceView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetGraphicsRootSignature(ID3D12RootSignature* pRootSignature)
+//			{
+//				Self().SetGraphicsRootSignature(pRootSignature);
+//			}
+//
+//			void SetGraphicsRootUnorderedAccessView(
+//				UINT RootParameterIndex,
+//				D3D12_GPU_VIRTUAL_ADDRESS BufferLocation)
+//			{
+//				Self().SetGraphicsRootUnorderedAccessView(RootParameterIndex, BufferLocation);
+//			}
+//
+//			void SetMarker(
+//				UINT Metadata,
+//				const void* pData,
+//				UINT Size)
+//			{
+//				Self().SetMarker(Metadata, pData, Size);
+//			}
+//
+//			void SetPipelineState(ID3D12PipelineState* pPipelineState)
+//			{
+//				Self().SetPipelineState(pPipelineState);
+//			}
+//
+//			void SetPredication(
+//				ID3D12Resource* pBuffer,
+//				UINT64 AlignedBufferOffset,
+//				D3D12_PREDICATION_OP Operation)
+//			{
+//				Self().SetPredication(pBuffer, AlignedBufferOffset, Operation);
+//			}
+//
+//			void SOSetTargets(
+//				UINT StartSlot,
+//				std::span<const D3D12_STREAM_OUTPUT_BUFFER_VIEW> views)
+//			{
+//				Self().SOSetTargets(StartSlot, static_cast<UINT>(views.size()), views.data());
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			HRESULT Reset(
+//				allocator_value_type pAllocator,
+//				ID3D12PipelineState* pInitialState)
+//			{
+//				return Self().Reset(pAllocator.Get(), pInitialState);
+//			}
+//
+//		  ////Alphabetical order
+//		  //using Base::BeginEvent;
+//		  //using Base::BeginQuery;
+//		  //using Base::ClearDepthStencilView;
+//		  //using Base::ClearRenderTargetView;
+//		  //using Base::ClearState;
+//		  //using Base::ClearUnorderedAccessViewFloat;
+//		  //using Base::ClearUnorderedAccessViewUint;
+//		  //using Base::Close;
+//		  //using Base::CopyBufferRegion;
+//		  //using Base::CopyResource;
+//		  //using Base::CopyTextureRegion;
+//		  //using Base::CopyTiles;
+//		  //using Base::DiscardResource;
+//		  //using Base::Dispatch;
+//		  //using Base::DrawIndexedInstanced;
+//		  //using Base::DrawInstanced;
+//		  //using Base::EndEvent;
+//		  //using Base::EndQuery;
+//		  //using Base::ExecuteBundle;
+//		  //using Base::ExecuteIndirect;
+//		  //using Base::IASetIndexBuffer;
+//		  //using Base::IASetPrimitiveTopology;
+//		  //using Base::IASetVertexBuffers;
+//		  //using Base::OMSetBlendFactor;
+//		  //using Base::OMSetRenderTargets;
+//		  //using Base::OMSetStencilRef;
+//		  //using Base::Reset;
+//		  //using Base::ResolveQueryData;
+//		  //using Base::ResolveSubresource;
+//		  //using Base::ResourceBarrier;
+//		  //using Base::RSSetScissorRects;
+//		  //using Base::RSSetViewports;
+//		  //using Base::SetComputeRoot32BitConstant;
+//		  //using Base::SetComputeRoot32BitConstants;
+//		  //using Base::SetComputeRootConstantBufferView;
+//		  //using Base::SetComputeRootDescriptorTable;
+//		  //using Base::SetComputeRootShaderResourceView;
+//		  //using Base::SetComputeRootSignature;
+//		  //using Base::SetComputeRootUnorderedAccessView;
+//		  //using Base::SetDescriptorHeaps;
+//		  //using Base::SetGraphicsRoot32BitConstant;
+//		  //using Base::SetGraphicsRoot32BitConstants;
+//		  //using Base::SetGraphicsRootConstantBufferView;
+//		  //using Base::SetGraphicsRootDescriptorTable;
+//		  //using Base::SetGraphicsRootShaderResourceView;
+//		  //using Base::SetGraphicsRootSignature;
+//		  //using Base::SetGraphicsRootUnorderedAccessView;
+//		  //using Base::SetMarker;
+//		  //using Base::SetPipelineState;
+//		  //using Base::SetPredication;
+//		  //using Base::SOSetTargets;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList;
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void AtomicCopyBufferUINT(
+//				ID3D12Resource& pDstBuffer,
+//				UINT64 DstOffset,
+//				ID3D12Resource& pSrcBuffer,
+//				UINT64 SrcOffset,
+//				UINT Dependencies,
+//				ID3D12Resource* const* ppDependentResources,
+//				const D3D12_SUBRESOURCE_RANGE_UINT64* pDependentSubresourceRanges)
+//			{
+//				Self().AtomicCopyBufferUINT(
+//					&pDstBuffer,
+//					DstOffset,
+//					&pSrcBuffer,
+//					SrcOffset,
+//					Dependencies,
+//					ppDependentResources,
+//					pDependentSubresourceRanges);
+//			}
+//
+//			void AtomicCopyBufferUINT64(
+//				ID3D12Resource& pDstBuffer,
+//				UINT64 DstOffset,
+//				ID3D12Resource& pSrcBuffer,
+//				UINT64 SrcOffset,
+//				UINT Dependencies,
+//				ID3D12Resource* const* ppDependentResources,
+//				const D3D12_SUBRESOURCE_RANGE_UINT64* pDependentSubresourceRanges)
+//			{
+//				Self().AtomicCopyBufferUINT64(
+//					&pDstBuffer,
+//					DstOffset,
+//					&pSrcBuffer,
+//					SrcOffset,
+//					Dependencies,
+//					ppDependentResources,
+//					pDependentSubresourceRanges);
+//			}
+//
+//			void OMSetDepthBounds(
+//				FLOAT Min,
+//				FLOAT Max)
+//			{
+//				Self().OMSetDepthBounds(Min, Max);
+//			}
+//
+//			void ResolveSubresourceRegion(
+//				ID3D12Resource& pDstResource,
+//				UINT DstSubresource,
+//				UINT DstX,
+//				UINT DstY,
+//				ID3D12Resource& pSrcResource,
+//				UINT SrcSubresource,
+//				D3D12_RECT* pSrcRect,
+//				DXGI_FORMAT Format,
+//				D3D12_RESOLVE_MODE ResolveMode)
+//			{
+//				Self().ResolveSubresourceRegion(
+//					&pDstResource,
+//					DstSubresource,
+//					DstX,
+//					DstY,
+//					&pSrcResource,
+//					SrcSubresource,
+//					pSrcRect,
+//					Format,
+//					ResolveMode
+//				);
+//			}
+//
+//			void SetSamplePositions(
+//				UINT NumSamplesPerPixel,
+//				UINT NumPixels,
+//				D3D12_SAMPLE_POSITION* pSamplePositions)
+//			{
+//				Self().SetSamplePositions(
+//					NumSamplesPerPixel,
+//					NumPixels,
+//					pSamplePositions);
+//			}
+//
+//			void SetViewInstanceMask(
+//				UINT Mask)
+//			{
+//				Self().SetViewInstanceMask(Mask);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::AtomicCopyBufferUINT;
+//			//using Base::AtomicCopyBufferUINT64;
+//			//using Base::OMSetDepthBounds;
+//			//using Base::ResolveSubresourceRegion;
+//			//using Base::SetSamplePositions;
+//			//using Base::SetViewInstanceMask;     
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	export class WriteBufferImmediateData
+//	{
+//		UINT count;
+//		D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* parameters;
+//		D3D12_WRITEBUFFERIMMEDIATE_MODE* modes = nullptr;
+//
+//	public:
+//		template<UINT Count>
+//		WriteBufferImmediateData(std::span<D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, Count> parameters, std::optional<std::span<D3D12_WRITEBUFFERIMMEDIATE_MODE, Count>> modes) :
+//			count{ Count },
+//			parameters{ parameters.data() },
+//			modes{ modes.value_or({}).data() }
+//		{
+//
+//		}
+//
+//		WriteBufferImmediateData(UINT count, D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* parameters, D3D12_WRITEBUFFERIMMEDIATE_MODE* optionalModes) :
+//			count{ count },
+//			parameters{ parameters },
+//			modes{ optionalModes }
+//		{
+//
+//		}
+//
+//	public:
+//		UINT GetCount() const noexcept { return count; }
+//		const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER* GetParameters() const noexcept { return parameters; }
+//		const D3D12_WRITEBUFFERIMMEDIATE_MODE* GetModes() const noexcept { return modes; }
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList1;
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void WriteBufferImmediate(WriteBufferImmediateData data)
+//			{
+//				Self().WriteBufferImmediate(data.GetCount(), data.GetParameters(), data.GetModes());
+//			}
+//
+//			void WriteBufferImmediate(D3D12_WRITEBUFFERIMMEDIATE_PARAMETER parameters, std::optional<D3D12_WRITEBUFFERIMMEDIATE_MODE> modes)
+//			{
+//				Self().WriteBufferImmediate({ 1, &parameters, modes ? std::optional{ std::span{1, &modes.value()} } : std::optional{ std::nullopt } });
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::WriteBufferImmediate;
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList2;
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void SetProtectedResourceSession(
+//				ID3D12ProtectedResourceSession* pProtectedResourceSession)
+//			{
+//				Self().SetProtectedResourceSession(pProtectedResourceSession);
+//			}
+//
+//			//In code order                                                          //Alphabetical order
+//			//using Base::SetProtectedResourceSession;                               using Base::SetProtectedResourceSession;
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			//In code order                                                          //Alphabetical order
+//			//using Base::SetProtectedResourceSession;                               using Base::SetProtectedResourceSession;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList3;
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			RenderPass_t<ID3D12GraphicsCommandList4> BeginRenderPass(
+//				std::span<const D3D12_RENDER_PASS_RENDER_TARGET_DESC> renderTargets,
+//				const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* pDepthStencil,
+//				D3D12_RENDER_PASS_FLAGS Flags);
+//
+//			void BuildRaytracingAccelerationStructure(
+//				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC& pDesc,
+//				std::span<const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC> pPostbuildInfoDescs)
+//			{
+//				Self().BuildRaytracingAccelerationStructure(
+//					&pDesc,
+//					static_cast<UINT>(pPostbuildInfoDescs.size()),
+//					pPostbuildInfoDescs.data());
+//			}
+//
+//			void CopyRaytracingAccelerationStructure(
+//				D3D12_GPU_VIRTUAL_ADDRESS DestAccelerationStructureData,
+//				D3D12_GPU_VIRTUAL_ADDRESS SourceAccelerationStructureData,
+//				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_COPY_MODE Mode)
+//			{
+//				Self().CopyRaytracingAccelerationStructure(
+//					DestAccelerationStructureData,
+//					SourceAccelerationStructureData,
+//					Mode);
+//			}
+//
+//			void DispatchRays(
+//				const D3D12_DISPATCH_RAYS_DESC& pDesc)
+//			{
+//				Self().DispatchRays(&pDesc);
+//			}
+//
+//			void EmitRaytracingAccelerationStructurePostbuildInfo(
+//				const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC& pDesc,
+//				std::span<const D3D12_GPU_VIRTUAL_ADDRESS> pSourceAccelerationStructureData)
+//			{
+//				Self().EmitRaytracingAccelerationStructurePostbuildInfo(
+//					&pDesc,
+//					static_cast<UINT>(pSourceAccelerationStructureData.size()),
+//					pSourceAccelerationStructureData.data());
+//			}
+//
+//			void EndRenderPass()
+//			{
+//				Self().EndRenderPass();
+//			}
+//
+//			void InitializeMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand,
+//				const void* pInitializationParametersData,
+//				SIZE_T InitializationParametersDataSizeInBytes)
+//			{
+//				Self().InitializeMetaCommand(&pMetaCommand, pInitializationParametersData, InitializationParametersDataSizeInBytes);
+//			}
+//
+//			void ExecuteMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand,
+//				const void* pExecutionParametersData,
+//				SIZE_T ExecutionParametersDataSizeInBytes)
+//			{
+//				Self().ExecuteMetaCommand(&pMetaCommand, pExecutionParametersData, ExecutionParametersDataSizeInBytes);
+//			}
+//
+//			void ExecuteMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand)
+//			{
+//				ExecuteMetaCommand(pMetaCommand, nullptr, 0);
+//			}
+//
+//			template<class T>
+//			void ExecuteMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand,
+//				const T& pExecutionParametersData)
+//			{
+//				ExecuteMetaCommand(pMetaCommand, &pExecutionParametersData, sizeof(T));
+//			}
+//
+//			void InitializeMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand)
+//			{
+//				InitializeMetaCommand(pMetaCommand, nullptr, 0);
+//			}
+//
+//			template<class T>
+//			void InitializeMetaCommand(
+//				ID3D12MetaCommand& pMetaCommand,
+//				const T& pInitializationParametersData)
+//			{
+//				InitializeMetaCommand(pMetaCommand, &pInitializationParametersData, sizeof(T));
+//			}
+//
+//			void SetPipelineState1(
+//				ID3D12StateObject* pStateObject)
+//			{
+//				Self().SetPipelineState1(pStateObject);
+//			}
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::BeginRenderPass;
+//			//using Base::BuildRaytracingAccelerationStructure;
+//			//using Base::CopyRaytracingAccelerationStructure;
+//			//using Base::DispatchRays;
+//			//using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
+//			//using Base::EndRenderPass;
+//			//using Base::ExecuteMetaCommand;
+//			//using Base::InitializeMetaCommand;
+//			//using Base::SetPipelineState1;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList4;
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void RSSetShadingRate(
+//				D3D12_SHADING_RATE baseShadingRate,
+//				const D3D12_SHADING_RATE_COMBINER* combiners)
+//			{
+//				Self().RSSetShadingRate(
+//					baseShadingRate,
+//					combiners);
+//			}
+//
+//			void RSSetShadingRateImage(
+//				ID3D12Resource* shadingRateImage)
+//			{
+//				Self().RSSetShadingRateImage(
+//					shadingRateImage);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::RSSetShadingRate;
+//			//using Base::RSSetShadingRateImage;
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList5;
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void DispatchMesh(
+//				UINT ThreadGroupCountX,
+//				UINT ThreadGroupCountY,
+//				UINT ThreadGroupCountZ)
+//			{
+//				Self().DispatchMesh(
+//					ThreadGroupCountX,
+//					ThreadGroupCountY,
+//					ThreadGroupCountZ);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::DispatchMesh;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct CommandListTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using base_value_type = ID3D12GraphicsCommandList6;
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			void Barrier(
+//				std::span<const D3D12_BARRIER_GROUP> pBarrierGroups)
+//			{
+//				Self().Barrier(static_cast<UINT32>(pBarrierGroups.size()), pBarrierGroups.data());
+//			}
+//
+//			template<std::size_t Size>
+//			void Barrier(
+//				std::array<const D3D12_BARRIER_GROUP, Size> pBarrierGroups)
+//			{
+//				Barrier(std::span{ pBarrierGroups });
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//
+//		template<class DerivedSelf, D3D12_COMMAND_LIST_TYPE Type>
+//		class InterfaceTagged : public CommandListTraits<base_value_type>::InterfaceTagged<DerivedSelf, Type>,
+//			public Interface<DerivedSelf>
+//		{
+//		private:
+//			static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+//			using derived_self = DerivedSelf;
+//			using allocator_value_type = CommandAllocator_t<Type>;
+//
+//		public:
+//			////Alphabetical order
+//			//using Base::DispatchMesh;
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//#pragma endregion
+//
+//#pragma region Direct Traits
+//	template<>
+//	struct DirectTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
+//
+//	template<>	
+//	struct DirectTraits<ID3D12GraphicsCommandList> 
+//	{
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//
+//	template<>
+//	struct DirectTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//
+//		};
+//	};
+//#pragma endregion
+//
+//#pragma region Compute Traits
+//	template<>
+//	struct ComputeTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList>
+//	{
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//		private:
+//			using Base::BeginEvent;
+//			using Base::BeginQuery;
+//			using Base::ClearDepthStencilView;
+//			using Base::ClearRenderTargetView;
+//			//using Base::ClearState;
+//			//using Base::ClearUnorderedAccessViewFloat;
+//			//using Base::ClearUnorderedAccessViewUint;
+//			//using Base::Close;
+//			//using Base::CopyBufferRegion;
+//			//using Base::CopyResource;
+//			//using Base::CopyTextureRegion;
+//			//using Base::CopyTiles;
+//			//using Base::DiscardResource;
+//			//using Base::Dispatch;
+//			using Base::DrawIndexedInstanced;
+//			using Base::DrawInstanced;
+//			using Base::EndEvent;
+//			//using Base::EndQuery;
+//			using Base::ExecuteBundle;
+//			//using Base::ExecuteIndirect;
+//			using Base::IASetIndexBuffer;
+//			using Base::IASetPrimitiveTopology;
+//			using Base::IASetVertexBuffers;
+//			using Base::OMSetBlendFactor;
+//			using Base::OMSetRenderTargets;
+//			using Base::OMSetStencilRef;
+//			//using Base::Reset;
+//			//using Base::ResolveQueryData;
+//			using Base::ResolveSubresource;
+//			//using Base::ResourceBarrier;
+//			//using Base::RSSetScissorRects;
+//			//using Base::RSSetViewports;
+//			//using Base::SetComputeRoot32BitConstant;
+//			//using Base::SetComputeRoot32BitConstants;
+//			//using Base::SetComputeRootConstantBufferView;
+//			//using Base::SetComputeRootDescriptorTable;
+//			//using Base::SetComputeRootShaderResourceView;
+//			//using Base::SetComputeRootSignature;
+//			//using Base::SetComputeRootUnorderedAccessView;
+//			//using Base::SetDescriptorHeaps;
+//			using Base::SetGraphicsRoot32BitConstant;
+//			using Base::SetGraphicsRoot32BitConstants;
+//			using Base::SetGraphicsRootConstantBufferView;
+//			using Base::SetGraphicsRootDescriptorTable;
+//			using Base::SetGraphicsRootShaderResourceView;
+//			using Base::SetGraphicsRootSignature;
+//			using Base::SetGraphicsRootUnorderedAccessView;
+//			using Base::SetMarker;
+//			//using Base::SetPipelineState;
+//			//using Base::SetPredication;
+//			using Base::SOSetTargets;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//
+//		private:
+//			//using Base::AtomicCopyBufferUINT;
+//			//using Base::AtomicCopyBufferUINT64;
+//			using Base::OMSetDepthBounds;
+//			using Base::ResolveSubresourceRegion;
+//			using Base::SetSamplePositions;
+//			using Base::SetViewInstanceMask;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//
+//		private:
+//			//using Base::WriteBufferImmediate;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//
+//		private:
+//			//using Base::SetProtectedResourceSession;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//		private:
+//			using Base::BeginRenderPass;
+//			using Base::BuildRaytracingAccelerationStructure;
+//			using Base::CopyRaytracingAccelerationStructure;
+//			//using Base::DispatchRays;
+//			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
+//			using Base::EndRenderPass;
+//			using Base::ExecuteMetaCommand;
+//			using Base::InitializeMetaCommand;
+//			//using Base::SetPipelineState1;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//		private:
+//			using Base::RSSetShadingRate;
+//			using Base::RSSetShadingRateImage;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//		//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//		private:
+//			//using Base::DispatchMesh;
+//		};
+//	};
+//
+//	template<>
+//	struct ComputeTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//		//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COMPUTE>;
+//		private:
+//			//using Base::Barrier;
+//		};
+//	};
+//#pragma endregion
+//
+//#pragma region Copy Traits	
+//	template<>
+//	struct CopyTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList>
+//	{
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		private:
+//			using Base::BeginEvent;
+//			using Base::BeginQuery;
+//			using Base::ClearDepthStencilView;
+//			using Base::ClearRenderTargetView;
+//			using Base::ClearState;
+//			using Base::ClearUnorderedAccessViewFloat;
+//			using Base::ClearUnorderedAccessViewUint;
+//			//using Base::Close;
+//			//using Base::CopyBufferRegion;
+//			//using Base::CopyResource;
+//			//using Base::CopyTextureRegion;
+//			//using Base::CopyTiles;
+//			//using Base::DiscardResource;
+//			//using Base::Dispatch;
+//			using Base::DrawIndexedInstanced;
+//			using Base::DrawInstanced;
+//			using Base::EndEvent;
+//			//using Base::EndQuery;
+//			using Base::ExecuteBundle;
+//			using Base::ExecuteIndirect;
+//			using Base::IASetIndexBuffer;
+//			using Base::IASetPrimitiveTopology;
+//			using Base::IASetVertexBuffers;
+//			using Base::OMSetBlendFactor;
+//			using Base::OMSetRenderTargets;
+//			using Base::OMSetStencilRef;
+//			//using Base::Reset;
+//			//using Base::ResolveQueryData;
+//			using Base::ResolveSubresource;
+//			//using Base::ResourceBarrier;
+//			using Base::RSSetScissorRects;
+//			using Base::RSSetViewports;
+//			using Base::SetComputeRoot32BitConstant;
+//			using Base::SetComputeRoot32BitConstants;
+//			using Base::SetComputeRootConstantBufferView;
+//			using Base::SetComputeRootDescriptorTable;
+//			using Base::SetComputeRootShaderResourceView;
+//			using Base::SetComputeRootSignature;
+//			using Base::SetComputeRootUnorderedAccessView;
+//			using Base::SetDescriptorHeaps;
+//			using Base::SetGraphicsRoot32BitConstant;
+//			using Base::SetGraphicsRoot32BitConstants;
+//			using Base::SetGraphicsRootConstantBufferView;
+//			using Base::SetGraphicsRootDescriptorTable;
+//			using Base::SetGraphicsRootShaderResourceView;
+//			using Base::SetGraphicsRootSignature;
+//			using Base::SetGraphicsRootUnorderedAccessView;
+//			using Base::SetMarker;
+//			using Base::SetPipelineState;
+//			using Base::SetPredication;
+//			using Base::SOSetTargets;
+//		};
+//	};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		private:
+//			//using Base::AtomicCopyBufferUINT;
+//			//using Base::AtomicCopyBufferUINT64;
+//			using Base::OMSetDepthBounds;
+//			using Base::ResolveSubresourceRegion;
+//			using Base::SetSamplePositions;
+//			using Base::SetViewInstanceMask;
+//		};
+//	};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		private:
+//			//using Base::WriteBufferImmediate;
+//		};
+//	};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		private:
+//			//using Base::SetProtectedResourceSession;
+//		};
+//	};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//
+//		private:
+//			using Base::BeginRenderPass;
+//			using Base::BuildRaytracingAccelerationStructure;
+//			using Base::CopyRaytracingAccelerationStructure;
+//			//using Base::DispatchRays;
+//			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
+//			using Base::EndRenderPass;
+//			using Base::ExecuteMetaCommand;
+//			using Base::InitializeMetaCommand;
+//			//using Base::SetPipelineState1;
+//		};
+//	};
+//
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//		private:
+//			using Base::RSSetShadingRate;
+//			using Base::RSSetShadingRateImage;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//		private:
+//			//using Base::DispatchMesh;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct CopyTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_COPY>;
+//		private:
+//			//using Base::Barrier;
+//		};
+//	};
+//
+//#pragma endregion
+//
+//#pragma region Bundle Traits
+//	template<>
+//	struct BundleTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList>
+//	{
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		private:
+//			using Base::BeginEvent;
+//			using Base::BeginQuery;
+//			using Base::ClearDepthStencilView;
+//			using Base::ClearRenderTargetView;
+//			using Base::ClearState;
+//			using Base::ClearUnorderedAccessViewFloat;
+//			using Base::ClearUnorderedAccessViewUint;
+//			//using Base::Close;
+//			using Base::CopyBufferRegion;
+//			using Base::CopyResource;
+//			using Base::CopyTextureRegion;
+//			using Base::CopyTiles;
+//			using Base::DiscardResource;
+//			//using Base::Dispatch;
+//			//using Base::DrawIndexedInstanced;
+//			//using Base::DrawInstanced;
+//			using Base::EndEvent;
+//			using Base::EndQuery;
+//			using Base::ExecuteBundle;
+//			//using Base::ExecuteIndirect;
+//			//using Base::IASetIndexBuffer;
+//			//using Base::IASetPrimitiveTopology;
+//			//using Base::IASetVertexBuffers;
+//			//using Base::OMSetBlendFactor;
+//			using Base::OMSetRenderTargets;
+//			//using Base::OMSetStencilRef;
+//			//using Base::Reset;
+//			using Base::ResolveQueryData;
+//			using Base::ResolveSubresource;
+//			using Base::ResourceBarrier;
+//			using Base::RSSetScissorRects;
+//			using Base::RSSetViewports;
+//			//using Base::SetComputeRoot32BitConstant;
+//			//using Base::SetComputeRoot32BitConstants;
+//			//using Base::SetComputeRootConstantBufferView;
+//			//using Base::SetComputeRootDescriptorTable;
+//			//using Base::SetComputeRootShaderResourceView;
+//			//using Base::SetComputeRootSignature;
+//			//using Base::SetComputeRootUnorderedAccessView;
+//			//using Base::SetDescriptorHeaps;
+//			//using Base::SetGraphicsRoot32BitConstant;
+//			//using Base::SetGraphicsRoot32BitConstants;
+//			//using Base::SetGraphicsRootConstantBufferView;
+//			//using Base::SetGraphicsRootDescriptorTable;
+//			//using Base::SetGraphicsRootShaderResourceView;
+//			//using Base::SetGraphicsRootSignature;
+//			//using Base::SetGraphicsRootUnorderedAccessView;
+//			//using Base::SetMarker;
+//			//using Base::SetPipelineState;
+//			using Base::SetPredication;
+//			using Base::SOSetTargets;
+//		};
+//	};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		private:
+//			using Base::AtomicCopyBufferUINT;
+//			using Base::AtomicCopyBufferUINT64;
+//			//using Base::OMSetDepthBounds;
+//			using Base::ResolveSubresourceRegion;
+//			//using Base::SetSamplePositions;
+//			//using Base::SetViewInstanceMask;
+//		};
+//	};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		private:
+//			//using Base::WriteBufferImmediate;
+//		};
+//	};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		private:
+//			using Base::SetProtectedResourceSession;
+//		};
+//	};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//
+//		private:
+//			using Base::BeginRenderPass;
+//			//using Base::BuildRaytracingAccelerationStructure;
+//			//using Base::CopyRaytracingAccelerationStructure;
+//			//using Base::DispatchRays;
+//			//using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
+//			using Base::EndRenderPass;
+//			//using Base::ExecuteMetaCommand;
+//			//using Base::InitializeMetaCommand;
+//			//using Base::SetPipelineState1;
+//		};
+//	};
+//
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//		private:
+//			//using Base::RSSetShadingRate;
+//			//using Base::RSSetShadingRateImage;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//		private:
+//			//using Base::DispatchMesh;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct BundleTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_BUNDLE>;
+//		private:
+//			//using Base::Barrier;
+//		};
+//	};
+//#pragma endregion
+//
+//#pragma region RenderPass Traits
+//	template<>
+//	struct RenderPassTraits<ID3D12CommandList> : CommandListTraits<ID3D12CommandList> {};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList>
+//	{
+//		using value_type = ID3D12GraphicsCommandList;
+//		using pointer = ID3D12GraphicsCommandList*;
+//		using const_pointer = const ID3D12GraphicsCommandList*;
+//		using reference = ID3D12GraphicsCommandList&;
+//		using const_reference = const ID3D12GraphicsCommandList&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//
+//		private:
+//			using Base::BeginEvent;
+//			//using Base::BeginQuery;
+//			using Base::ClearDepthStencilView;
+//			using Base::ClearRenderTargetView;
+//			using Base::ClearState;
+//			using Base::ClearUnorderedAccessViewFloat;
+//			using Base::ClearUnorderedAccessViewUint;
+//			//using Base::Close;
+//			using Base::CopyBufferRegion;
+//			using Base::CopyResource;
+//			using Base::CopyTextureRegion;
+//			using Base::CopyTiles;
+//			using Base::DiscardResource;
+//			using Base::Dispatch;
+//			//using Base::DrawIndexedInstanced;
+//			//using Base::DrawInstanced;
+//			//using Base::EndEvent;
+//			//using Base::EndQuery;
+//			//using Base::ExecuteBundle;
+//			//using Base::ExecuteIndirect;
+//			//using Base::IASetIndexBuffer;
+//			//using Base::IASetPrimitiveTopology;
+//			//using Base::IASetVertexBuffers;
+//			//using Base::OMSetBlendFactor;
+//			using Base::OMSetRenderTargets;
+//			//using Base::OMSetStencilRef;
+//			//using Base::Reset;
+//			using Base::ResolveQueryData;
+//			using Base::ResolveSubresource;
+//			//using Base::ResourceBarrier;
+//			//using Base::RSSetScissorRects;
+//			//using Base::RSSetViewports;
+//			//using Base::SetComputeRoot32BitConstant;
+//			//using Base::SetComputeRoot32BitConstants;
+//			//using Base::SetComputeRootConstantBufferView;
+//			//using Base::SetComputeRootDescriptorTable;
+//			//using Base::SetComputeRootShaderResourceView;
+//			//using Base::SetComputeRootSignature;
+//			//using Base::SetComputeRootUnorderedAccessView;
+//			//using Base::SetDescriptorHeaps;
+//			//using Base::SetGraphicsRoot32BitConstant;
+//			//using Base::SetGraphicsRoot32BitConstants;
+//			//using Base::SetGraphicsRootConstantBufferView;
+//			//using Base::SetGraphicsRootDescriptorTable;
+//			//using Base::SetGraphicsRootShaderResourceView;
+//			//using Base::SetGraphicsRootSignature;
+//			//using Base::SetGraphicsRootUnorderedAccessView;
+//			//using Base::SetMarker;
+//			//using Base::SetPipelineState;
+//			//using Base::SetPredication;
+//			//using Base::SOSetTargets;
+//		};
+//	};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList1>
+//	{
+//		using value_type = ID3D12GraphicsCommandList1;
+//		using pointer = ID3D12GraphicsCommandList1*;
+//		using const_pointer = const ID3D12GraphicsCommandList1*;
+//		using reference = ID3D12GraphicsCommandList1&;
+//		using const_reference = const ID3D12GraphicsCommandList1&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//
+//		private:
+//			using Base::AtomicCopyBufferUINT;
+//			using Base::AtomicCopyBufferUINT64;
+//			//using Base::OMSetDepthBounds;
+//			using Base::ResolveSubresourceRegion;
+//			//using Base::SetSamplePositions;
+//			//using Base::SetViewInstanceMask;
+//		};
+//	};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList2>
+//	{
+//		using value_type = ID3D12GraphicsCommandList2;
+//		using pointer = ID3D12GraphicsCommandList2*;
+//		using const_pointer = const ID3D12GraphicsCommandList2*;
+//		using reference = ID3D12GraphicsCommandList2&;
+//		using const_reference = const ID3D12GraphicsCommandList2&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//
+//		private:
+//			//using Base::WriteBufferImmediate;
+//		};
+//	};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList3>
+//	{
+//		using value_type = ID3D12GraphicsCommandList3;
+//		using pointer = ID3D12GraphicsCommandList3*;
+//		using const_pointer = const ID3D12GraphicsCommandList3*;
+//		using reference = ID3D12GraphicsCommandList3&;
+//		using const_reference = const ID3D12GraphicsCommandList3&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//		};
+//	};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList4>
+//	{
+//		using value_type = ID3D12GraphicsCommandList4;
+//		using pointer = ID3D12GraphicsCommandList4*;
+//		using const_pointer = const ID3D12GraphicsCommandList4*;
+//		using reference = ID3D12GraphicsCommandList4&;
+//		using const_reference = const ID3D12GraphicsCommandList4&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//
+//		private:
+//			using Base::BeginRenderPass;
+//			using Base::BuildRaytracingAccelerationStructure;
+//			using Base::CopyRaytracingAccelerationStructure;
+//			using Base::DispatchRays;
+//			using Base::EmitRaytracingAccelerationStructurePostbuildInfo;
+//			//using Base::EndRenderPass;
+//			using Base::ExecuteMetaCommand;
+//			using Base::InitializeMetaCommand;
+//			using Base::SetPipelineState1;
+//		};
+//	};
+//
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList5>
+//	{
+//		using value_type = ID3D12GraphicsCommandList5;
+//		using pointer = ID3D12GraphicsCommandList5*;
+//		using const_pointer = const ID3D12GraphicsCommandList5*;
+//		using reference = ID3D12GraphicsCommandList5&;
+//		using const_reference = const ID3D12GraphicsCommandList5&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//		private:
+//			//using Base::RSSetShadingRate;
+//			//using Base::RSSetShadingRateImage;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList6>
+//	{
+//		using value_type = ID3D12GraphicsCommandList6;
+//		using pointer = ID3D12GraphicsCommandList6*;
+//		using const_pointer = const ID3D12GraphicsCommandList6*;
+//		using reference = ID3D12GraphicsCommandList6&;
+//		using const_reference = const ID3D12GraphicsCommandList6&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//		private:
+//			//using Base::DispatchMesh;
+//		};
+//	};
+//
+//	//TODO: Figure out what functions are restricted as at the time of writing, is not reflected in the linked API restriction document 
+//	template<>
+//	struct RenderPassTraits<ID3D12GraphicsCommandList7>
+//	{
+//		using value_type = ID3D12GraphicsCommandList7;
+//		using pointer = ID3D12GraphicsCommandList7*;
+//		using const_pointer = const ID3D12GraphicsCommandList7*;
+//		using reference = ID3D12GraphicsCommandList7&;
+//		using const_reference = const ID3D12GraphicsCommandList7&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>
+//		{
+//			using Base = CommandListTraits<value_type>::InterfaceTagged<DerivedSelf, D3D12_COMMAND_LIST_TYPE_DIRECT>;
+//		private:
+//			//using Base::Barrier;
+//		};
+//	};
+//#pragma endregion
+//
+//	template<class DerivedSelf>
+//	void CommandListTraits<ID3D12GraphicsCommandList>::Interface<DerivedSelf>::ExecuteBundle(CommandList_t<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE> pCommandList)
+//	{
+//		Self().ExecuteBundle(pCommandList.Get());
+//	}
+//
+//	template<class DerivedSelf>
+//	RenderPass_t<ID3D12GraphicsCommandList4> CommandListTraits<ID3D12GraphicsCommandList4>::Interface<DerivedSelf>::BeginRenderPass(std::span<const D3D12_RENDER_PASS_RENDER_TARGET_DESC> renderTargets, const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* pDepthStencil, D3D12_RENDER_PASS_FLAGS Flags)
+//	{
+//		Self().BeginRenderPass(static_cast<UINT>(renderTargets.size()), renderTargets.data(), pDepthStencil, Flags);
+//		return RenderPass_t<ID3D12GraphicsCommandList4>(&Get());
+//	}
+//}
+//
+//#pragma warning(pop)

--- a/TypedD3D/source/D3D12/CommandList.ixx
+++ b/TypedD3D/source/D3D12/CommandList.ixx
@@ -16,8 +16,10 @@ export module TypedD3D12:CommandList;
 import :CommandAllocator;
 import :DescriptorHeap;
 //import :DeviceChild;
+import :D3D12Object;
 import TypedD3D.Shared;
 import :Wrappers;
+import :PipelineState;
 
 namespace TypedD3D::D3D12
 {
@@ -27,6 +29,9 @@ namespace TypedD3D::D3D12
 	template<D3D12_COMMAND_LIST_TYPE Type>
 	struct CommandListTrait<ID3D12CommandList, Type>
 	{
+
+		using inner_type = ID3D12CommandList;
+
 		template<class Derived>
 		struct Interface : InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
@@ -40,6 +45,7 @@ namespace TypedD3D::D3D12
 	template<D3D12_COMMAND_LIST_TYPE Type>
 	struct CommandListTrait<ID3D12GraphicsCommandList, Type>
 	{
+		using inner_type = ID3D12GraphicsCommandList;
 		template<class Derived>
 		struct Interface : InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
@@ -519,8 +525,17 @@ namespace TypedD3D
 	};
 
 	template<>
+	struct DirectTraits<ID3D12CommandList>
+	{
+		using inner_type = ID3D12CommandList;
+		template<class Derived>
+		using Interface = ID3D12CommandList*;
+	};
+
+	template<>
 	struct DirectTraits<ID3D12GraphicsCommandList>
 	{
+		using inner_type = ID3D12GraphicsCommandList;
 		template<class Derived>
 		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_DIRECT>::Interface<Derived>
 		{
@@ -530,6 +545,7 @@ namespace TypedD3D
 	template<>
 	struct ComputeTraits<ID3D12GraphicsCommandList>
 	{
+		using inner_type = ID3D12GraphicsCommandList;
 		template<class Derived>
 		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_COMPUTE>::Interface<Derived>
 		{
@@ -539,6 +555,7 @@ namespace TypedD3D
 	template<>
 	struct CopyTraits<ID3D12GraphicsCommandList>
 	{
+		using inner_type = ID3D12GraphicsCommandList;
 		template<class Derived>
 		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_COPY>::Interface<Derived>
 		{
@@ -548,6 +565,7 @@ namespace TypedD3D
 	template<>
 	struct BundleTraits<ID3D12GraphicsCommandList>
 	{
+		using inner_type = ID3D12GraphicsCommandList;
 		template<class Derived>
 		class Interface : public D3D12::CommandListTrait<ID3D12GraphicsCommandList, D3D12_COMMAND_LIST_TYPE_BUNDLE>::Interface<Derived>
 		{

--- a/TypedD3D/source/D3D12/CommandQueue.ixx
+++ b/TypedD3D/source/D3D12/CommandQueue.ixx
@@ -31,6 +31,8 @@ namespace TypedD3D::D3D12
 		using reference = ID3D12CommandQueue&;
 		using const_reference = const ID3D12CommandQueue&;
 
+		using inner_type = ID3D12CommandQueue;
+
 		template<class Derived>
 		class Interface : public InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{

--- a/TypedD3D/source/D3D12/CommandQueue.ixx
+++ b/TypedD3D/source/D3D12/CommandQueue.ixx
@@ -19,27 +19,29 @@ namespace TypedD3D::D3D12
 		UINT64 cpuTimestamp;
 	};
 
-	struct CommonCommandQueueTraits
+
+	export template<D3D12_COMMAND_LIST_TYPE Type>
+		struct CommandQueueTraits
 	{
+		static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
+
 		using value_type = ID3D12CommandQueue;
 		using pointer = ID3D12CommandQueue*;
 		using const_pointer = const ID3D12CommandQueue*;
 		using reference = ID3D12CommandQueue&;
 		using const_reference = const ID3D12CommandQueue&;
 
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		class Interface : public InterfaceBase<CommandListTypeToTrait<Type, Derived>>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
 		public:
+
 			void BeginEvent(
 				UINT Metadata,
 				const void* pData,
 				UINT Size)
 			{
-				Get().BeginEvent(Metadata, pData, Size);
+				Self().BeginEvent(Metadata, pData, Size);
 			}
 
 			void CopyTileMappings(
@@ -50,7 +52,7 @@ namespace TypedD3D::D3D12
 				const D3D12_TILE_REGION_SIZE& pRegionSize,
 				D3D12_TILE_MAPPING_FLAGS Flags)
 			{
-				Get().CopyTileMappings(
+				Self().CopyTileMappings(
 					&pDstResource,
 					&pDstRegionStartCoordinate,
 					&pSrcResource,
@@ -59,21 +61,21 @@ namespace TypedD3D::D3D12
 					Flags);
 			}
 
-			void EndEvent() { Get().EndEvent(); }
+			void EndEvent() { Self().EndEvent(); }
 
 			ClockCalibrationData GetClockCalibration()
 			{
 				ClockCalibrationData timeStamps;
-				Get().GetClockCalibration(&timeStamps.gpuTimestamp, &timeStamps.cpuTimestamp);
+				Self().GetClockCalibration(&timeStamps.gpuTimestamp, &timeStamps.cpuTimestamp);
 				return timeStamps;
 			}
 
-			D3D12_COMMAND_QUEUE_DESC GetDesc() { return Get().GetDesc(); }
+			D3D12_COMMAND_QUEUE_DESC GetDesc() { return Self().GetDesc(); }
 
 			UINT64 GetTimestampFrequency()
 			{
 				UINT64 frequency = 0;
-				Get().GetTimestampFrequency(&frequency);
+				Self().GetTimestampFrequency(&frequency);
 				return frequency;
 			}
 
@@ -82,14 +84,14 @@ namespace TypedD3D::D3D12
 				const void* pData,
 				UINT Size)
 			{
-				Get().SetMarker(Metadata, pData, Size);
+				Self().SetMarker(Metadata, pData, Size);
 			}
 
 			HRESULT Signal(
 				ID3D12Fence& Fence,
 				UINT64 Value)
 			{
-				return Get().Signal(&Fence, Value);
+				return Self().Signal(&Fence, Value);
 			}
 
 			void UpdateTileMappings(
@@ -104,7 +106,7 @@ namespace TypedD3D::D3D12
 				const UINT* pRangeTileCounts,
 				D3D12_TILE_MAPPING_FLAGS Flags)
 			{
-				Get().UpdateTileMappings(
+				Self().UpdateTileMappings(
 					&pResource,
 					NumResourceRegions,
 					pResourceRegionStartCoordinates,
@@ -121,65 +123,29 @@ namespace TypedD3D::D3D12
 				ID3D12Fence& Fence,
 				UINT64 Value)
 			{
-				return Get().Wait(&Fence, Value);
+				return Self().Wait(&Fence, Value);
 			}
 
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	export template<D3D12_COMMAND_LIST_TYPE Type>
-		struct CommandQueueTraits
-	{
-		static constexpr D3D12_COMMAND_LIST_TYPE command_list_value = Type;
-
-		using value_type = ID3D12CommandQueue;
-		using pointer = ID3D12CommandQueue*;
-		using const_pointer = const ID3D12CommandQueue*;
-		using reference = ID3D12CommandQueue&;
-		using const_reference = const ID3D12CommandQueue&;
-
-		using list_value_type = CommandList_t<ID3D12CommandList, command_list_value>;
-		using allocator_value_type = CommandAllocator_t<command_list_value>;
-
-		template<class DerivedSelf>
-		class Interface : public CommonCommandQueueTraits::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			template<std::convertible_to<list_value_type> ListTy, size_t Extents>
-			void ExecuteCommandLists(
-				Span<ListTy, Extents> commandLists)
+			void ExecuteCommandLists(Span<WeakWrapper<CommandListTypeToTrait<Type, ID3D12CommandList>>> commandLists)
 			{
-				Get().ExecuteCommandLists(static_cast<UINT>(commandLists.size()), commandLists.data());
+				Self().ExecuteCommandLists(static_cast<UINT>(commandLists.size()), commandLists.data());
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::Self;
+			using InterfaceBase<CommandListTypeToTrait<Type, Derived>>::ToDerived;
 		};
 	};
+}
+
+namespace TypedD3D
+{
+	template<>
+	struct DirectTraits<ID3D12CommandQueue> : D3D12::CommandQueueTraits<D3D12_COMMAND_LIST_TYPE_DIRECT> {};
 
 	template<>
-	struct DirectTraits<ID3D12CommandQueue> : CommandQueueTraits<TraitToCommandListType<DirectTraits>> {};
+	struct ComputeTraits<ID3D12CommandQueue> : D3D12::CommandQueueTraits<D3D12_COMMAND_LIST_TYPE_COMPUTE> {};
 
 	template<>
-	struct ComputeTraits<ID3D12CommandQueue> : CommandQueueTraits<TraitToCommandListType<ComputeTraits>> {};
-
-	template<>
-	struct CopyTraits<ID3D12CommandQueue> : CommandQueueTraits<TraitToCommandListType<CopyTraits>> {};
-
-	export template<D3D12_COMMAND_LIST_TYPE Type>
-		using D3D12CommandQueue_t = IUnknownWrapper<ID3D12CommandQueue, CommandListTypeToTrait<Type>::template type>;
-
-	namespace Aliases
-	{
-		export using D3D12DirectCommandQueue = D3D12CommandQueue_t<D3D12_COMMAND_LIST_TYPE_DIRECT>;
-		export using D3D12ComputeCommandQueue = D3D12CommandQueue_t<D3D12_COMMAND_LIST_TYPE_COMPUTE>;
-		export using D3D12CopyCommandQueue = D3D12CommandQueue_t<D3D12_COMMAND_LIST_TYPE_COPY>;
-	}
+	struct CopyTraits<ID3D12CommandQueue> : D3D12::CommandQueueTraits<D3D12_COMMAND_LIST_TYPE_COPY> {};
 }

--- a/TypedD3D/source/D3D12/D3D12Device.ixx
+++ b/TypedD3D/source/D3D12/D3D12Device.ixx
@@ -217,6 +217,7 @@ namespace TypedD3D
 	template<>
 	struct UntaggedTraits<ID3D12Device>
 	{
+		using inner_type = ID3D12Device;
 		template<class Derived>
 		struct Interface : InterfaceBase<UntaggedTraits<Derived>>
 		{

--- a/TypedD3D/source/D3D12/D3D12Device.ixx
+++ b/TypedD3D/source/D3D12/D3D12Device.ixx
@@ -19,6 +19,7 @@ export import :PipelineState;
 export import :Resource;
 
 
+
 namespace TypedD3D::D3D12
 {
 	struct MetaCommandParameterInfo
@@ -215,11 +216,20 @@ namespace TypedD3D::D3D12
 namespace TypedD3D
 {
 	template<>
-	struct UntaggedTraits<ID3D12Device>
+	struct Trait<Untagged<ID3D12Device>>
 	{
 		using inner_type = ID3D12Device;
+
+		using inner_tag = ID3D12Device;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		struct Interface : InterfaceBase<UntaggedTraits<Derived>>
+		struct Interface : InterfaceBase<Untagged<Derived>>
 		{
 			UINT GetNodeCount()
 			{
@@ -320,11 +330,11 @@ namespace TypedD3D
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
 			void CreateShaderResourceView(
-				ID3D12Resource& pResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
 				const D3D12_SHADER_RESOURCE_VIEW_DESC* optDesc,
 				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Self().CreateShaderResourceView(&pResource, optDesc, DestDescriptor.Raw());
+				Self().CreateShaderResourceView(pResource.get().Get(), optDesc, DestDescriptor.Raw());
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
@@ -337,20 +347,20 @@ namespace TypedD3D
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
 			void CreateUnorderedAccessView(
-				ID3D12Resource& pResource,
-				ID3D12Resource& pCounterResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pCounterResource,
 				const D3D12_UNORDERED_ACCESS_VIEW_DESC& pDesc,
 				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Self().CreateUnorderedAccessView(&pResource, &pCounterResource, &pDesc, DestDescriptor.Raw());
+				Self().CreateUnorderedAccessView(pResource.get().Get(), pCounterResource.get().Get(), &pDesc, DestDescriptor.Raw());
 			}
 
 			void CreateRenderTargetView(
-				ID3D12Resource& Resource,
+				gsl::not_null<WrapperView<ID3D12Resource>> Resource,
 				const D3D12_RENDER_TARGET_VIEW_DESC* optDesc,
 				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Self().CreateRenderTargetView(&Resource, optDesc, DestDescriptor.Raw());
+				Self().CreateRenderTargetView(Resource.get().Get(), optDesc, DestDescriptor.Raw());
 			}
 
 			void CreateNullRenderTargetView(
@@ -361,11 +371,11 @@ namespace TypedD3D
 			}
 
 			void CreateDepthStencilView(
-				ID3D12Resource& Resource,
+				gsl::not_null<WrapperView<ID3D12Resource>> Resource,
 				const D3D12_DEPTH_STENCIL_VIEW_DESC* optDesc,
 				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Self().CreateDepthStencilView(&Resource, optDesc, DestDescriptor.Raw());
+				Self().CreateDepthStencilView(Resource.get().Get(), optDesc, DestDescriptor.Raw());
 			}
 
 			void CreateNullDepthStencilView(
@@ -613,638 +623,12 @@ namespace TypedD3D
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }
 
-//import TypedD3D.Legacy.D3D12Helpers;
-//
-//namespace TypedD3D::D3D12
-//{
-//	using Microsoft::WRL::ComPtr;
-//	struct MetaCommandParameterInfo
-//	{
-//		UINT totalStructureSizeInBytes;
-//		UINT parameterCount;
-//		std::vector<D3D12_META_COMMAND_PARAMETER_DESC> parameterDescs;
-//	};
-//
-//#pragma region Device Feature Map
-//	template<D3D12_FEATURE Feature>
-//	struct DeviceFeatureMap;
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_ARCHITECTURE>
-//	{
-//		using type = D3D12_FEATURE_DATA_ARCHITECTURE;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_FEATURE_LEVELS>
-//	{
-//		using type = D3D12_FEATURE_DATA_FEATURE_LEVELS;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_FORMAT_SUPPORT>
-//	{
-//		using type = D3D12_FEATURE_DATA_FORMAT_INFO;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT>
-//	{
-//		using type = D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_SHADER_MODEL>
-//	{
-//		using type = D3D12_FEATURE_DATA_SHADER_MODEL;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS1>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS1;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_SUPPORT>
-//	{
-//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_ROOT_SIGNATURE>
-//	{
-//		using type = D3D12_FEATURE_DATA_ROOT_SIGNATURE;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_ARCHITECTURE1>
-//	{
-//		using type = D3D12_FEATURE_DATA_ARCHITECTURE1;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS2>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS2;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_SHADER_CACHE>
-//	{
-//		using type = D3D12_FEATURE_DATA_SHADER_CACHE;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_COMMAND_QUEUE_PRIORITY>
-//	{
-//		using type = D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS3>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS3;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_EXISTING_HEAPS>
-//	{
-//		using type = D3D12_FEATURE_DATA_EXISTING_HEAPS;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS4>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS4;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_SERIALIZATION>
-//	{
-//		using type = D3D12_FEATURE_DATA_SERIALIZATION;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_CROSS_NODE>
-//	{
-//		using type = D3D12_FEATURE_DATA_CROSS_NODE;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS5>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS5;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS6>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS6;
-//	};
-//
-//	//Requires Windows 11
-//	//template<>
-//	//struct DeviceFeatureMap<D3D12_FEATURE_DISPLAYABLE>
-//	//{
-//	//    using type = D3D12_FEATURE_DATA_DISPLAYABLE;
-//	//};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_QUERY_META_COMMAND>
-//	{
-//		using type = D3D12_FEATURE_DATA_QUERY_META_COMMAND;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS7>
-//	{
-//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS7;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPE_COUNT>
-//	{
-//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT;
-//	};
-//
-//	template<>
-//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPES>
-//	{
-//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES;
-//	};
-//
-//	//Requires Windows 11
-//	//template<>
-//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS8>
-//	//{
-//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS8;
-//	//};
-//
-//	//Requires Windows 11
-//	//template<>
-//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS9>
-//	//{
-//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS9;
-//	//};
-//
-//	//Requires Windows 11
-//	//template<>
-//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS10>
-//	//{
-//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS10;
-//	//};
-//
-//	//Requires Windows 11
-//	//template<>
-//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS11>
-//	//{
-//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS11;
-//	//};
-//#pragma endregion
-//
-//	export template<std::derived_from<ID3D12Device> DeviceTy>
-//	using Device_t = IUnknownWrapper<DeviceTy, UntaggedTraits>;
-//
-//	template<class Ty>
-//	struct DeviceTraits;
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device>
-//	{
-//		using value_type = ID3D12Device;
-//		using pointer = ID3D12Device*;
-//		using const_pointer = const ID3D12Device*;
-//		using reference = ID3D12Device&;
-//		using const_reference = const ID3D12Device&;
-//
-//		template<class DerivedSelf>
-//		class Interface
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			UINT GetNodeCount()
-//			{
-//				return Self().GetNodeCount();
-//			}
-//
-//			template<D3D12_COMMAND_LIST_TYPE Type>
-//			D3D12CommandQueue_t<Type> CreateCommandQueue(
-//				D3D12_COMMAND_QUEUE_PRIORITY priority,
-//				D3D12_COMMAND_QUEUE_FLAGS flags,
-//				UINT nodeMask)
-//			{
-//				using queue_type = D3D12CommandQueue_t<Type>;
-//
-//				D3D12_COMMAND_QUEUE_DESC desc
-//				{
-//					.Type = Type,
-//					.Priority = priority,
-//					.Flags = flags,
-//					.NodeMask = nodeMask
-//				};
-//
-//				return Helpers::D3D12::CreateCommandQueue(Get(), desc);
-//			}
-//
-//			template<D3D12_COMMAND_LIST_TYPE Type>
-//			CommandAllocator_t<Type> CreateCommandAllocator()
-//			{
-//				using allocator_type = CommandAllocator_t<Type>;
-//
-//				return Helpers::D3D12::CreateCommandAllocator(Get(), Type);
-//			}
-//
-//			Graphics<ID3D12PipelineState> CreateGraphicsPipelineState(
-//				const D3D12_GRAPHICS_PIPELINE_STATE_DESC& pDesc)
-//			{
-//				return Helpers::D3D12::CreateGraphicsPipelineState(Get(), pDesc);
-//			}
-//
-//			Compute<ID3D12PipelineState> CreateComputePipelineState(
-//				const D3D12_COMPUTE_PIPELINE_STATE_DESC& pDesc)
-//			{
-//				return Helpers::D3D12::CreateComputePipelineState(Get(), pDesc);
-//			}
-//
-//			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
-//			CommandList_t<ListTy, Type> CreateCommandList(
-//				CommandAllocator_t<Type> pCommandAllocator,
-//				UINT nodeMask = 0,
-//				ID3D12PipelineState* optInitialState = nullptr)
-//			{
-//				using command_list_type = CommandList_t<ListTy, Type>;
-//				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, *pCommandAllocator.Get(), nodeMask, optInitialState);
-//			}
-//
-//			template<D3D12_FEATURE Feature>
-//			typename DeviceFeatureMap<Feature>::type CheckFeatureSupport()
-//			{
-//				using feature_t = typename DeviceFeatureMap<Feature>::type;
-//				feature_t feature{};
-//				ThrowIfFailed(Self().CheckFeatureSupport(Feature, &feature, sizeof(feature_t)));
-//				return feature;
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlag>
-//			DescriptorHeap_t<Type, HeapFlag> CreateDescriptorHeap(
-//				UINT NumDescriptors,
-//				UINT NodeMask)
-//			{
-//				using DescriptorHeap_t = DescriptorHeap_t<Type, HeapFlag>;
-//
-//				D3D12_DESCRIPTOR_HEAP_DESC desc
-//				{
-//					.Type = Type,
-//					.NumDescriptors = NumDescriptors,
-//					.Flags = HeapFlag,
-//					.NodeMask = NodeMask
-//				};
-//
-//				return Helpers::D3D12::CreateDescriptorHeap(Get(), desc);
-//			}
-//
-//			UINT GetDescriptorHandleIncrementSize(
-//				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType)
-//			{
-//				return Self().GetDescriptorHandleIncrementSize(DescriptorHeapType);
-//			}
-//
-//			ComPtr<ID3D12RootSignature> CreateRootSignature(
-//				UINT nodeMask,
-//				const void* pBlobWithRootSignature,
-//				SIZE_T blobLengthInBytes)
-//			{
-//				return Helpers::D3D12::CreateRootSignature(Get(), nodeMask, pBlobWithRootSignature, blobLengthInBytes);
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//			void CreateConstantBufferView(
-//				const D3D12_CONSTANT_BUFFER_VIEW_DESC& pDesc,
-//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
-//			{
-//				Self().CreateConstantBufferView(pDesc, DestDescriptor.Get());
-//			}
-//
-//
-//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//			void CreateShaderResourceView(
-//				ID3D12Resource& pResource,
-//				const D3D12_SHADER_RESOURCE_VIEW_DESC* optDesc,
-//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
-//			{
-//				Self().CreateShaderResourceView(&pResource, optDesc, DestDescriptor.Get());
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//			void CreateNullShaderResourceView(
-//				const D3D12_SHADER_RESOURCE_VIEW_DESC& pDesc,
-//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
-//			{
-//				Self().CreateShaderResourceView(nullptr, &pDesc, DestDescriptor.Get());
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//			void CreateUnorderedAccessView(
-//				ID3D12Resource& pResource,
-//				ID3D12Resource& pCounterResource,
-//				const D3D12_UNORDERED_ACCESS_VIEW_DESC& pDesc,
-//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
-//			{
-//				Self().CreateUnorderedAccessView(&pResource, &pCounterResource, &pDesc, DestDescriptor.Get());
-//			}
-//
-//			void CreateRenderTargetView(
-//				ID3D12Resource& Resource,
-//				const D3D12_RENDER_TARGET_VIEW_DESC* optDesc,
-//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
-//			{
-//				Self().CreateRenderTargetView(&Resource, optDesc, DestDescriptor.Get());
-//			}
-//
-//			void CreateNullRenderTargetView(
-//				const D3D12_RENDER_TARGET_VIEW_DESC& Desc,
-//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
-//			{
-//				Self().CreateRenderTargetView(nullptr, &Desc, DestDescriptor.Get());
-//			}
-//
-//			void CreateDepthStencilView(
-//				ID3D12Resource& Resource,
-//				const D3D12_DEPTH_STENCIL_VIEW_DESC* optDesc,
-//				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
-//			{
-//				Self().CreateDepthStencilView(&Resource, optDesc, DestDescriptor.Get());
-//			}
-//
-//			void CreateNullDepthStencilView(
-//				const D3D12_DEPTH_STENCIL_VIEW_DESC& optDesc,
-//				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
-//			{
-//				Self().CreateDepthStencilView(nullptr, optDesc, DestDescriptor.Get());
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//			void CreateSampler(
-//				const D3D12_SAMPLER_DESC& pDesc,
-//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, HeapFlags> DestDescriptor)
-//			{
-//				Self().CreateSampler(&pDesc, DestDescriptor.Get());
-//			}
-//
-//
-//			void CopyDescriptors(
-//				UINT NumDestDescriptorRanges,
-//				const D3D12_CPU_DESCRIPTOR_HANDLE* pDestDescriptorRangeStarts,
-//				const UINT* pDestDescriptorRangeSizes,
-//				UINT NumSrcDescriptorRanges,
-//				const D3D12_CPU_DESCRIPTOR_HANDLE* pSrcDescriptorRangeStarts,
-//				const UINT* pSrcDescriptorRangeSizes,
-//				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType)
-//			{
-//				Self().CopyDescriptors(
-//					NumDestDescriptorRanges,
-//					pDestDescriptorRangeStarts,
-//					pDestDescriptorRangeSizes,
-//					NumSrcDescriptorRanges,
-//					pSrcDescriptorRangeStarts,
-//					pSrcDescriptorRangeSizes,
-//					DescriptorHeapsType);
-//			}
-//
-//			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS DestinationFlag>
-//			void CopyDescriptorsSimple(
-//				UINT NumDescriptors,
-//				DescriptorHeap_t<Type, DestinationFlag>::CPU_DESCRIPTOR_HANDLE DestDescriptorRangeStart,
-//				DescriptorHeap_t<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart)
-//			{
-//				Self().CopyDescriptorsSimple(NumDescriptors, DestDescriptorRangeStart.Get(), SrcDescriptorRangeStart.Get(), Type);
-//			}
-//
-//			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo(
-//				UINT visibleMask,
-//				const std::span<D3D12_RESOURCE_DESC> resourceDescs)
-//			{
-//				return Self().GetResourceAllocationInfo(
-//					visibleMask,
-//					static_cast<UINT>(resourceDescs.size()),
-//					resourceDescs.data());
-//			}
-//
-//			D3D12_HEAP_PROPERTIES GetCustomHeapProperties(
-//				UINT nodeMask,
-//				D3D12_HEAP_TYPE heapType)
-//			{
-//				return Self().GetCustomHeapProperties(nodeMask, heapType);
-//			}
-//
-//			Wrapper<ID3D12Resource> CreateCommittedResource(
-//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-//				D3D12_HEAP_FLAGS HeapFlags,
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialResourceState,
-//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-//			{
-//				return Helpers::D3D12::CreateCommittedResource(
-//					Get(),
-//					pHeapProperties,
-//					HeapFlags,
-//					pDesc,
-//					InitialResourceState,
-//					optOptimizedClearValue);
-//			}
-//
-//			ComPtr<ID3D12Heap> CreateHeap(
-//				const D3D12_HEAP_DESC& pDesc)
-//			{
-//				return Helpers::D3D12::CreateHeap(
-//					Get(),
-//					pDesc);
-//			}
-//
-//			Wrapper<ID3D12Resource> CreatePlacedResource(
-//				ID3D12Heap& pHeap,
-//				UINT64 HeapOffset,
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialState,
-//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-//			{
-//				return Helpers::D3D12::CreatePlacedResource(
-//					Get(),
-//					pHeap,
-//					HeapOffset,
-//					pDesc,
-//					InitialState,
-//					optOptimizedClearValue);
-//			}
-//
-//			Wrapper<ID3D12Resource> CreateReservedResource(
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialState,
-//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-//			{
-//				return Helpers::D3D12::CreateReservedResource(
-//					Get(),
-//					pDesc,
-//					InitialState,
-//					optOptimizedClearValue);
-//			}
-//
-//			HANDLE CreateSharedHandle(
-//				ID3D12DeviceChild& pObject,
-//				const SECURITY_ATTRIBUTES* optAttributes,
-//				DWORD Access,
-//				LPCWSTR Name)
-//			{
-//				HANDLE handle;
-//
-//				ThrowIfFailed(Self().CreateSharedHandle(
-//					&pObject,
-//					optAttributes,
-//					Access,
-//					Name,
-//					&handle));
-//
-//				return handle;
-//			}
-//
-//			  //TODO: Figure out how this works to update to a more modern API
-//			HRESULT OpenSharedHandle(
-//				HANDLE NTHandle,
-//				const IID& riid,
-//				void** ppvObj)
-//			{
-//				return Self().OpenSharedHandle(
-//					NTHandle,
-//					riid,
-//					ppvObj);
-//			}
-//
-//			HANDLE OpenSharedHandleByName(
-//				LPCWSTR Name,
-//				DWORD Access)
-//			{
-//				HANDLE handle;
-//
-//				ThrowIfFailed(Self().OpenSharedHandleByName(
-//					Name,
-//					Access,
-//					&handle));
-//
-//				return handle;
-//			}
-//
-//			void MakeResident(
-//				const std::span<ID3D12Pageable*> objects)
-//			{
-//				ThrowIfFailed(Self().MakeResident(
-//					static_cast<UINT>(objects.size()),
-//					objects.data()));
-//			}
-//
-//			void Evict(
-//				const std::span<ID3D12Pageable*> objects)
-//			{
-//				ThrowIfFailed(Self().Evict(
-//					static_cast<UINT>(objects.size()),
-//					objects.data()));
-//			}
-//
-//			ComPtr<ID3D12Fence> CreateFence(
-//				UINT64 InitialValue,
-//				D3D12_FENCE_FLAGS Flags)
-//			{
-//				return Helpers::D3D12::CreateFence(Get(), Flags, InitialValue);
-//			}
-//
-//			HRESULT GetDeviceRemovedReason()
-//			{
-//				return Self().GetDeviceRemovedReason();
-//			}
-//
-//			void GetCopyableFootprints(
-//				const D3D12_RESOURCE_DESC& pResourceDesc,
-//				UINT FirstSubresource,
-//				UINT NumSubresources,
-//				UINT64 BaseOffset,
-//				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* optOutLayouts,
-//				UINT* optOutNumRows,
-//				UINT64* optOutRowSizeInBytes,
-//				UINT64* optOutTotalBytes)
-//			{
-//				Self().GetCopyableFootprints(
-//					&pResourceDesc,
-//					FirstSubresource,
-//					NumSubresources,
-//					BaseOffset,
-//					optOutLayouts,
-//					optOutNumRows,
-//					optOutRowSizeInBytes,
-//					optOutTotalBytes);
-//			}
-//
-//			ComPtr<ID3D12QueryHeap> CreateQueryHeap(
-//				const D3D12_QUERY_HEAP_DESC& pDesc)
-//			{
-//				return Helpers::D3D12::CreateQueryHeap(Get(), pDesc);
-//			}
-//
-//			void SetStablePowerState(
-//				BOOL Enable)
-//			{
-//				ThrowIfFailed(Self().SetStablePowerState(Enable));
-//			}
-//
-//			ComPtr<ID3D12CommandSignature> CreateCommandSignature(
-//				const D3D12_COMMAND_SIGNATURE_DESC& pDesc,
-//				ID3D12RootSignature* optRootSignature)
-//			{
-//				return Helpers::D3D12::CreateCommandSignature(Get(), pDesc, optRootSignature);
-//			}
-//
-//			void GetResourceTiling(
-//				ID3D12Resource& pTiledResource,
-//				UINT* optOutNumTilesForEntireResource,
-//				D3D12_PACKED_MIP_INFO* optOutPackedMipDesc,
-//				D3D12_TILE_SHAPE* optOutStandardTileShapeForNonPackedMips,
-//				UINT* pNumSubresourceTilings,
-//				UINT FirstSubresourceTilingToGet,
-//				D3D12_SUBRESOURCE_TILING& pSubresourceTilingsForNonPackedMips)
-//			{
-//				Self().GetResourceTiling(
-//					&pTiledResource,
-//					optOutNumTilesForEntireResource,
-//					optOutPackedMipDesc,
-//					optOutStandardTileShapeForNonPackedMips,
-//					pNumSubresourceTilings,
-//					FirstSubresourceTilingToGet,
-//					&pSubresourceTilingsForNonPackedMips);
-//			}
-//
-//			LUID GetAdapterLuid()
-//			{
-//				return Self().GetAdapterLuid();
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
 //
 //	class SetEventOnMultipleFenceCompletionData
 //	{
@@ -1806,7 +1190,7 @@ namespace TypedD3D
 //				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
 //				ID3D12ProtectedResourceSession* pProtectedSession)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreateCommittedResource2, Get(),
+//				return IIDToObjectForwardFunction<ID3D12Resource>(&inner_type::CreateCommittedResource2, Get(),
 //					&pHeapProperties,
 //					HeapFlags,
 //					&pDesc,
@@ -1822,7 +1206,7 @@ namespace TypedD3D
 //				D3D12_RESOURCE_STATES InitialState,
 //				const D3D12_CLEAR_VALUE* pOptimizedClearValue)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreatePlacedResource1, Get(),
+//				return IIDToObjectForwardFunction<ID3D12Resource>(&inner_type::CreatePlacedResource1, Get(),
 //					&pHeap,
 //					HeapOffset,
 //					&pDesc,
@@ -1888,7 +1272,7 @@ namespace TypedD3D
 //			ComPtr<ID3D12ShaderCacheSession> CreateShaderCacheSession(
 //				const D3D12_SHADER_CACHE_SESSION_DESC& pDesc)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12ShaderCacheSession>(&value_type::CreateShaderCacheSession, Get(), &pDesc);
+//				return IIDToObjectForwardFunction<ID3D12ShaderCacheSession>(&inner_type::CreateShaderCacheSession, Get(), &pDesc);
 //			}
 //
 //			HRESULT ShaderCacheControl(
@@ -1915,7 +1299,7 @@ namespace TypedD3D
 //					.NodeMask = nodeMask
 //				};
 //
-//				return IIDToObjectForwardFunction<ID3D12CommandQueue>(&value_type::CreateCommandQueue1, Get(), &desc, CreatorID);
+//				return IIDToObjectForwardFunction<ID3D12CommandQueue>(&inner_type::CreateCommandQueue1, Get(), &desc, CreatorID);
 //			}
 //
 //		private:
@@ -1950,7 +1334,7 @@ namespace TypedD3D
 //				ID3D12ProtectedResourceSession* pProtectedSession,
 //				std::span<DXGI_FORMAT> CastableFormats)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreateCommittedResource3, Get(),
+//				return IIDToObjectForwardFunction<ID3D12Resource2>(&inner_type::CreateCommittedResource3, Get(),
 //					&pHeapProperties,
 //					HeapFlags,
 //					&pDesc,
@@ -1969,7 +1353,7 @@ namespace TypedD3D
 //				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
 //				std::span<DXGI_FORMAT> CastableFormats)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreatePlacedResource2, Get(),
+//				return IIDToObjectForwardFunction<ID3D12Resource2>(&inner_type::CreatePlacedResource2, Get(),
 //					&pHeap,
 //					HeapOffset,
 //					pDesc,
@@ -1986,7 +1370,7 @@ namespace TypedD3D
 //				ID3D12ProtectedResourceSession* pProtectedSession,
 //				std::span<DXGI_FORMAT> CastableFormats)
 //			{
-//				return IIDToObjectForwardFunction<ID3D12Resource1>(&value_type::CreateReservedResource2, Get(),
+//				return IIDToObjectForwardFunction<ID3D12Resource1>(&inner_type::CreateReservedResource2, Get(),
 //					pDesc,
 //					InitialLayout,
 //					pOptimizedClearValue,

--- a/TypedD3D/source/D3D12/D3D12Device.ixx
+++ b/TypedD3D/source/D3D12/D3D12Device.ixx
@@ -1,12 +1,13 @@
 module;
 
 #include <d3d12.h>
-#include <wrl/client.h>
+
 #include <vector>
 #include <memory>
 #include <dxgi1_6.h>
 #include <cassert>
 #include <span>
+#include <gsl/pointers>
 
 export module TypedD3D12:Device;
 export import TypedD3D.Shared;
@@ -17,11 +18,9 @@ export import :DescriptorHeap;
 export import :PipelineState;
 export import :Resource;
 
-import TypedD3D.Legacy.D3D12Helpers;
 
 namespace TypedD3D::D3D12
 {
-	using Microsoft::WRL::ComPtr;
 	struct MetaCommandParameterInfo
 	{
 		UINT totalStructureSizeInBytes;
@@ -211,43 +210,27 @@ namespace TypedD3D::D3D12
 	//{
 	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS11;
 	//};
-#pragma endregion
+}
 
-	export template<std::derived_from<ID3D12Device> DeviceTy>
-	using Device_t = IUnknownWrapper<DeviceTy, UntaggedTraits>;
-
-	template<class Ty>
-	struct DeviceTraits;
-
+namespace TypedD3D
+{
 	template<>
-	struct DeviceTraits<ID3D12Device>
+	struct UntaggedTraits<ID3D12Device>
 	{
-		using value_type = ID3D12Device;
-		using pointer = ID3D12Device*;
-		using const_pointer = const ID3D12Device*;
-		using reference = ID3D12Device&;
-		using const_reference = const ID3D12Device&;
-
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		struct Interface : InterfaceBase<UntaggedTraits<Derived>>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
 			UINT GetNodeCount()
 			{
-				return Get().GetNodeCount();
+				return Self().GetNodeCount();
 			}
 
 			template<D3D12_COMMAND_LIST_TYPE Type>
-			D3D12CommandQueue_t<Type> CreateCommandQueue(
+			StrongWrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandQueue>> CreateCommandQueue(
 				D3D12_COMMAND_QUEUE_PRIORITY priority,
 				D3D12_COMMAND_QUEUE_FLAGS flags,
 				UINT nodeMask)
 			{
-				using queue_type = D3D12CommandQueue_t<Type>;
-
 				D3D12_COMMAND_QUEUE_DESC desc
 				{
 					.Type = Type,
@@ -256,55 +239,50 @@ namespace TypedD3D::D3D12
 					.NodeMask = nodeMask
 				};
 
-				return Helpers::D3D12::CreateCommandQueue(Get(), desc);
+				return ForwardFunction<StrongWrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandQueue>>>(&ID3D12Device::CreateCommandQueue, Self(), &desc);
 			}
 
 			template<D3D12_COMMAND_LIST_TYPE Type>
-			CommandAllocator_t<Type> CreateCommandAllocator()
+			StrongWrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandAllocator>> CreateCommandAllocator()
 			{
-				using allocator_type = CommandAllocator_t<Type>;
-
-				return Helpers::D3D12::CreateCommandAllocator(Get(), Type);
+				return ForwardFunction<StrongWrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandAllocator>>>(&ID3D12Device::CreateCommandAllocator, Self(), Type);
 			}
 
 			Graphics<ID3D12PipelineState> CreateGraphicsPipelineState(
 				const D3D12_GRAPHICS_PIPELINE_STATE_DESC& pDesc)
 			{
-				return Helpers::D3D12::CreateGraphicsPipelineState(Get(), pDesc);
+				return ForwardFunction<Graphics<ID3D12PipelineState>>(&ID3D12Device::CreateGraphicsPipelineState, Self(), &pDesc);
 			}
 
 			Compute<ID3D12PipelineState> CreateComputePipelineState(
 				const D3D12_COMPUTE_PIPELINE_STATE_DESC& pDesc)
 			{
-				return Helpers::D3D12::CreateComputePipelineState(Get(), pDesc);
+				return ForwardFunction<Compute<ID3D12PipelineState>>(&ID3D12Device::CreateComputePipelineState, Self(), &pDesc);
 			}
 
 			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
-			CommandList_t<ListTy, Type> CreateCommandList(
-				CommandAllocator_t<Type> pCommandAllocator,
+			StrongWrapper<D3D12::CommandListTypeToTrait<Type, ListTy>> CreateCommandList(
+				WeakWrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandAllocator>> pCommandAllocator,
 				UINT nodeMask = 0,
 				ID3D12PipelineState* optInitialState = nullptr)
 			{
-				using command_list_type = CommandList_t<ListTy, Type>;
-				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, *pCommandAllocator.Get(), nodeMask, optInitialState);
+				return ForwardFunction<StrongWrapper<D3D12::CommandListTypeToTrait<Type, ListTy>>>(&ID3D12Device::CreateCommandList, Self(), nodeMask, Type, pCommandAllocator.Get(), optInitialState);
 			}
 
 			template<D3D12_FEATURE Feature>
-			typename DeviceFeatureMap<Feature>::type CheckFeatureSupport()
+			typename D3D12::DeviceFeatureMap<Feature>::type CheckFeatureSupport()
 			{
-				using feature_t = typename DeviceFeatureMap<Feature>::type;
+				using feature_t = typename D3D12::DeviceFeatureMap<Feature>::type;
 				feature_t feature{};
-				ThrowIfFailed(Get().CheckFeatureSupport(Feature, &feature, sizeof(feature_t)));
+				ThrowIfFailed(Self().CheckFeatureSupport(Feature, &feature, sizeof(feature_t)));
 				return feature;
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlag>
-			DescriptorHeap_t<Type, HeapFlag> CreateDescriptorHeap(
+			StrongWrapper<D3D12::HeapTypeToTrait<Type, HeapFlag, ID3D12DescriptorHeap>> CreateDescriptorHeap(
 				UINT NumDescriptors,
 				UINT NodeMask)
 			{
-				using DescriptorHeap_t = DescriptorHeap_t<Type, HeapFlag>;
-
 				D3D12_DESCRIPTOR_HEAP_DESC desc
 				{
 					.Type = Type,
@@ -313,29 +291,29 @@ namespace TypedD3D::D3D12
 					.NodeMask = NodeMask
 				};
 
-				return Helpers::D3D12::CreateDescriptorHeap(Get(), desc);
+				return ForwardFunction<StrongWrapper<D3D12::HeapTypeToTrait<Type, HeapFlag, ID3D12DescriptorHeap>>>(&ID3D12Device::CreateDescriptorHeap, Self(), &desc);
 			}
 
 			UINT GetDescriptorHandleIncrementSize(
 				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType)
 			{
-				return Get().GetDescriptorHandleIncrementSize(DescriptorHeapType);
+				return Self().GetDescriptorHandleIncrementSize(DescriptorHeapType);
 			}
 
-			ComPtr<ID3D12RootSignature> CreateRootSignature(
+			Wrapper<ID3D12RootSignature> CreateRootSignature(
 				UINT nodeMask,
 				const void* pBlobWithRootSignature,
 				SIZE_T blobLengthInBytes)
 			{
-				return Helpers::D3D12::CreateRootSignature(Get(), nodeMask, pBlobWithRootSignature, blobLengthInBytes);
+				return ForwardFunction<Wrapper<ID3D12RootSignature>>(&ID3D12Device::CreateRootSignature, Self(), nodeMask, pBlobWithRootSignature, blobLengthInBytes);
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
 			void CreateConstantBufferView(
 				const D3D12_CONSTANT_BUFFER_VIEW_DESC& pDesc,
-				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Get().CreateConstantBufferView(pDesc, DestDescriptor.Get());
+				Self().CreateConstantBufferView(pDesc, DestDescriptor.Raw());
 			}
 
 
@@ -343,17 +321,17 @@ namespace TypedD3D::D3D12
 			void CreateShaderResourceView(
 				ID3D12Resource& pResource,
 				const D3D12_SHADER_RESOURCE_VIEW_DESC* optDesc,
-				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Get().CreateShaderResourceView(&pResource, optDesc, DestDescriptor.Get());
+				Self().CreateShaderResourceView(&pResource, optDesc, DestDescriptor.Raw());
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
 			void CreateNullShaderResourceView(
 				const D3D12_SHADER_RESOURCE_VIEW_DESC& pDesc,
-				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Get().CreateShaderResourceView(nullptr, &pDesc, DestDescriptor.Get());
+				Self().CreateShaderResourceView(nullptr, &pDesc, DestDescriptor.Raw());
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
@@ -361,9 +339,9 @@ namespace TypedD3D::D3D12
 				ID3D12Resource& pResource,
 				ID3D12Resource& pCounterResource,
 				const D3D12_UNORDERED_ACCESS_VIEW_DESC& pDesc,
-				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Get().CreateUnorderedAccessView(&pResource, &pCounterResource, &pDesc, DestDescriptor.Get());
+				Self().CreateUnorderedAccessView(&pResource, &pCounterResource, &pDesc, DestDescriptor.Raw());
 			}
 
 			void CreateRenderTargetView(
@@ -371,14 +349,14 @@ namespace TypedD3D::D3D12
 				const D3D12_RENDER_TARGET_VIEW_DESC* optDesc,
 				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Get().CreateRenderTargetView(&Resource, optDesc, DestDescriptor.Get());
+				Self().CreateRenderTargetView(&Resource, optDesc, DestDescriptor.Raw());
 			}
 
 			void CreateNullRenderTargetView(
 				const D3D12_RENDER_TARGET_VIEW_DESC& Desc,
 				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Get().CreateRenderTargetView(nullptr, &Desc, DestDescriptor.Get());
+				Self().CreateRenderTargetView(nullptr, &Desc, DestDescriptor.Raw());
 			}
 
 			void CreateDepthStencilView(
@@ -386,22 +364,22 @@ namespace TypedD3D::D3D12
 				const D3D12_DEPTH_STENCIL_VIEW_DESC* optDesc,
 				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Get().CreateDepthStencilView(&Resource, optDesc, DestDescriptor.Get());
+				Self().CreateDepthStencilView(&Resource, optDesc, DestDescriptor.Raw());
 			}
 
 			void CreateNullDepthStencilView(
 				const D3D12_DEPTH_STENCIL_VIEW_DESC& optDesc,
 				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
 			{
-				Get().CreateDepthStencilView(nullptr, optDesc, DestDescriptor.Get());
+				Self().CreateDepthStencilView(nullptr, optDesc, DestDescriptor.Raw());
 			}
 
 			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
 			void CreateSampler(
 				const D3D12_SAMPLER_DESC& pDesc,
-				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, HeapFlags> DestDescriptor)
+				TypedStruct<D3D12::HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptor)
 			{
-				Get().CreateSampler(&pDesc, DestDescriptor.Get());
+				Self().CreateSampler(&pDesc, DestDescriptor.Raw());
 			}
 
 
@@ -414,7 +392,7 @@ namespace TypedD3D::D3D12
 				const UINT* pSrcDescriptorRangeSizes,
 				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType)
 			{
-				Get().CopyDescriptors(
+				Self().CopyDescriptors(
 					NumDestDescriptorRanges,
 					pDestDescriptorRangeStarts,
 					pDestDescriptorRangeSizes,
@@ -424,20 +402,20 @@ namespace TypedD3D::D3D12
 					DescriptorHeapsType);
 			}
 
-			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS DestinationFlag>
+			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS DestinationFlag, D3D12_DESCRIPTOR_HEAP_FLAGS SourceFlag>
 			void CopyDescriptorsSimple(
 				UINT NumDescriptors,
-				DescriptorHeap_t<Type, DestinationFlag>::CPU_DESCRIPTOR_HANDLE DestDescriptorRangeStart,
-				DescriptorHeap_t<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart)
+				TypedStruct<D3D12::HeapTypeToTrait<Type, DestinationFlag, D3D12_CPU_DESCRIPTOR_HANDLE>> DestDescriptorRangeStart,
+				TypedStruct<D3D12::HeapTypeToTrait<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE, D3D12_CPU_DESCRIPTOR_HANDLE>> SrcDescriptorRangeStart)
 			{
-				Get().CopyDescriptorsSimple(NumDescriptors, DestDescriptorRangeStart.Get(), SrcDescriptorRangeStart.Get(), Type);
+				Self().CopyDescriptorsSimple(NumDescriptors, DestDescriptorRangeStart.Raw(), SrcDescriptorRangeStart.Raw(), Type);
 			}
 
 			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo(
 				UINT visibleMask,
 				const std::span<D3D12_RESOURCE_DESC> resourceDescs)
 			{
-				return Get().GetResourceAllocationInfo(
+				return Self().GetResourceAllocationInfo(
 					visibleMask,
 					static_cast<UINT>(resourceDescs.size()),
 					resourceDescs.data());
@@ -447,7 +425,7 @@ namespace TypedD3D::D3D12
 				UINT nodeMask,
 				D3D12_HEAP_TYPE heapType)
 			{
-				return Get().GetCustomHeapProperties(nodeMask, heapType);
+				return Self().GetCustomHeapProperties(nodeMask, heapType);
 			}
 
 			Wrapper<ID3D12Resource> CreateCommittedResource(
@@ -457,35 +435,31 @@ namespace TypedD3D::D3D12
 				D3D12_RESOURCE_STATES InitialResourceState,
 				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
 			{
-				return Helpers::D3D12::CreateCommittedResource(
-					Get(),
-					pHeapProperties,
+				return ForwardFunction<Wrapper<ID3D12Resource>>(&ID3D12Device::CreateCommittedResource, Self(),
+					&pHeapProperties,
 					HeapFlags,
-					pDesc,
+					&pDesc,
 					InitialResourceState,
 					optOptimizedClearValue);
 			}
 
-			ComPtr<ID3D12Heap> CreateHeap(
+			Wrapper<ID3D12Heap> CreateHeap(
 				const D3D12_HEAP_DESC& pDesc)
 			{
-				return Helpers::D3D12::CreateHeap(
-					Get(),
-					pDesc);
+				return ForwardFunction<Wrapper<ID3D12Heap>>(&ID3D12Device::CreateHeap, Self(), &pDesc);
 			}
 
 			Wrapper<ID3D12Resource> CreatePlacedResource(
-				ID3D12Heap& pHeap,
+				gsl::not_null<WrapperView<ID3D12Heap>> pHeap,
 				UINT64 HeapOffset,
 				const D3D12_RESOURCE_DESC& pDesc,
 				D3D12_RESOURCE_STATES InitialState,
 				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
 			{
-				return Helpers::D3D12::CreatePlacedResource(
-					Get(),
-					pHeap,
+				return ForwardFunction<Wrapper<ID3D12Resource>>(&ID3D12Device::CreatePlacedResource, Self(),
+					pHeap.get().Get(),
 					HeapOffset,
-					pDesc,
+					&pDesc,
 					InitialState,
 					optOptimizedClearValue);
 			}
@@ -495,23 +469,22 @@ namespace TypedD3D::D3D12
 				D3D12_RESOURCE_STATES InitialState,
 				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
 			{
-				return Helpers::D3D12::CreateReservedResource(
-					Get(),
-					pDesc,
+				return ForwardFunction<Wrapper<ID3D12Resource>>(&ID3D12Device::CreateReservedResource, Self(),
+					&pDesc,
 					InitialState,
 					optOptimizedClearValue);
 			}
 
 			HANDLE CreateSharedHandle(
-				ID3D12DeviceChild& pObject,
+				gsl::not_null<ID3D12DeviceChild*> pObject,
 				const SECURITY_ATTRIBUTES* optAttributes,
 				DWORD Access,
 				LPCWSTR Name)
 			{
 				HANDLE handle;
 
-				ThrowIfFailed(Get().CreateSharedHandle(
-					&pObject,
+				ThrowIfFailed(Self().CreateSharedHandle(
+					pObject.get(),
 					optAttributes,
 					Access,
 					Name,
@@ -526,7 +499,7 @@ namespace TypedD3D::D3D12
 				const IID& riid,
 				void** ppvObj)
 			{
-				return Get().OpenSharedHandle(
+				return Self().OpenSharedHandle(
 					NTHandle,
 					riid,
 					ppvObj);
@@ -538,7 +511,7 @@ namespace TypedD3D::D3D12
 			{
 				HANDLE handle;
 
-				ThrowIfFailed(Get().OpenSharedHandleByName(
+				ThrowIfFailed(Self().OpenSharedHandleByName(
 					Name,
 					Access,
 					&handle));
@@ -549,7 +522,7 @@ namespace TypedD3D::D3D12
 			void MakeResident(
 				const std::span<ID3D12Pageable*> objects)
 			{
-				ThrowIfFailed(Get().MakeResident(
+				ThrowIfFailed(Self().MakeResident(
 					static_cast<UINT>(objects.size()),
 					objects.data()));
 			}
@@ -557,21 +530,21 @@ namespace TypedD3D::D3D12
 			void Evict(
 				const std::span<ID3D12Pageable*> objects)
 			{
-				ThrowIfFailed(Get().Evict(
+				ThrowIfFailed(Self().Evict(
 					static_cast<UINT>(objects.size()),
 					objects.data()));
 			}
 
-			ComPtr<ID3D12Fence> CreateFence(
+			Wrapper<ID3D12Fence> CreateFence(
 				UINT64 InitialValue,
 				D3D12_FENCE_FLAGS Flags)
 			{
-				return Helpers::D3D12::CreateFence(Get(), Flags, InitialValue);
+				return ForwardFunction<Wrapper<ID3D12Fence>>(&ID3D12Device::CreateFence, Self(), InitialValue, Flags);
 			}
 
 			HRESULT GetDeviceRemovedReason()
 			{
-				return Get().GetDeviceRemovedReason();
+				return Self().GetDeviceRemovedReason();
 			}
 
 			void GetCopyableFootprints(
@@ -584,7 +557,7 @@ namespace TypedD3D::D3D12
 				UINT64* optOutRowSizeInBytes,
 				UINT64* optOutTotalBytes)
 			{
-				Get().GetCopyableFootprints(
+				Self().GetCopyableFootprints(
 					&pResourceDesc,
 					FirstSubresource,
 					NumSubresources,
@@ -595,27 +568,27 @@ namespace TypedD3D::D3D12
 					optOutTotalBytes);
 			}
 
-			ComPtr<ID3D12QueryHeap> CreateQueryHeap(
+			Wrapper<ID3D12QueryHeap> CreateQueryHeap(
 				const D3D12_QUERY_HEAP_DESC& pDesc)
 			{
-				return Helpers::D3D12::CreateQueryHeap(Get(), pDesc);
+				return ForwardFunction<Wrapper<ID3D12QueryHeap>>(&ID3D12Device::CreateQueryHeap, Self(), &pDesc);
 			}
 
 			void SetStablePowerState(
 				BOOL Enable)
 			{
-				ThrowIfFailed(Get().SetStablePowerState(Enable));
+				ThrowIfFailed(Self().SetStablePowerState(Enable));
 			}
 
-			ComPtr<ID3D12CommandSignature> CreateCommandSignature(
+			Wrapper<ID3D12CommandSignature> CreateCommandSignature(
 				const D3D12_COMMAND_SIGNATURE_DESC& pDesc,
 				ID3D12RootSignature* optRootSignature)
 			{
-				return Helpers::D3D12::CreateCommandSignature(Get(), pDesc, optRootSignature);
+				return ForwardFunction<Wrapper<ID3D12CommandSignature>>(&ID3D12Device::CreateCommandSignature, Self(), &pDesc, optRootSignature);
 			}
 
 			void GetResourceTiling(
-				ID3D12Resource& pTiledResource,
+				gsl::not_null<WrapperView<ID3D12Resource>> pTiledResource,
 				UINT* optOutNumTilesForEntireResource,
 				D3D12_PACKED_MIP_INFO* optOutPackedMipDesc,
 				D3D12_TILE_SHAPE* optOutStandardTileShapeForNonPackedMips,
@@ -623,8 +596,8 @@ namespace TypedD3D::D3D12
 				UINT FirstSubresourceTilingToGet,
 				D3D12_SUBRESOURCE_TILING& pSubresourceTilingsForNonPackedMips)
 			{
-				Get().GetResourceTiling(
-					&pTiledResource,
+				Self().GetResourceTiling(
+					pTiledResource.get().Get(),
 					optOutNumTilesForEntireResource,
 					optOutPackedMipDesc,
 					optOutStandardTileShapeForNonPackedMips,
@@ -635,811 +608,1439 @@ namespace TypedD3D::D3D12
 
 			LUID GetAdapterLuid()
 			{
-				return Get().GetAdapterLuid();
+				return Self().GetAdapterLuid();
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
-
-	class SetEventOnMultipleFenceCompletionData
-	{
-		UINT count;
-		ID3D12Fence* const* fenceViews;
-		const UINT64* fenceValues;
-
-	public:
-		template<UINT Count>
-		SetEventOnMultipleFenceCompletionData(std::span<ID3D12Fence*, Count> fences, std::span<UINT64, Count> fenceValues) :
-			count{ Count },
-			fenceViews{ fences.data() },
-			fenceValues{ fenceValues.data() }
-		{
-
-		}
-
-		SetEventOnMultipleFenceCompletionData(UINT count, ID3D12Fence*const* fences, UINT64* fenceValues) :
-			count{ count },
-			fenceViews{ fences },
-			fenceValues{ fenceValues }
-		{
-
-		}
-
-	public:
-		UINT GetCount() const noexcept { return count; }
-		ID3D12Fence* const* GetFences() const noexcept { return fenceViews; }
-		const UINT64* GetFenceValues() const noexcept { return fenceValues; }
-	};
-
-	class SetResidencyPriorityData
-	{
-		UINT count;
-		ID3D12Pageable* const* pageables;
-		const D3D12_RESIDENCY_PRIORITY* priorities;
-
-	public:
-		template<UINT Count>
-		SetResidencyPriorityData(std::span<ID3D12Pageable*, Count> pageables, std::span<D3D12_RESIDENCY_PRIORITY, Count> priorities) :
-			count{ Count },
-			pageables{ pageables.data() },
-			priorities{ priorities.data() }
-		{
-
-		}
-
-		SetResidencyPriorityData(UINT count, ID3D12Pageable* const* pageables, D3D12_RESIDENCY_PRIORITY* priorities) :
-			count{ count },
-			pageables{ pageables },
-			priorities{ priorities }
-		{
-
-		}
-
-	public:
-		UINT GetCount() const noexcept { return count; }
-		ID3D12Pageable* const* GetPageables() const noexcept { return pageables; }
-		const D3D12_RESIDENCY_PRIORITY* GetPriorities() const noexcept { return priorities; }
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device1>
-	{
-		using value_type = ID3D12Device1;
-		using pointer = ID3D12Device1*;
-		using const_pointer = const ID3D12Device1*;
-		using reference = ID3D12Device1&;
-		using const_reference = const ID3D12Device1&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<ID3D12Device>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			ComPtr<ID3D12PipelineLibrary> CreatePipelineLibrary(
-				const void* pLibraryBlob,
-				SIZE_T BlobLength)
-			{
-				return IIDToObjectForwardFunction<ID3D12PipelineLibrary>(ID3D12Device1::CreatePipelineLibrary, Get(), pLibraryBlob, BlobLength);
-			}
-
-			void SetEventOnMultipleFenceCompletion(
-				SetEventOnMultipleFenceCompletionData data,
-				D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
-				HANDLE hEvent)
-			{
-
-				ThrowIfFailed(Get().SetEventOnMultipleFenceCompletion(
-					data.GetFences(),
-					data.GetFenceValues(),
-					data.GetCount(),
-					Flags,
-					hEvent));
-			}
-
-			void SetResidencyPriority(SetResidencyPriorityData data)
-			{
-				ThrowIfFailed(Get().SetResidencyPriority(
-					data.GetCount(),
-					data.GetPageables(),
-					data.GetPriorities()));
-			}
-
-			void SetResidencyPriority(ID3D12Pageable* page, D3D12_RESIDENCY_PRIORITY priority)
-			{
-				SetResidencyPriority({ 1, &page, &priority });
-			}
-
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device2>
-	{
-		using value_type = ID3D12Device2;
-		using pointer = ID3D12Device2*;
-		using const_pointer = const ID3D12Device2*;
-		using reference = ID3D12Device2&;
-		using const_reference = const ID3D12Device2&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<ID3D12Device1>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-
-			template<class Ty>
-			PipelineState_t<Ty> CreatePipelineState(
-				const D3D12_PIPELINE_STATE_STREAM_DESC pDesc)
-			{
-				return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device2::CreatePipelineState, Get(), &pDesc);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device3>
-	{
-		using value_type = ID3D12Device3;
-		using pointer = ID3D12Device3*;
-		using const_pointer = const ID3D12Device3*;
-		using reference = ID3D12Device3&;
-		using const_reference = const ID3D12Device3&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<ID3D12Device2>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			ComPtr<ID3D12Heap> OpenExistingHeapFromAddress(
-				const void* pAddress)
-			{
-				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromAddress, Get(), pAddress);
-			}
-
-			ComPtr<ID3D12Heap> OpenExistingHeapFromFileMapping(
-				HANDLE hFileMapping)
-			{
-				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromFileMapping, Get(), hFileMapping);
-			}
-
-			void EnqueueMakeResident(
-				D3D12_RESIDENCY_FLAGS Flags,
-				std::span<ID3D12Pageable*> ppObjects,
-				ID3D12Fence& pFenceToSignal,
-				UINT64 FenceValueToSignal)
-			{
-				ThrowIfFailed(Get().EnqueueMakeResident(
-					Flags,
-					static_cast<UINT>(ppObjects.size()),
-					ppObjects.data(),
-					&pFenceToSignal, FenceValueToSignal));
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device4>
-	{
-		using value_type = ID3D12Device4;
-		using pointer = ID3D12Device4*;
-		using const_pointer = const ID3D12Device4*;
-		using reference = ID3D12Device4&;
-		using const_reference = const ID3D12Device4&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<ID3D12Device3>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
-			CommandList_t<ListTy, Type> CreateCommandList1(
-				UINT nodeMask,
-				D3D12_COMMAND_LIST_FLAGS flags)
-			{
-				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, flags, nodeMask);
-			}
-
-			ComPtr<ID3D12ProtectedResourceSession> CreateProtectedResourceSession(
-				const D3D12_PROTECTED_RESOURCE_SESSION_DESC& pDesc)
-			{
-				return IIDToObjectForwardFunction<ID3D12ProtectedResourceSession>(&ID3D12Device4::CreateProtectedResourceSession, Get(), &pDesc);
-			}
-
-			Wrapper<ID3D12Resource> CreateCommittedResource1(
-				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-				D3D12_HEAP_FLAGS HeapFlags,
-				const D3D12_RESOURCE_DESC& pDesc,
-				D3D12_RESOURCE_STATES InitialResourceState,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				ID3D12ProtectedResourceSession* pProtectedSession)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource>(
-					&ID3D12Device4::CreateCommittedResource1,
-					Get(),
-					&pHeapProperties,
-					HeapFlags,
-					&pDesc,
-					InitialResourceState,
-					pOptimizedClearValue,
-					pProtectedSession);
-			}
-
-			ComPtr<ID3D12Heap> CreateHeap1(
-				const D3D12_HEAP_DESC& pDesc,
-				ID3D12ProtectedResourceSession* pProtectedSession)
-			{
-				return IIDToObjectForwardFunction<ID3D12Heap>(
-					&ID3D12Device4::CreateHeap1,
-					Get(),
-					&pDesc,
-					pProtectedSession);
-			}
-
-			Wrapper<ID3D12Resource> CreateReservedResource1(
-				const D3D12_RESOURCE_DESC& pDesc,
-				D3D12_RESOURCE_STATES InitialState,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				ID3D12ProtectedResourceSession* pProtectedSession)
-			{
-				return IIDToObjectForwardFunction<ID3D12Heap>(
-					&ID3D12Device4::CreateReservedResource1,
-					Get(),
-					&pDesc,
-					InitialState,
-					pOptimizedClearValue,
-					pProtectedSession);
-			}
-
-			std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> GetResourceAllocationInfo1(
-				UINT visibleMask,
-				std::span<const D3D12_RESOURCE_DESC> pResourceDescs)
-			{
-				std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> pResourceAllocationInfo1(pResourceDescs.size());
-				Get().GetResourceAllocationInfo1(visibleMask, static_cast<UINT>(pResourceDescs.size()), pResourceDescs.data(), pResourceAllocationInfo1.data());
-				return pResourceAllocationInfo1;
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device5>
-	{
-		using value_type = ID3D12Device5;
-		using pointer = ID3D12Device5*;
-		using const_pointer = const ID3D12Device5*;
-		using reference = ID3D12Device5&;
-		using const_reference = const ID3D12Device5&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<ID3D12Device4>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-		//TODO: Figure out how this works to update to a more modern API
-			void CreateLifetimeTracker(
-				ID3D12LifetimeOwner& pOwner,
-				REFIID riid,
-				void** ppvTracker)
-			{
-				ThrowIfFailed(Get().CreateLifetimeTracker(&pOwner, riid, ppvTracker));
-			}
-
-			void RemoveDevice()
-			{
-				Get().RemoveDevice();
-			}
-
-			UINT GetNumMetaCommands()
-			{
-				UINT pNumMetaCommands = 0;
-				Get().EnumerateMetaCommands(&pNumMetaCommands, nullptr);
-				return pNumMetaCommands;
-			}
-
-			std::vector<D3D12_META_COMMAND_DESC> EnumerateMetaCommands(
-				UINT pNumMetaCommands)
-			{
-				std::vector<D3D12_META_COMMAND_DESC> pDescs(pNumMetaCommands);
-				ThrowIfFailed(Get().EnumerateMetaCommands(&pNumMetaCommands, pDescs.data()));
-				return pDescs;
-			}
-
-			UINT GetNumMetaCommandParameters(
-				REFGUID CommandId,
-				D3D12_META_COMMAND_PARAMETER_STAGE Stage)
-			{
-				UINT pNumMetaCommandParams = 0;
-				Get().EnumerateMetaCommandParameters(CommandId, Stage, nullptr, &pNumMetaCommandParams, nullptr);
-				return pNumMetaCommandParams;
-			}
-
-			MetaCommandParameterInfo STDMETHODCALLTYPE EnumerateMetaCommandParameters(
-				_In_  REFGUID CommandId,
-				_In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
-				UINT parameterCount)
-			{
-				MetaCommandParameterInfo info{};
-
-				info.parameterCount = parameterCount;
-				info.parameterDescs.resize(parameterCount);
-
-				ThrowIfFailed(Get().EnumerateMetaCommandParameters(
-					CommandId,
-					Stage,
-					&info.totalStructureSizeInBytes,
-					&info.parameterCount,
-					info.parameterDescs.data()));
-
-				return info;
-			}
-
-			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-				REFGUID CommandId,
-				UINT NodeMask,
-				const void* pCreationParametersData,
-				SIZE_T CreationParametersDataSizeInBytes)
-			{
-				return IIDToObjectForwardFunction<ID3D12MetaCommand>(
-					&ID3D12Device5::CreateMetaCommand,
-					Get(),
-					CommandId,
-					NodeMask,
-					pCreationParametersData,
-					CreationParametersDataSizeInBytes);
-			}
-
-			template<class CreationParamStruct>
-			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-				REFGUID CommandId,
-				UINT NodeMask,
-				const CreationParamStruct& pCreationParametersData)
-			{
-				return CreateMetaCommand(CommandId, NodeMask, &pCreationParametersData, sizeof(CreationParamStruct));
-			}
-
-			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-				REFGUID CommandId,
-				UINT NodeMask)
-			{
-				return CreateMetaCommand(CommandId, NodeMask, nullptr, 0);
-			}
-
-			ComPtr<ID3D12StateObject> CreateStateObject(
-				const D3D12_STATE_OBJECT_DESC& pDesc)
-			{
-				return IIDToObjectForwardFunction<ID3D12StateObject>(
-					&ID3D12Device5::CreateStateObject,
-					Get(),
-					&pDesc);
-			}
-
-			D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO GetRaytracingAccelerationStructurePrebuildInfo(
-				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& pDesc)
-			{
-				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
-				Get().GetRaytracingAccelerationStructurePrebuildInfo(&pDesc, &prebuildInfo);
-				return prebuildInfo;
-			}
-
-			D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS CheckDriverMatchingIdentifier(
-				D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
-				const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER& pIdentifierToCheck)
-			{
-				return Get().CheckDriverMatchingIdentifier(
-					SerializedDataType,
-					&pIdentifierToCheck);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device6>
-	{
-		using base_value_type = ID3D12Device5;
-		using value_type = ID3D12Device6;
-		using pointer = ID3D12Device6*;
-		using const_pointer = const ID3D12Device6*;
-		using reference = ID3D12Device6&;
-		using const_reference = const ID3D12Device6&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-		//TODO: Figure out how this works to update to a more modern API
-			HRESULT SetBackgroundProcessingMode(
-				D3D12_BACKGROUND_PROCESSING_MODE Mode,
-				D3D12_MEASUREMENTS_ACTION MeasurementsAction,
-				_In_opt_  HANDLE hEventToSignalUponCompletion,
-				_Out_opt_  BOOL* pbFurtherMeasurementsDesired)
-			{
-				return Get().SetBackgroundProcessingMode(
-					Mode,
-					MeasurementsAction,
-					hEventToSignalUponCompletion,
-					pbFurtherMeasurementsDesired);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device7>
-	{
-		using base_value_type = ID3D12Device6;
-		using value_type = ID3D12Device7;
-		using pointer = ID3D12Device7*;
-		using const_pointer = const ID3D12Device7*;
-		using reference = ID3D12Device7&;
-		using const_reference = const ID3D12Device7&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			//TODO: Figure out how this works to update to a more modern API
-			HRESULT AddToStateObject(
-				const D3D12_STATE_OBJECT_DESC* pAddition,
-				ID3D12StateObject* pStateObjectToGrowFrom,
-				REFIID riid,
-				_COM_Outptr_  void** ppNewStateObject)
-			{
-				return Get().AddToStateObject(
-					pAddition,
-					pStateObjectToGrowFrom,
-					riid,
-					ppNewStateObject);
-			}
-
-			//TODO: Figure out how this works to update to a more modern API
-			HRESULT CreateProtectedResourceSession1(
-				const D3D12_PROTECTED_RESOURCE_SESSION_DESC1* pDesc,
-				REFIID riid,
-				void** ppSession)
-			{
-				return Get().CreateProtectedResourceSession1(
-					pDesc,
-					riid,
-					ppSession);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device8>
-	{
-		using base_value_type = ID3D12Device7;
-		using value_type = ID3D12Device8;
-		using pointer = ID3D12Device8*;
-		using const_pointer = const ID3D12Device8*;
-		using reference = ID3D12Device8&;
-		using const_reference = const ID3D12Device8&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-#if defined(_MSC_VER) || !defined(_WIN32)
-			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo2(
-				UINT visibleMask,
-				UINT numResourceDescs,
-				const D3D12_RESOURCE_DESC1* pResourceDescs,
-				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
-			{
-				return Get().GetResourceAllocationInfo2(visibleMask,
-					numResourceDescs,
-					pResourceDescs,
-					pResourceAllocationInfo1);
-			}
-#else
-			D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE GetResourceAllocationInfo2(
-				D3D12_RESOURCE_ALLOCATION_INFO* RetVal,
-				UINT visibleMask,
-				UINT numResourceDescs,
-				const D3D12_RESOURCE_DESC1* pResourceDescs,
-				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
-			{
-				return Get().GetResourceAllocationInfo2(RetVal,
-					visibleMask,
-					numResourceDescs,
-					pResourceDescs,
-					pResourceAllocationInfo1);
-			}
-#endif
-
-			TypedD3D::Wrapper<ID3D12Resource> CreateCommittedResource2(
-				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-				D3D12_HEAP_FLAGS HeapFlags,
-				const D3D12_RESOURCE_DESC1& pDesc,
-				D3D12_RESOURCE_STATES InitialResourceState,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				ID3D12ProtectedResourceSession* pProtectedSession)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreateCommittedResource2, Get(),
-					&pHeapProperties,
-					HeapFlags,
-					&pDesc,
-					InitialResourceState,
-					pOptimizedClearValue,
-					pProtectedSession);
-			}
-
-			TypedD3D::Wrapper<ID3D12Resource> CreatePlacedResource1(
-				ID3D12Heap& pHeap,
-				UINT64 HeapOffset,
-				const D3D12_RESOURCE_DESC& pDesc,
-				D3D12_RESOURCE_STATES InitialState,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreatePlacedResource1, Get(),
-					&pHeap,
-					HeapOffset,
-					&pDesc,
-					InitialState,
-					pOptimizedClearValue);
-			}
-
-			void CreateSamplerFeedbackUnorderedAccessView(
-				ID3D12Resource* pTargetedResource,
-				ID3D12Resource* pFeedbackResource,
-				D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
-			{
-				Get().CreateSamplerFeedbackUnorderedAccessView(
-					pTargetedResource,
-					pFeedbackResource,
-					DestDescriptor);
-			}
-
-			void GetCopyableFootprints1(
-				const D3D12_RESOURCE_DESC1& pResourceDesc,
-				UINT FirstSubresource,
-				UINT NumSubresources,
-				UINT64 BaseOffset,
-				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
-				UINT* pNumRows,
-				UINT64* pRowSizeInBytes,
-				UINT64* pTotalBytes)
-			{
-				Get().GetCopyableFootprints1(
-					&pResourceDesc,
-					FirstSubresource,
-					NumSubresources,
-					BaseOffset,
-					pLayouts,
-					pNumRows,
-					pRowSizeInBytes,
-					pTotalBytes);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device9>
-	{
-		using base_value_type = ID3D12Device8;
-		using value_type = ID3D12Device9;
-		using pointer = ID3D12Device9*;
-		using const_pointer = const ID3D12Device9*;
-		using reference = ID3D12Device9&;
-		using const_reference = const ID3D12Device9&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			ComPtr<ID3D12ShaderCacheSession> CreateShaderCacheSession(
-				const D3D12_SHADER_CACHE_SESSION_DESC& pDesc)
-			{
-				return IIDToObjectForwardFunction<ID3D12ShaderCacheSession>(&value_type::CreateShaderCacheSession, Get(), &pDesc);
-			}
-
-			HRESULT ShaderCacheControl(
-				D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
-				D3D12_SHADER_CACHE_CONTROL_FLAGS Control)
-			{
-				return Get().ShaderCacheControl(Kinds, Control);
-			}
-
-			template<D3D12_COMMAND_LIST_TYPE Type>
-			D3D12CommandQueue_t<Type> CreateCommandQueue1(
-				D3D12_COMMAND_QUEUE_PRIORITY priority,
-				D3D12_COMMAND_QUEUE_FLAGS flags,
-				UINT nodeMask,
-				REFIID CreatorID)
-			{
-				using queue_type = D3D12CommandQueue_t<Type>;
-
-				D3D12_COMMAND_QUEUE_DESC desc
-				{
-					.Type = Type,
-					.Priority = priority,
-					.Flags = flags,
-					.NodeMask = nodeMask
-				};
-
-				return IIDToObjectForwardFunction<ID3D12CommandQueue>(&value_type::CreateCommandQueue1, Get(), &desc, CreatorID);
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	template<>
-	struct DeviceTraits<ID3D12Device10>
-	{
-		using base_value_type = ID3D12Device9;
-		using value_type = ID3D12Device10;
-		using pointer = ID3D12Device10*;
-		using const_pointer = const ID3D12Device10*;
-		using reference = ID3D12Device10&;
-		using const_reference = const ID3D12Device10&;
-
-		template<class DerivedSelf>
-		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-		{
-		private:
-			using derived_self = DerivedSelf;
-
-		public:
-			TypedD3D::Wrapper<ID3D12Resource2> CreateCommittedResource3(
-				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-				D3D12_HEAP_FLAGS HeapFlags,
-				const D3D12_RESOURCE_DESC1& pDesc,
-				D3D12_BARRIER_LAYOUT InitialLayout,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				ID3D12ProtectedResourceSession* pProtectedSession,
-				std::span<DXGI_FORMAT> CastableFormats)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreateCommittedResource3, Get(),
-					&pHeapProperties,
-					HeapFlags,
-					&pDesc,
-					InitialLayout,
-					pOptimizedClearValue,
-					pProtectedSession,
-					static_cast<UINT32>(CastableFormats.size()),
-					CastableFormats.data());
-			}
-
-			TypedD3D::Wrapper<ID3D12Resource2> CreatePlacedResource2(
-				ID3D12Heap& pHeap,
-				UINT64 HeapOffset,
-				const D3D12_RESOURCE_DESC1& pDesc,
-				D3D12_BARRIER_LAYOUT InitialLayout,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				std::span<DXGI_FORMAT> CastableFormats)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreatePlacedResource2, Get(),
-					&pHeap,
-					HeapOffset,
-					pDesc,
-					InitialLayout,
-					pOptimizedClearValue,
-					static_cast<UINT32>(CastableFormats.size()),
-					CastableFormats.data());
-			}
-
-			TypedD3D::Wrapper<ID3D12Resource1> CreateReservedResource2(
-				const D3D12_RESOURCE_DESC& pDesc,
-				D3D12_BARRIER_LAYOUT InitialLayout,
-				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-				ID3D12ProtectedResourceSession* pProtectedSession,
-				std::span<DXGI_FORMAT> CastableFormats)
-			{
-				return IIDToObjectForwardFunction<ID3D12Resource1>(&value_type::CreateReservedResource2, Get(),
-					pDesc,
-					InitialLayout,
-					pOptimizedClearValue,
-					pProtectedSession,
-					static_cast<UINT32>(CastableFormats.size()),
-					CastableFormats.data());
-			}
-
-		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
-		};
-	};
-
-	namespace Aliases
-	{
-		export using Device = Device_t<ID3D12Device>;
-		export using Device1 = Device_t<ID3D12Device1>;
-		export using Device2 = Device_t<ID3D12Device2>;
-		export using Device3 = Device_t<ID3D12Device3>;
-		export using Device4 = Device_t<ID3D12Device4>;
-		export using Device5 = Device_t<ID3D12Device5>;
-		export using Device6 = Device_t<ID3D12Device6>;
-		export using Device7 = Device_t<ID3D12Device7>;
-		export using Device8 = Device_t<ID3D12Device8>;
-		export using Device9 = Device_t<ID3D12Device9>;
-		export using Device10 = Device_t<ID3D12Device10>;
-	}
-
-	export template<class DeviceTy = Aliases::Device>
-	Device_t<DeviceTy> CreateDevice(D3D_FEATURE_LEVEL minimumFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
-	{
-		if constexpr(std::is_base_of_v<ID3D12Device, DeviceTy>)
-		{
-			return Helpers::D3D12::CreateDevice<DeviceTy>(minimumFeatureLevel, optAdapter);
-		}
-		else
-		{
-			return Helpers::D3D12::CreateDevice<typename DeviceTy::value_type>(minimumFeatureLevel, optAdapter);
-		}
-	}
 }
 
-namespace TypedD3D
-{
-	template<std::derived_from<ID3D12Device> Ty>
-	struct UntaggedTraits<Ty>
-	{
-		using value_type = Ty;
-		using pointer = Ty*;
-		using const_pointer = const Ty*;
-		using reference = Ty&;
-		using const_reference = const Ty&;
-
-		template<class DerivedSelf>
-		using Interface = typename D3D12::DeviceTraits<Ty>::template Interface<DerivedSelf>;
-	};
-}
+//import TypedD3D.Legacy.D3D12Helpers;
+//
+//namespace TypedD3D::D3D12
+//{
+//	using Microsoft::WRL::ComPtr;
+//	struct MetaCommandParameterInfo
+//	{
+//		UINT totalStructureSizeInBytes;
+//		UINT parameterCount;
+//		std::vector<D3D12_META_COMMAND_PARAMETER_DESC> parameterDescs;
+//	};
+//
+//#pragma region Device Feature Map
+//	template<D3D12_FEATURE Feature>
+//	struct DeviceFeatureMap;
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_ARCHITECTURE>
+//	{
+//		using type = D3D12_FEATURE_DATA_ARCHITECTURE;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_FEATURE_LEVELS>
+//	{
+//		using type = D3D12_FEATURE_DATA_FEATURE_LEVELS;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_FORMAT_SUPPORT>
+//	{
+//		using type = D3D12_FEATURE_DATA_FORMAT_INFO;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_GPU_VIRTUAL_ADDRESS_SUPPORT>
+//	{
+//		using type = D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_SHADER_MODEL>
+//	{
+//		using type = D3D12_FEATURE_DATA_SHADER_MODEL;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS1>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS1;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_SUPPORT>
+//	{
+//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_ROOT_SIGNATURE>
+//	{
+//		using type = D3D12_FEATURE_DATA_ROOT_SIGNATURE;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_ARCHITECTURE1>
+//	{
+//		using type = D3D12_FEATURE_DATA_ARCHITECTURE1;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS2>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS2;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_SHADER_CACHE>
+//	{
+//		using type = D3D12_FEATURE_DATA_SHADER_CACHE;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_COMMAND_QUEUE_PRIORITY>
+//	{
+//		using type = D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS3>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS3;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_EXISTING_HEAPS>
+//	{
+//		using type = D3D12_FEATURE_DATA_EXISTING_HEAPS;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS4>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS4;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_SERIALIZATION>
+//	{
+//		using type = D3D12_FEATURE_DATA_SERIALIZATION;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_CROSS_NODE>
+//	{
+//		using type = D3D12_FEATURE_DATA_CROSS_NODE;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS5>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS5;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS6>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS6;
+//	};
+//
+//	//Requires Windows 11
+//	//template<>
+//	//struct DeviceFeatureMap<D3D12_FEATURE_DISPLAYABLE>
+//	//{
+//	//    using type = D3D12_FEATURE_DATA_DISPLAYABLE;
+//	//};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_QUERY_META_COMMAND>
+//	{
+//		using type = D3D12_FEATURE_DATA_QUERY_META_COMMAND;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS7>
+//	{
+//		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS7;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPE_COUNT>
+//	{
+//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT;
+//	};
+//
+//	template<>
+//	struct DeviceFeatureMap<D3D12_FEATURE_PROTECTED_RESOURCE_SESSION_TYPES>
+//	{
+//		using type = D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES;
+//	};
+//
+//	//Requires Windows 11
+//	//template<>
+//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS8>
+//	//{
+//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS8;
+//	//};
+//
+//	//Requires Windows 11
+//	//template<>
+//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS9>
+//	//{
+//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS9;
+//	//};
+//
+//	//Requires Windows 11
+//	//template<>
+//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS10>
+//	//{
+//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS10;
+//	//};
+//
+//	//Requires Windows 11
+//	//template<>
+//	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS11>
+//	//{
+//	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS11;
+//	//};
+//#pragma endregion
+//
+//	export template<std::derived_from<ID3D12Device> DeviceTy>
+//	using Device_t = IUnknownWrapper<DeviceTy, UntaggedTraits>;
+//
+//	template<class Ty>
+//	struct DeviceTraits;
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device>
+//	{
+//		using value_type = ID3D12Device;
+//		using pointer = ID3D12Device*;
+//		using const_pointer = const ID3D12Device*;
+//		using reference = ID3D12Device&;
+//		using const_reference = const ID3D12Device&;
+//
+//		template<class DerivedSelf>
+//		class Interface
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			UINT GetNodeCount()
+//			{
+//				return Self().GetNodeCount();
+//			}
+//
+//			template<D3D12_COMMAND_LIST_TYPE Type>
+//			D3D12CommandQueue_t<Type> CreateCommandQueue(
+//				D3D12_COMMAND_QUEUE_PRIORITY priority,
+//				D3D12_COMMAND_QUEUE_FLAGS flags,
+//				UINT nodeMask)
+//			{
+//				using queue_type = D3D12CommandQueue_t<Type>;
+//
+//				D3D12_COMMAND_QUEUE_DESC desc
+//				{
+//					.Type = Type,
+//					.Priority = priority,
+//					.Flags = flags,
+//					.NodeMask = nodeMask
+//				};
+//
+//				return Helpers::D3D12::CreateCommandQueue(Get(), desc);
+//			}
+//
+//			template<D3D12_COMMAND_LIST_TYPE Type>
+//			CommandAllocator_t<Type> CreateCommandAllocator()
+//			{
+//				using allocator_type = CommandAllocator_t<Type>;
+//
+//				return Helpers::D3D12::CreateCommandAllocator(Get(), Type);
+//			}
+//
+//			Graphics<ID3D12PipelineState> CreateGraphicsPipelineState(
+//				const D3D12_GRAPHICS_PIPELINE_STATE_DESC& pDesc)
+//			{
+//				return Helpers::D3D12::CreateGraphicsPipelineState(Get(), pDesc);
+//			}
+//
+//			Compute<ID3D12PipelineState> CreateComputePipelineState(
+//				const D3D12_COMPUTE_PIPELINE_STATE_DESC& pDesc)
+//			{
+//				return Helpers::D3D12::CreateComputePipelineState(Get(), pDesc);
+//			}
+//
+//			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
+//			CommandList_t<ListTy, Type> CreateCommandList(
+//				CommandAllocator_t<Type> pCommandAllocator,
+//				UINT nodeMask = 0,
+//				ID3D12PipelineState* optInitialState = nullptr)
+//			{
+//				using command_list_type = CommandList_t<ListTy, Type>;
+//				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, *pCommandAllocator.Get(), nodeMask, optInitialState);
+//			}
+//
+//			template<D3D12_FEATURE Feature>
+//			typename DeviceFeatureMap<Feature>::type CheckFeatureSupport()
+//			{
+//				using feature_t = typename DeviceFeatureMap<Feature>::type;
+//				feature_t feature{};
+//				ThrowIfFailed(Self().CheckFeatureSupport(Feature, &feature, sizeof(feature_t)));
+//				return feature;
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlag>
+//			DescriptorHeap_t<Type, HeapFlag> CreateDescriptorHeap(
+//				UINT NumDescriptors,
+//				UINT NodeMask)
+//			{
+//				using DescriptorHeap_t = DescriptorHeap_t<Type, HeapFlag>;
+//
+//				D3D12_DESCRIPTOR_HEAP_DESC desc
+//				{
+//					.Type = Type,
+//					.NumDescriptors = NumDescriptors,
+//					.Flags = HeapFlag,
+//					.NodeMask = NodeMask
+//				};
+//
+//				return Helpers::D3D12::CreateDescriptorHeap(Get(), desc);
+//			}
+//
+//			UINT GetDescriptorHandleIncrementSize(
+//				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapType)
+//			{
+//				return Self().GetDescriptorHandleIncrementSize(DescriptorHeapType);
+//			}
+//
+//			ComPtr<ID3D12RootSignature> CreateRootSignature(
+//				UINT nodeMask,
+//				const void* pBlobWithRootSignature,
+//				SIZE_T blobLengthInBytes)
+//			{
+//				return Helpers::D3D12::CreateRootSignature(Get(), nodeMask, pBlobWithRootSignature, blobLengthInBytes);
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//			void CreateConstantBufferView(
+//				const D3D12_CONSTANT_BUFFER_VIEW_DESC& pDesc,
+//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+//			{
+//				Self().CreateConstantBufferView(pDesc, DestDescriptor.Get());
+//			}
+//
+//
+//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//			void CreateShaderResourceView(
+//				ID3D12Resource& pResource,
+//				const D3D12_SHADER_RESOURCE_VIEW_DESC* optDesc,
+//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+//			{
+//				Self().CreateShaderResourceView(&pResource, optDesc, DestDescriptor.Get());
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//			void CreateNullShaderResourceView(
+//				const D3D12_SHADER_RESOURCE_VIEW_DESC& pDesc,
+//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+//			{
+//				Self().CreateShaderResourceView(nullptr, &pDesc, DestDescriptor.Get());
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//			void CreateUnorderedAccessView(
+//				ID3D12Resource& pResource,
+//				ID3D12Resource& pCounterResource,
+//				const D3D12_UNORDERED_ACCESS_VIEW_DESC& pDesc,
+//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, HeapFlags> DestDescriptor)
+//			{
+//				Self().CreateUnorderedAccessView(&pResource, &pCounterResource, &pDesc, DestDescriptor.Get());
+//			}
+//
+//			void CreateRenderTargetView(
+//				ID3D12Resource& Resource,
+//				const D3D12_RENDER_TARGET_VIEW_DESC* optDesc,
+//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
+//			{
+//				Self().CreateRenderTargetView(&Resource, optDesc, DestDescriptor.Get());
+//			}
+//
+//			void CreateNullRenderTargetView(
+//				const D3D12_RENDER_TARGET_VIEW_DESC& Desc,
+//				RTV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
+//			{
+//				Self().CreateRenderTargetView(nullptr, &Desc, DestDescriptor.Get());
+//			}
+//
+//			void CreateDepthStencilView(
+//				ID3D12Resource& Resource,
+//				const D3D12_DEPTH_STENCIL_VIEW_DESC* optDesc,
+//				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
+//			{
+//				Self().CreateDepthStencilView(&Resource, optDesc, DestDescriptor.Get());
+//			}
+//
+//			void CreateNullDepthStencilView(
+//				const D3D12_DEPTH_STENCIL_VIEW_DESC& optDesc,
+//				DSV<D3D12_CPU_DESCRIPTOR_HANDLE> DestDescriptor)
+//			{
+//				Self().CreateDepthStencilView(nullptr, optDesc, DestDescriptor.Get());
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//			void CreateSampler(
+//				const D3D12_SAMPLER_DESC& pDesc,
+//				CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, HeapFlags> DestDescriptor)
+//			{
+//				Self().CreateSampler(&pDesc, DestDescriptor.Get());
+//			}
+//
+//
+//			void CopyDescriptors(
+//				UINT NumDestDescriptorRanges,
+//				const D3D12_CPU_DESCRIPTOR_HANDLE* pDestDescriptorRangeStarts,
+//				const UINT* pDestDescriptorRangeSizes,
+//				UINT NumSrcDescriptorRanges,
+//				const D3D12_CPU_DESCRIPTOR_HANDLE* pSrcDescriptorRangeStarts,
+//				const UINT* pSrcDescriptorRangeSizes,
+//				D3D12_DESCRIPTOR_HEAP_TYPE DescriptorHeapsType)
+//			{
+//				Self().CopyDescriptors(
+//					NumDestDescriptorRanges,
+//					pDestDescriptorRangeStarts,
+//					pDestDescriptorRangeSizes,
+//					NumSrcDescriptorRanges,
+//					pSrcDescriptorRangeStarts,
+//					pSrcDescriptorRangeSizes,
+//					DescriptorHeapsType);
+//			}
+//
+//			template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS DestinationFlag>
+//			void CopyDescriptorsSimple(
+//				UINT NumDescriptors,
+//				DescriptorHeap_t<Type, DestinationFlag>::CPU_DESCRIPTOR_HANDLE DestDescriptorRangeStart,
+//				DescriptorHeap_t<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::CPU_DESCRIPTOR_HANDLE SrcDescriptorRangeStart)
+//			{
+//				Self().CopyDescriptorsSimple(NumDescriptors, DestDescriptorRangeStart.Get(), SrcDescriptorRangeStart.Get(), Type);
+//			}
+//
+//			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo(
+//				UINT visibleMask,
+//				const std::span<D3D12_RESOURCE_DESC> resourceDescs)
+//			{
+//				return Self().GetResourceAllocationInfo(
+//					visibleMask,
+//					static_cast<UINT>(resourceDescs.size()),
+//					resourceDescs.data());
+//			}
+//
+//			D3D12_HEAP_PROPERTIES GetCustomHeapProperties(
+//				UINT nodeMask,
+//				D3D12_HEAP_TYPE heapType)
+//			{
+//				return Self().GetCustomHeapProperties(nodeMask, heapType);
+//			}
+//
+//			Wrapper<ID3D12Resource> CreateCommittedResource(
+//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+//				D3D12_HEAP_FLAGS HeapFlags,
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialResourceState,
+//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+//			{
+//				return Helpers::D3D12::CreateCommittedResource(
+//					Get(),
+//					pHeapProperties,
+//					HeapFlags,
+//					pDesc,
+//					InitialResourceState,
+//					optOptimizedClearValue);
+//			}
+//
+//			ComPtr<ID3D12Heap> CreateHeap(
+//				const D3D12_HEAP_DESC& pDesc)
+//			{
+//				return Helpers::D3D12::CreateHeap(
+//					Get(),
+//					pDesc);
+//			}
+//
+//			Wrapper<ID3D12Resource> CreatePlacedResource(
+//				ID3D12Heap& pHeap,
+//				UINT64 HeapOffset,
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialState,
+//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+//			{
+//				return Helpers::D3D12::CreatePlacedResource(
+//					Get(),
+//					pHeap,
+//					HeapOffset,
+//					pDesc,
+//					InitialState,
+//					optOptimizedClearValue);
+//			}
+//
+//			Wrapper<ID3D12Resource> CreateReservedResource(
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialState,
+//				const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+//			{
+//				return Helpers::D3D12::CreateReservedResource(
+//					Get(),
+//					pDesc,
+//					InitialState,
+//					optOptimizedClearValue);
+//			}
+//
+//			HANDLE CreateSharedHandle(
+//				ID3D12DeviceChild& pObject,
+//				const SECURITY_ATTRIBUTES* optAttributes,
+//				DWORD Access,
+//				LPCWSTR Name)
+//			{
+//				HANDLE handle;
+//
+//				ThrowIfFailed(Self().CreateSharedHandle(
+//					&pObject,
+//					optAttributes,
+//					Access,
+//					Name,
+//					&handle));
+//
+//				return handle;
+//			}
+//
+//			  //TODO: Figure out how this works to update to a more modern API
+//			HRESULT OpenSharedHandle(
+//				HANDLE NTHandle,
+//				const IID& riid,
+//				void** ppvObj)
+//			{
+//				return Self().OpenSharedHandle(
+//					NTHandle,
+//					riid,
+//					ppvObj);
+//			}
+//
+//			HANDLE OpenSharedHandleByName(
+//				LPCWSTR Name,
+//				DWORD Access)
+//			{
+//				HANDLE handle;
+//
+//				ThrowIfFailed(Self().OpenSharedHandleByName(
+//					Name,
+//					Access,
+//					&handle));
+//
+//				return handle;
+//			}
+//
+//			void MakeResident(
+//				const std::span<ID3D12Pageable*> objects)
+//			{
+//				ThrowIfFailed(Self().MakeResident(
+//					static_cast<UINT>(objects.size()),
+//					objects.data()));
+//			}
+//
+//			void Evict(
+//				const std::span<ID3D12Pageable*> objects)
+//			{
+//				ThrowIfFailed(Self().Evict(
+//					static_cast<UINT>(objects.size()),
+//					objects.data()));
+//			}
+//
+//			ComPtr<ID3D12Fence> CreateFence(
+//				UINT64 InitialValue,
+//				D3D12_FENCE_FLAGS Flags)
+//			{
+//				return Helpers::D3D12::CreateFence(Get(), Flags, InitialValue);
+//			}
+//
+//			HRESULT GetDeviceRemovedReason()
+//			{
+//				return Self().GetDeviceRemovedReason();
+//			}
+//
+//			void GetCopyableFootprints(
+//				const D3D12_RESOURCE_DESC& pResourceDesc,
+//				UINT FirstSubresource,
+//				UINT NumSubresources,
+//				UINT64 BaseOffset,
+//				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* optOutLayouts,
+//				UINT* optOutNumRows,
+//				UINT64* optOutRowSizeInBytes,
+//				UINT64* optOutTotalBytes)
+//			{
+//				Self().GetCopyableFootprints(
+//					&pResourceDesc,
+//					FirstSubresource,
+//					NumSubresources,
+//					BaseOffset,
+//					optOutLayouts,
+//					optOutNumRows,
+//					optOutRowSizeInBytes,
+//					optOutTotalBytes);
+//			}
+//
+//			ComPtr<ID3D12QueryHeap> CreateQueryHeap(
+//				const D3D12_QUERY_HEAP_DESC& pDesc)
+//			{
+//				return Helpers::D3D12::CreateQueryHeap(Get(), pDesc);
+//			}
+//
+//			void SetStablePowerState(
+//				BOOL Enable)
+//			{
+//				ThrowIfFailed(Self().SetStablePowerState(Enable));
+//			}
+//
+//			ComPtr<ID3D12CommandSignature> CreateCommandSignature(
+//				const D3D12_COMMAND_SIGNATURE_DESC& pDesc,
+//				ID3D12RootSignature* optRootSignature)
+//			{
+//				return Helpers::D3D12::CreateCommandSignature(Get(), pDesc, optRootSignature);
+//			}
+//
+//			void GetResourceTiling(
+//				ID3D12Resource& pTiledResource,
+//				UINT* optOutNumTilesForEntireResource,
+//				D3D12_PACKED_MIP_INFO* optOutPackedMipDesc,
+//				D3D12_TILE_SHAPE* optOutStandardTileShapeForNonPackedMips,
+//				UINT* pNumSubresourceTilings,
+//				UINT FirstSubresourceTilingToGet,
+//				D3D12_SUBRESOURCE_TILING& pSubresourceTilingsForNonPackedMips)
+//			{
+//				Self().GetResourceTiling(
+//					&pTiledResource,
+//					optOutNumTilesForEntireResource,
+//					optOutPackedMipDesc,
+//					optOutStandardTileShapeForNonPackedMips,
+//					pNumSubresourceTilings,
+//					FirstSubresourceTilingToGet,
+//					&pSubresourceTilingsForNonPackedMips);
+//			}
+//
+//			LUID GetAdapterLuid()
+//			{
+//				return Self().GetAdapterLuid();
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	class SetEventOnMultipleFenceCompletionData
+//	{
+//		UINT count;
+//		ID3D12Fence* const* fenceViews;
+//		const UINT64* fenceValues;
+//
+//	public:
+//		template<UINT Count>
+//		SetEventOnMultipleFenceCompletionData(std::span<ID3D12Fence*, Count> fences, std::span<UINT64, Count> fenceValues) :
+//			count{ Count },
+//			fenceViews{ fences.data() },
+//			fenceValues{ fenceValues.data() }
+//		{
+//
+//		}
+//
+//		SetEventOnMultipleFenceCompletionData(UINT count, ID3D12Fence*const* fences, UINT64* fenceValues) :
+//			count{ count },
+//			fenceViews{ fences },
+//			fenceValues{ fenceValues }
+//		{
+//
+//		}
+//
+//	public:
+//		UINT GetCount() const noexcept { return count; }
+//		ID3D12Fence* const* GetFences() const noexcept { return fenceViews; }
+//		const UINT64* GetFenceValues() const noexcept { return fenceValues; }
+//	};
+//
+//	class SetResidencyPriorityData
+//	{
+//		UINT count;
+//		ID3D12Pageable* const* pageables;
+//		const D3D12_RESIDENCY_PRIORITY* priorities;
+//
+//	public:
+//		template<UINT Count>
+//		SetResidencyPriorityData(std::span<ID3D12Pageable*, Count> pageables, std::span<D3D12_RESIDENCY_PRIORITY, Count> priorities) :
+//			count{ Count },
+//			pageables{ pageables.data() },
+//			priorities{ priorities.data() }
+//		{
+//
+//		}
+//
+//		SetResidencyPriorityData(UINT count, ID3D12Pageable* const* pageables, D3D12_RESIDENCY_PRIORITY* priorities) :
+//			count{ count },
+//			pageables{ pageables },
+//			priorities{ priorities }
+//		{
+//
+//		}
+//
+//	public:
+//		UINT GetCount() const noexcept { return count; }
+//		ID3D12Pageable* const* GetPageables() const noexcept { return pageables; }
+//		const D3D12_RESIDENCY_PRIORITY* GetPriorities() const noexcept { return priorities; }
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device1>
+//	{
+//		using value_type = ID3D12Device1;
+//		using pointer = ID3D12Device1*;
+//		using const_pointer = const ID3D12Device1*;
+//		using reference = ID3D12Device1&;
+//		using const_reference = const ID3D12Device1&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<ID3D12Device>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			ComPtr<ID3D12PipelineLibrary> CreatePipelineLibrary(
+//				const void* pLibraryBlob,
+//				SIZE_T BlobLength)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12PipelineLibrary>(ID3D12Device1::CreatePipelineLibrary, Get(), pLibraryBlob, BlobLength);
+//			}
+//
+//			void SetEventOnMultipleFenceCompletion(
+//				SetEventOnMultipleFenceCompletionData data,
+//				D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
+//				HANDLE hEvent)
+//			{
+//
+//				ThrowIfFailed(Self().SetEventOnMultipleFenceCompletion(
+//					data.GetFences(),
+//					data.GetFenceValues(),
+//					data.GetCount(),
+//					Flags,
+//					hEvent));
+//			}
+//
+//			void SetResidencyPriority(SetResidencyPriorityData data)
+//			{
+//				ThrowIfFailed(Self().SetResidencyPriority(
+//					data.GetCount(),
+//					data.GetPageables(),
+//					data.GetPriorities()));
+//			}
+//
+//			void SetResidencyPriority(ID3D12Pageable* page, D3D12_RESIDENCY_PRIORITY priority)
+//			{
+//				SetResidencyPriority({ 1, &page, &priority });
+//			}
+//
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device2>
+//	{
+//		using value_type = ID3D12Device2;
+//		using pointer = ID3D12Device2*;
+//		using const_pointer = const ID3D12Device2*;
+//		using reference = ID3D12Device2&;
+//		using const_reference = const ID3D12Device2&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<ID3D12Device1>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//
+//			template<class Ty>
+//			PipelineState_t<Ty> CreatePipelineState(
+//				const D3D12_PIPELINE_STATE_STREAM_DESC pDesc)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device2::CreatePipelineState, Get(), &pDesc);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device3>
+//	{
+//		using value_type = ID3D12Device3;
+//		using pointer = ID3D12Device3*;
+//		using const_pointer = const ID3D12Device3*;
+//		using reference = ID3D12Device3&;
+//		using const_reference = const ID3D12Device3&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<ID3D12Device2>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			ComPtr<ID3D12Heap> OpenExistingHeapFromAddress(
+//				const void* pAddress)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromAddress, Get(), pAddress);
+//			}
+//
+//			ComPtr<ID3D12Heap> OpenExistingHeapFromFileMapping(
+//				HANDLE hFileMapping)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromFileMapping, Get(), hFileMapping);
+//			}
+//
+//			void EnqueueMakeResident(
+//				D3D12_RESIDENCY_FLAGS Flags,
+//				std::span<ID3D12Pageable*> ppObjects,
+//				ID3D12Fence& pFenceToSignal,
+//				UINT64 FenceValueToSignal)
+//			{
+//				ThrowIfFailed(Self().EnqueueMakeResident(
+//					Flags,
+//					static_cast<UINT>(ppObjects.size()),
+//					ppObjects.data(),
+//					&pFenceToSignal, FenceValueToSignal));
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device4>
+//	{
+//		using value_type = ID3D12Device4;
+//		using pointer = ID3D12Device4*;
+//		using const_pointer = const ID3D12Device4*;
+//		using reference = ID3D12Device4&;
+//		using const_reference = const ID3D12Device4&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<ID3D12Device3>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
+//			CommandList_t<ListTy, Type> CreateCommandList1(
+//				UINT nodeMask,
+//				D3D12_COMMAND_LIST_FLAGS flags)
+//			{
+//				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, flags, nodeMask);
+//			}
+//
+//			ComPtr<ID3D12ProtectedResourceSession> CreateProtectedResourceSession(
+//				const D3D12_PROTECTED_RESOURCE_SESSION_DESC& pDesc)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12ProtectedResourceSession>(&ID3D12Device4::CreateProtectedResourceSession, Get(), &pDesc);
+//			}
+//
+//			Wrapper<ID3D12Resource> CreateCommittedResource1(
+//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+//				D3D12_HEAP_FLAGS HeapFlags,
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialResourceState,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				ID3D12ProtectedResourceSession* pProtectedSession)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource>(
+//					&ID3D12Device4::CreateCommittedResource1,
+//					Get(),
+//					&pHeapProperties,
+//					HeapFlags,
+//					&pDesc,
+//					InitialResourceState,
+//					pOptimizedClearValue,
+//					pProtectedSession);
+//			}
+//
+//			ComPtr<ID3D12Heap> CreateHeap1(
+//				const D3D12_HEAP_DESC& pDesc,
+//				ID3D12ProtectedResourceSession* pProtectedSession)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Heap>(
+//					&ID3D12Device4::CreateHeap1,
+//					Get(),
+//					&pDesc,
+//					pProtectedSession);
+//			}
+//
+//			Wrapper<ID3D12Resource> CreateReservedResource1(
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialState,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				ID3D12ProtectedResourceSession* pProtectedSession)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Heap>(
+//					&ID3D12Device4::CreateReservedResource1,
+//					Get(),
+//					&pDesc,
+//					InitialState,
+//					pOptimizedClearValue,
+//					pProtectedSession);
+//			}
+//
+//			std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> GetResourceAllocationInfo1(
+//				UINT visibleMask,
+//				std::span<const D3D12_RESOURCE_DESC> pResourceDescs)
+//			{
+//				std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> pResourceAllocationInfo1(pResourceDescs.size());
+//				Self().GetResourceAllocationInfo1(visibleMask, static_cast<UINT>(pResourceDescs.size()), pResourceDescs.data(), pResourceAllocationInfo1.data());
+//				return pResourceAllocationInfo1;
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device5>
+//	{
+//		using value_type = ID3D12Device5;
+//		using pointer = ID3D12Device5*;
+//		using const_pointer = const ID3D12Device5*;
+//		using reference = ID3D12Device5&;
+//		using const_reference = const ID3D12Device5&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<ID3D12Device4>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//		//TODO: Figure out how this works to update to a more modern API
+//			void CreateLifetimeTracker(
+//				ID3D12LifetimeOwner& pOwner,
+//				REFIID riid,
+//				void** ppvTracker)
+//			{
+//				ThrowIfFailed(Self().CreateLifetimeTracker(&pOwner, riid, ppvTracker));
+//			}
+//
+//			void RemoveDevice()
+//			{
+//				Self().RemoveDevice();
+//			}
+//
+//			UINT GetNumMetaCommands()
+//			{
+//				UINT pNumMetaCommands = 0;
+//				Self().EnumerateMetaCommands(&pNumMetaCommands, nullptr);
+//				return pNumMetaCommands;
+//			}
+//
+//			std::vector<D3D12_META_COMMAND_DESC> EnumerateMetaCommands(
+//				UINT pNumMetaCommands)
+//			{
+//				std::vector<D3D12_META_COMMAND_DESC> pDescs(pNumMetaCommands);
+//				ThrowIfFailed(Self().EnumerateMetaCommands(&pNumMetaCommands, pDescs.data()));
+//				return pDescs;
+//			}
+//
+//			UINT GetNumMetaCommandParameters(
+//				REFGUID CommandId,
+//				D3D12_META_COMMAND_PARAMETER_STAGE Stage)
+//			{
+//				UINT pNumMetaCommandParams = 0;
+//				Self().EnumerateMetaCommandParameters(CommandId, Stage, nullptr, &pNumMetaCommandParams, nullptr);
+//				return pNumMetaCommandParams;
+//			}
+//
+//			MetaCommandParameterInfo STDMETHODCALLTYPE EnumerateMetaCommandParameters(
+//				_In_  REFGUID CommandId,
+//				_In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
+//				UINT parameterCount)
+//			{
+//				MetaCommandParameterInfo info{};
+//
+//				info.parameterCount = parameterCount;
+//				info.parameterDescs.resize(parameterCount);
+//
+//				ThrowIfFailed(Self().EnumerateMetaCommandParameters(
+//					CommandId,
+//					Stage,
+//					&info.totalStructureSizeInBytes,
+//					&info.parameterCount,
+//					info.parameterDescs.data()));
+//
+//				return info;
+//			}
+//
+//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
+//				REFGUID CommandId,
+//				UINT NodeMask,
+//				const void* pCreationParametersData,
+//				SIZE_T CreationParametersDataSizeInBytes)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12MetaCommand>(
+//					&ID3D12Device5::CreateMetaCommand,
+//					Get(),
+//					CommandId,
+//					NodeMask,
+//					pCreationParametersData,
+//					CreationParametersDataSizeInBytes);
+//			}
+//
+//			template<class CreationParamStruct>
+//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
+//				REFGUID CommandId,
+//				UINT NodeMask,
+//				const CreationParamStruct& pCreationParametersData)
+//			{
+//				return CreateMetaCommand(CommandId, NodeMask, &pCreationParametersData, sizeof(CreationParamStruct));
+//			}
+//
+//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
+//				REFGUID CommandId,
+//				UINT NodeMask)
+//			{
+//				return CreateMetaCommand(CommandId, NodeMask, nullptr, 0);
+//			}
+//
+//			ComPtr<ID3D12StateObject> CreateStateObject(
+//				const D3D12_STATE_OBJECT_DESC& pDesc)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12StateObject>(
+//					&ID3D12Device5::CreateStateObject,
+//					Get(),
+//					&pDesc);
+//			}
+//
+//			D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO GetRaytracingAccelerationStructurePrebuildInfo(
+//				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& pDesc)
+//			{
+//				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
+//				Self().GetRaytracingAccelerationStructurePrebuildInfo(&pDesc, &prebuildInfo);
+//				return prebuildInfo;
+//			}
+//
+//			D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS CheckDriverMatchingIdentifier(
+//				D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
+//				const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER& pIdentifierToCheck)
+//			{
+//				return Self().CheckDriverMatchingIdentifier(
+//					SerializedDataType,
+//					&pIdentifierToCheck);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device6>
+//	{
+//		using base_value_type = ID3D12Device5;
+//		using value_type = ID3D12Device6;
+//		using pointer = ID3D12Device6*;
+//		using const_pointer = const ID3D12Device6*;
+//		using reference = ID3D12Device6&;
+//		using const_reference = const ID3D12Device6&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//		//TODO: Figure out how this works to update to a more modern API
+//			HRESULT SetBackgroundProcessingMode(
+//				D3D12_BACKGROUND_PROCESSING_MODE Mode,
+//				D3D12_MEASUREMENTS_ACTION MeasurementsAction,
+//				_In_opt_  HANDLE hEventToSignalUponCompletion,
+//				_Out_opt_  BOOL* pbFurtherMeasurementsDesired)
+//			{
+//				return Self().SetBackgroundProcessingMode(
+//					Mode,
+//					MeasurementsAction,
+//					hEventToSignalUponCompletion,
+//					pbFurtherMeasurementsDesired);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device7>
+//	{
+//		using base_value_type = ID3D12Device6;
+//		using value_type = ID3D12Device7;
+//		using pointer = ID3D12Device7*;
+//		using const_pointer = const ID3D12Device7*;
+//		using reference = ID3D12Device7&;
+//		using const_reference = const ID3D12Device7&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			//TODO: Figure out how this works to update to a more modern API
+//			HRESULT AddToStateObject(
+//				const D3D12_STATE_OBJECT_DESC* pAddition,
+//				ID3D12StateObject* pStateObjectToGrowFrom,
+//				REFIID riid,
+//				_COM_Outptr_  void** ppNewStateObject)
+//			{
+//				return Self().AddToStateObject(
+//					pAddition,
+//					pStateObjectToGrowFrom,
+//					riid,
+//					ppNewStateObject);
+//			}
+//
+//			//TODO: Figure out how this works to update to a more modern API
+//			HRESULT CreateProtectedResourceSession1(
+//				const D3D12_PROTECTED_RESOURCE_SESSION_DESC1* pDesc,
+//				REFIID riid,
+//				void** ppSession)
+//			{
+//				return Self().CreateProtectedResourceSession1(
+//					pDesc,
+//					riid,
+//					ppSession);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device8>
+//	{
+//		using base_value_type = ID3D12Device7;
+//		using value_type = ID3D12Device8;
+//		using pointer = ID3D12Device8*;
+//		using const_pointer = const ID3D12Device8*;
+//		using reference = ID3D12Device8&;
+//		using const_reference = const ID3D12Device8&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//#if defined(_MSC_VER) || !defined(_WIN32)
+//			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo2(
+//				UINT visibleMask,
+//				UINT numResourceDescs,
+//				const D3D12_RESOURCE_DESC1* pResourceDescs,
+//				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
+//			{
+//				return Self().GetResourceAllocationInfo2(visibleMask,
+//					numResourceDescs,
+//					pResourceDescs,
+//					pResourceAllocationInfo1);
+//			}
+//#else
+//			D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE GetResourceAllocationInfo2(
+//				D3D12_RESOURCE_ALLOCATION_INFO* RetVal,
+//				UINT visibleMask,
+//				UINT numResourceDescs,
+//				const D3D12_RESOURCE_DESC1* pResourceDescs,
+//				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
+//			{
+//				return Self().GetResourceAllocationInfo2(RetVal,
+//					visibleMask,
+//					numResourceDescs,
+//					pResourceDescs,
+//					pResourceAllocationInfo1);
+//			}
+//#endif
+//
+//			TypedD3D::Wrapper<ID3D12Resource> CreateCommittedResource2(
+//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+//				D3D12_HEAP_FLAGS HeapFlags,
+//				const D3D12_RESOURCE_DESC1& pDesc,
+//				D3D12_RESOURCE_STATES InitialResourceState,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				ID3D12ProtectedResourceSession* pProtectedSession)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreateCommittedResource2, Get(),
+//					&pHeapProperties,
+//					HeapFlags,
+//					&pDesc,
+//					InitialResourceState,
+//					pOptimizedClearValue,
+//					pProtectedSession);
+//			}
+//
+//			TypedD3D::Wrapper<ID3D12Resource> CreatePlacedResource1(
+//				ID3D12Heap& pHeap,
+//				UINT64 HeapOffset,
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_RESOURCE_STATES InitialState,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource>(&value_type::CreatePlacedResource1, Get(),
+//					&pHeap,
+//					HeapOffset,
+//					&pDesc,
+//					InitialState,
+//					pOptimizedClearValue);
+//			}
+//
+//			void CreateSamplerFeedbackUnorderedAccessView(
+//				ID3D12Resource* pTargetedResource,
+//				ID3D12Resource* pFeedbackResource,
+//				D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
+//			{
+//				Self().CreateSamplerFeedbackUnorderedAccessView(
+//					pTargetedResource,
+//					pFeedbackResource,
+//					DestDescriptor);
+//			}
+//
+//			void GetCopyableFootprints1(
+//				const D3D12_RESOURCE_DESC1& pResourceDesc,
+//				UINT FirstSubresource,
+//				UINT NumSubresources,
+//				UINT64 BaseOffset,
+//				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
+//				UINT* pNumRows,
+//				UINT64* pRowSizeInBytes,
+//				UINT64* pTotalBytes)
+//			{
+//				Self().GetCopyableFootprints1(
+//					&pResourceDesc,
+//					FirstSubresource,
+//					NumSubresources,
+//					BaseOffset,
+//					pLayouts,
+//					pNumRows,
+//					pRowSizeInBytes,
+//					pTotalBytes);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device9>
+//	{
+//		using base_value_type = ID3D12Device8;
+//		using value_type = ID3D12Device9;
+//		using pointer = ID3D12Device9*;
+//		using const_pointer = const ID3D12Device9*;
+//		using reference = ID3D12Device9&;
+//		using const_reference = const ID3D12Device9&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			ComPtr<ID3D12ShaderCacheSession> CreateShaderCacheSession(
+//				const D3D12_SHADER_CACHE_SESSION_DESC& pDesc)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12ShaderCacheSession>(&value_type::CreateShaderCacheSession, Get(), &pDesc);
+//			}
+//
+//			HRESULT ShaderCacheControl(
+//				D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
+//				D3D12_SHADER_CACHE_CONTROL_FLAGS Control)
+//			{
+//				return Self().ShaderCacheControl(Kinds, Control);
+//			}
+//
+//			template<D3D12_COMMAND_LIST_TYPE Type>
+//			D3D12CommandQueue_t<Type> CreateCommandQueue1(
+//				D3D12_COMMAND_QUEUE_PRIORITY priority,
+//				D3D12_COMMAND_QUEUE_FLAGS flags,
+//				UINT nodeMask,
+//				REFIID CreatorID)
+//			{
+//				using queue_type = D3D12CommandQueue_t<Type>;
+//
+//				D3D12_COMMAND_QUEUE_DESC desc
+//				{
+//					.Type = Type,
+//					.Priority = priority,
+//					.Flags = flags,
+//					.NodeMask = nodeMask
+//				};
+//
+//				return IIDToObjectForwardFunction<ID3D12CommandQueue>(&value_type::CreateCommandQueue1, Get(), &desc, CreatorID);
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	template<>
+//	struct DeviceTraits<ID3D12Device10>
+//	{
+//		using base_value_type = ID3D12Device9;
+//		using value_type = ID3D12Device10;
+//		using pointer = ID3D12Device10*;
+//		using const_pointer = const ID3D12Device10*;
+//		using reference = ID3D12Device10&;
+//		using const_reference = const ID3D12Device10&;
+//
+//		template<class DerivedSelf>
+//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
+//		{
+//		private:
+//			using derived_self = DerivedSelf;
+//
+//		public:
+//			TypedD3D::Wrapper<ID3D12Resource2> CreateCommittedResource3(
+//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+//				D3D12_HEAP_FLAGS HeapFlags,
+//				const D3D12_RESOURCE_DESC1& pDesc,
+//				D3D12_BARRIER_LAYOUT InitialLayout,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				ID3D12ProtectedResourceSession* pProtectedSession,
+//				std::span<DXGI_FORMAT> CastableFormats)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreateCommittedResource3, Get(),
+//					&pHeapProperties,
+//					HeapFlags,
+//					&pDesc,
+//					InitialLayout,
+//					pOptimizedClearValue,
+//					pProtectedSession,
+//					static_cast<UINT32>(CastableFormats.size()),
+//					CastableFormats.data());
+//			}
+//
+//			TypedD3D::Wrapper<ID3D12Resource2> CreatePlacedResource2(
+//				ID3D12Heap& pHeap,
+//				UINT64 HeapOffset,
+//				const D3D12_RESOURCE_DESC1& pDesc,
+//				D3D12_BARRIER_LAYOUT InitialLayout,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				std::span<DXGI_FORMAT> CastableFormats)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource2>(&value_type::CreatePlacedResource2, Get(),
+//					&pHeap,
+//					HeapOffset,
+//					pDesc,
+//					InitialLayout,
+//					pOptimizedClearValue,
+//					static_cast<UINT32>(CastableFormats.size()),
+//					CastableFormats.data());
+//			}
+//
+//			TypedD3D::Wrapper<ID3D12Resource1> CreateReservedResource2(
+//				const D3D12_RESOURCE_DESC& pDesc,
+//				D3D12_BARRIER_LAYOUT InitialLayout,
+//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+//				ID3D12ProtectedResourceSession* pProtectedSession,
+//				std::span<DXGI_FORMAT> CastableFormats)
+//			{
+//				return IIDToObjectForwardFunction<ID3D12Resource1>(&value_type::CreateReservedResource2, Get(),
+//					pDesc,
+//					InitialLayout,
+//					pOptimizedClearValue,
+//					pProtectedSession,
+//					static_cast<UINT32>(CastableFormats.size()),
+//					CastableFormats.data());
+//			}
+//
+//		private:
+//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//			reference Get() { return *ToDerived().derived_self::Get(); }
+//		};
+//	};
+//
+//	namespace Aliases
+//	{
+//		export using Device = Device_t<ID3D12Device>;
+//		export using Device1 = Device_t<ID3D12Device1>;
+//		export using Device2 = Device_t<ID3D12Device2>;
+//		export using Device3 = Device_t<ID3D12Device3>;
+//		export using Device4 = Device_t<ID3D12Device4>;
+//		export using Device5 = Device_t<ID3D12Device5>;
+//		export using Device6 = Device_t<ID3D12Device6>;
+//		export using Device7 = Device_t<ID3D12Device7>;
+//		export using Device8 = Device_t<ID3D12Device8>;
+//		export using Device9 = Device_t<ID3D12Device9>;
+//		export using Device10 = Device_t<ID3D12Device10>;
+//	}
+//
+//	export template<class DeviceTy = Aliases::Device>
+//	Device_t<DeviceTy> CreateDevice(D3D_FEATURE_LEVEL minimumFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
+//	{
+//		if constexpr(std::is_base_of_v<ID3D12Device, DeviceTy>)
+//		{
+//			return Helpers::D3D12::CreateDevice<DeviceTy>(minimumFeatureLevel, optAdapter);
+//		}
+//		else
+//		{
+//			return Helpers::D3D12::CreateDevice<typename DeviceTy::value_type>(minimumFeatureLevel, optAdapter);
+//		}
+//	}
+//}
+//
+//namespace TypedD3D
+//{
+//	template<std::derived_from<ID3D12Device> Ty>
+//	struct UntaggedTraits<Ty>
+//	{
+//		using value_type = Ty;
+//		using pointer = Ty*;
+//		using const_pointer = const Ty*;
+//		using reference = Ty&;
+//		using const_reference = const Ty&;
+//
+//		template<class DerivedSelf>
+//		using Interface = typename D3D12::DeviceTraits<Ty>::template Interface<DerivedSelf>;
+//	};
+//}

--- a/TypedD3D/source/D3D12/D3D12Device.ixx
+++ b/TypedD3D/source/D3D12/D3D12Device.ixx
@@ -154,11 +154,11 @@ namespace TypedD3D::D3D12
 	};
 
 	//Requires Windows 11
-	//template<>
-	//struct DeviceFeatureMap<D3D12_FEATURE_DISPLAYABLE>
-	//{
-	//    using type = D3D12_FEATURE_DATA_DISPLAYABLE;
-	//};
+	template<>
+	struct DeviceFeatureMap<D3D12_FEATURE_DISPLAYABLE>
+	{
+		using type = D3D12_FEATURE_DATA_DISPLAYABLE;
+	};
 
 	template<>
 	struct DeviceFeatureMap<D3D12_FEATURE_QUERY_META_COMMAND>
@@ -185,32 +185,92 @@ namespace TypedD3D::D3D12
 	};
 
 	//Requires Windows 11
-	//template<>
-	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS8>
-	//{
-	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS8;
-	//};
+	template<>
+	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS8>
+	{
+		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS8;
+	};
 
 	//Requires Windows 11
-	//template<>
-	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS9>
-	//{
-	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS9;
-	//};
+	template<>
+	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS9>
+	{
+		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS9;
+	};
 
 	//Requires Windows 11
-	//template<>
-	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS10>
-	//{
-	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS10;
-	//};
+	template<>
+	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS10>
+	{
+		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS10;
+	};
 
 	//Requires Windows 11
-	//template<>
-	//struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS11>
-	//{
-	//    using type = D3D12_FEATURE_DATA_D3D12_OPTIONS11;
-	//};
+	template<>
+	struct DeviceFeatureMap<D3D12_FEATURE_D3D12_OPTIONS11>
+	{
+		using type = D3D12_FEATURE_DATA_D3D12_OPTIONS11;
+	};
+
+	class SetEventOnMultipleFenceCompletionData
+	{
+		UINT count;
+		ID3D12Fence* const* fenceViews;
+		const UINT64* fenceValues;
+
+	public:
+		template<UINT Count>
+		SetEventOnMultipleFenceCompletionData(std::span<ID3D12Fence*, Count> fences, std::span<UINT64, Count> fenceValues) :
+			count{ Count },
+			fenceViews{ fences.data() },
+			fenceValues{ fenceValues.data() }
+		{
+
+		}
+
+		SetEventOnMultipleFenceCompletionData(UINT count, ID3D12Fence* const* fences, UINT64* fenceValues) :
+			count{ count },
+			fenceViews{ fences },
+			fenceValues{ fenceValues }
+		{
+
+		}
+
+	public:
+		UINT GetCount() const noexcept { return count; }
+		ID3D12Fence* const* GetFences() const noexcept { return fenceViews; }
+		const UINT64* GetFenceValues() const noexcept { return fenceValues; }
+	};
+
+	class SetResidencyPriorityData
+	{
+		UINT count;
+		ID3D12Pageable* const* pageables;
+		const D3D12_RESIDENCY_PRIORITY* priorities;
+
+	public:
+		template<UINT Count>
+		SetResidencyPriorityData(std::span<ID3D12Pageable*, Count> pageables, std::span<D3D12_RESIDENCY_PRIORITY, Count> priorities) :
+			count{ Count },
+			pageables{ pageables.data() },
+			priorities{ priorities.data() }
+		{
+
+		}
+
+		SetResidencyPriorityData(UINT count, ID3D12Pageable* const* pageables, D3D12_RESIDENCY_PRIORITY* priorities) :
+			count{ count },
+			pageables{ pageables },
+			priorities{ priorities }
+		{
+
+		}
+
+	public:
+		UINT GetCount() const noexcept { return count; }
+		ID3D12Pageable* const* GetPageables() const noexcept { return pageables; }
+		const D3D12_RESIDENCY_PRIORITY* GetPriorities() const noexcept { return priorities; }
+	};
 }
 
 namespace TypedD3D
@@ -504,7 +564,7 @@ namespace TypedD3D
 				return handle;
 			}
 
-			  //TODO: Figure out how this works to update to a more modern API
+			//TODO: Figure out how this works to update to a more modern API
 			HRESULT OpenSharedHandle(
 				HANDLE NTHandle,
 				const IID& riid,
@@ -627,805 +687,714 @@ namespace TypedD3D
 			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device1>>
+	{
+		using inner_type = ID3D12Device1;
+
+		using inner_tag = ID3D12Device1;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device>, Derived>
+		{
+			Wrapper<ID3D12PipelineLibrary> CreatePipelineLibrary(
+				const void* pLibraryBlob,
+				SIZE_T BlobLength)
+			{
+				return ForwardFunction<Wrapper<ID3D12PipelineLibrary>>(ID3D12Device1::CreatePipelineLibrary, Self(), pLibraryBlob, BlobLength);
+			}
+
+			void SetEventOnMultipleFenceCompletion(
+				D3D12::SetEventOnMultipleFenceCompletionData data,
+				D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
+				HANDLE hEvent)
+			{
+
+				ThrowIfFailed(Self().SetEventOnMultipleFenceCompletion(
+					data.GetFences(),
+					data.GetFenceValues(),
+					data.GetCount(),
+					Flags,
+					hEvent));
+			}
+
+			void SetResidencyPriority(D3D12::SetResidencyPriorityData data)
+			{
+				ThrowIfFailed(Self().SetResidencyPriority(
+					data.GetCount(),
+					data.GetPageables(),
+					data.GetPriorities()));
+			}
+
+			void SetResidencyPriority(ID3D12Pageable* page, D3D12_RESIDENCY_PRIORITY priority)
+			{
+				SetResidencyPriority({ 1, &page, &priority });
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device2>>
+	{
+		using inner_type = ID3D12Device2;
+
+		using inner_tag = ID3D12Device2;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device1>, Derived>
+		{
+			Graphics<ID3D12PipelineState> CreateGraphicsPipelineState(
+				const D3D12_PIPELINE_STATE_STREAM_DESC pDesc)
+			{
+				return ForwardFunction<Graphics<ID3D12PipelineState>>(&ID3D12Device2::CreatePipelineState, Self(), &pDesc);
+			}
+
+			Compute<ID3D12PipelineState> CreateComputePipelineState(
+				const D3D12_PIPELINE_STATE_STREAM_DESC pDesc)
+			{
+				return ForwardFunction<Compute<ID3D12PipelineState>>(&ID3D12Device2::CreatePipelineState, Self(), &pDesc);
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device3>>
+	{
+		using inner_type = ID3D12Device3;
+
+		using inner_tag = ID3D12Device3;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device2>, Derived>
+		{
+			Wrapper<ID3D12Heap> OpenExistingHeapFromAddress(
+				const void* pAddress)
+			{
+				return ForwardFunction<Wrapper<ID3D12Heap>>(&ID3D12Device3::OpenExistingHeapFromAddress, Self(), pAddress);
+			}
+
+			Wrapper<ID3D12Heap> OpenExistingHeapFromFileMapping(
+				HANDLE hFileMapping)
+			{
+				return ForwardFunction<Wrapper<ID3D12Heap>>(&ID3D12Device3::OpenExistingHeapFromFileMapping, Self(), hFileMapping);
+			}
+
+			void EnqueueMakeResident(
+				D3D12_RESIDENCY_FLAGS Flags,
+				std::span<ID3D12Pageable*> ppObjects,
+				gsl::not_null<WrapperView<ID3D12Fence>> pFenceToSignal,
+				UINT64 FenceValueToSignal)
+			{
+				ThrowIfFailed(Self().EnqueueMakeResident(
+					Flags,
+					static_cast<UINT>(ppObjects.size()),
+					ppObjects.data(),
+					pFenceToSignal.get().Self(), FenceValueToSignal));
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device4>>
+	{
+		using inner_type = ID3D12Device4;
+
+		using inner_tag = ID3D12Device4;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device3>, Derived>
+		{
+			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
+			StrongWrapper<D3D12::CommandListTypeToTrait<Type, ListTy>> CreateCommandList1(
+				UINT nodeMask,
+				D3D12_COMMAND_LIST_FLAGS flags)
+			{
+				return ForwardFunction<StrongWrapper<D3D12::CommandListTypeToTrait<Type, ListTy>>>(&ID3D12Device4::CreateCommandList1, Self(), nodeMask, Type, flags);
+			}
+
+			Wrapper<ID3D12ProtectedResourceSession> CreateProtectedResourceSession(
+				const D3D12_PROTECTED_RESOURCE_SESSION_DESC& pDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D12ProtectedResourceSession>>(&ID3D12Device4::CreateProtectedResourceSession, Self(), &pDesc);
+			}
+
+			Wrapper<ID3D12Resource> CreateCommittedResource1(
+				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+				D3D12_HEAP_FLAGS HeapFlags,
+				const D3D12_RESOURCE_DESC& pDesc,
+				D3D12_RESOURCE_STATES InitialResourceState,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				WrapperView<ID3D12ProtectedResourceSession> pProtectedSession)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource>>(
+					&ID3D12Device4::CreateCommittedResource1,
+					Self(),
+					&pHeapProperties,
+					HeapFlags,
+					&pDesc,
+					InitialResourceState,
+					pOptimizedClearValue,
+					pProtectedSession);
+			}
+
+			Wrapper<ID3D12Heap> CreateHeap1(
+				const D3D12_HEAP_DESC& pDesc,
+				WrapperView<ID3D12ProtectedResourceSession> pProtectedSession)
+			{
+				return ForwardFunction<Wrapper<ID3D12Heap>>(
+					&ID3D12Device4::CreateHeap1,
+					Self(),
+					&pDesc,
+					pProtectedSession);
+			}
+
+			Wrapper<ID3D12Resource> CreateReservedResource1(
+				const D3D12_RESOURCE_DESC& pDesc,
+				D3D12_RESOURCE_STATES InitialState,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				WrapperView<ID3D12ProtectedResourceSession> pProtectedSession)
+			{
+				return ForwardFunction<Wrapper<ID3D12Heap>>(
+					&ID3D12Device4::CreateReservedResource1,
+					Self(),
+					&pDesc,
+					InitialState,
+					pOptimizedClearValue,
+					pProtectedSession);
+			}
+
+			std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> GetResourceAllocationInfo1(
+				UINT visibleMask,
+				std::span<const D3D12_RESOURCE_DESC> pResourceDescs)
+			{
+				std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> pResourceAllocationInfo1(pResourceDescs.size());
+				Self().GetResourceAllocationInfo1(visibleMask, static_cast<UINT>(pResourceDescs.size()), pResourceDescs.data(), pResourceAllocationInfo1.data());
+				return pResourceAllocationInfo1;
+			}
+
+			void GetResourceAllocationInfo1(
+				UINT visibleMask,
+				std::span<const D3D12_RESOURCE_DESC> pResourceDescs,
+				std::span<D3D12_RESOURCE_ALLOCATION_INFO1> pResourceAllocationInfo1)
+			{
+				assert(pResourceDescs.size() == pResourceAllocationInfo1.size());
+				Self().GetResourceAllocationInfo1(visibleMask, static_cast<UINT>(pResourceDescs.size()), pResourceDescs.data(), pResourceAllocationInfo1.data());
+				return pResourceAllocationInfo1;
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device5>>
+	{
+		using inner_type = ID3D12Device5;
+
+		using inner_tag = ID3D12Device5;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device4>, Derived>
+		{
+			//TODO: Figure out how this works to update to a more modern API
+			void CreateLifetimeTracker(
+				gsl::not_null<WrapperView<ID3D12LifetimeOwner>> pOwner,
+				REFIID riid,
+				void** ppvTracker)
+			{
+				ThrowIfFailed(Self().CreateLifetimeTracker(pOwner.get().Get(), riid, ppvTracker));
+			}
+
+			void RemoveDevice()
+			{
+				Self().RemoveDevice();
+			}
+
+			UINT GetNumMetaCommands()
+			{
+				UINT pNumMetaCommands = 0;
+				Self().EnumerateMetaCommands(&pNumMetaCommands, nullptr);
+				return pNumMetaCommands;
+			}
+
+			std::vector<D3D12_META_COMMAND_DESC> EnumerateMetaCommands(
+				UINT pNumMetaCommands)
+			{
+				std::vector<D3D12_META_COMMAND_DESC> pDescs(pNumMetaCommands);
+				ThrowIfFailed(Self().EnumerateMetaCommands(&pNumMetaCommands, pDescs.data()));
+				return pDescs;
+			}
+
+			UINT GetNumMetaCommandParameters(
+				REFGUID CommandId,
+				D3D12_META_COMMAND_PARAMETER_STAGE Stage)
+			{
+				UINT pNumMetaCommandParams = 0;
+				Self().EnumerateMetaCommandParameters(CommandId, Stage, nullptr, &pNumMetaCommandParams, nullptr);
+				return pNumMetaCommandParams;
+			}
+
+			D3D12::MetaCommandParameterInfo STDMETHODCALLTYPE EnumerateMetaCommandParameters(
+				_In_  REFGUID CommandId,
+				_In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
+				UINT parameterCount)
+			{
+				D3D12::MetaCommandParameterInfo info{};
+
+				info.parameterCount = parameterCount;
+				info.parameterDescs.resize(parameterCount);
+
+				ThrowIfFailed(Self().EnumerateMetaCommandParameters(
+					CommandId,
+					Stage,
+					&info.totalStructureSizeInBytes,
+					&info.parameterCount,
+					info.parameterDescs.data()));
+
+				return info;
+			}
+
+			Wrapper<ID3D12MetaCommand> CreateMetaCommand(
+				REFGUID CommandId,
+				UINT NodeMask,
+				const void* pCreationParametersData,
+				SIZE_T CreationParametersDataSizeInBytes)
+			{
+				return ForwardFunction<Wrapper<ID3D12MetaCommand>>(
+					&ID3D12Device5::CreateMetaCommand,
+					Self(),
+					CommandId,
+					NodeMask,
+					pCreationParametersData,
+					CreationParametersDataSizeInBytes);
+			}
+
+			template<class CreationParamStruct>
+			Wrapper<ID3D12MetaCommand> CreateMetaCommand(
+				REFGUID CommandId,
+				UINT NodeMask,
+				const CreationParamStruct& pCreationParametersData)
+			{
+				return CreateMetaCommand(CommandId, NodeMask, &pCreationParametersData, sizeof(CreationParamStruct));
+			}
+
+			Wrapper<ID3D12MetaCommand> CreateMetaCommand(
+				REFGUID CommandId,
+				UINT NodeMask)
+			{
+				return CreateMetaCommand(CommandId, NodeMask, nullptr, 0);
+			}
+
+			Wrapper<ID3D12StateObject> CreateStateObject(
+				const D3D12_STATE_OBJECT_DESC& pDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D12StateObject>>(
+					&ID3D12Device5::CreateStateObject,
+					Self(),
+					&pDesc);
+			}
+
+			D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO GetRaytracingAccelerationStructurePrebuildInfo(
+				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& pDesc)
+			{
+				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
+				Self().GetRaytracingAccelerationStructurePrebuildInfo(&pDesc, &prebuildInfo);
+				return prebuildInfo;
+			}
+
+			D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS CheckDriverMatchingIdentifier(
+				D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
+				const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER& pIdentifierToCheck)
+			{
+				return Self().CheckDriverMatchingIdentifier(
+					SerializedDataType,
+					&pIdentifierToCheck);
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device6>>
+	{
+		using inner_type = ID3D12Device6;
+
+		using inner_tag = ID3D12Device6;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device5>, Derived>
+		{
+			//TODO: Figure out how this works to update to a more modern API
+			HRESULT SetBackgroundProcessingMode(
+				D3D12_BACKGROUND_PROCESSING_MODE Mode,
+				D3D12_MEASUREMENTS_ACTION MeasurementsAction,
+				_In_opt_  HANDLE hEventToSignalUponCompletion,
+				_Out_opt_  BOOL* pbFurtherMeasurementsDesired)
+			{
+				return Self().SetBackgroundProcessingMode(
+					Mode,
+					MeasurementsAction,
+					hEventToSignalUponCompletion,
+					pbFurtherMeasurementsDesired);
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device7>>
+	{
+		using inner_type = ID3D12Device7;
+
+		using inner_tag = ID3D12Device7;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device6>, Derived>
+		{
+			//TODO: Figure out how this works to update to a more modern API
+			HRESULT AddToStateObject(
+				const D3D12_STATE_OBJECT_DESC* pAddition,
+				ID3D12StateObject* pStateObjectToGrowFrom,
+				REFIID riid,
+				_COM_Outptr_  void** ppNewStateObject)
+			{
+				return Self().AddToStateObject(
+					pAddition,
+					pStateObjectToGrowFrom,
+					riid,
+					ppNewStateObject);
+			}
+
+			//TODO: Figure out how this works to update to a more modern API
+			HRESULT CreateProtectedResourceSession1(
+				const D3D12_PROTECTED_RESOURCE_SESSION_DESC1* pDesc,
+				REFIID riid,
+				void** ppSession)
+			{
+				return Self().CreateProtectedResourceSession1(
+					pDesc,
+					riid,
+					ppSession);
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device8>>
+	{
+		using inner_type = ID3D12Device8;
+
+		using inner_tag = ID3D12Device8;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device7>, Derived>
+		{
+#if defined(_MSC_VER) || !defined(_WIN32)
+			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo2(
+				UINT visibleMask,
+				UINT numResourceDescs,
+				const D3D12_RESOURCE_DESC1* pResourceDescs,
+				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
+			{
+				return Self().GetResourceAllocationInfo2(visibleMask,
+					numResourceDescs,
+					pResourceDescs,
+					pResourceAllocationInfo1);
+			}
+#else
+			D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE GetResourceAllocationInfo2(
+				D3D12_RESOURCE_ALLOCATION_INFO* RetVal,
+				UINT visibleMask,
+				UINT numResourceDescs,
+				const D3D12_RESOURCE_DESC1* pResourceDescs,
+				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
+			{
+				return Self().GetResourceAllocationInfo2(RetVal,
+					visibleMask,
+					numResourceDescs,
+					pResourceDescs,
+					pResourceAllocationInfo1);
+			}
+#endif
+
+			Wrapper<ID3D12Resource> CreateCommittedResource2(
+				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+				D3D12_HEAP_FLAGS HeapFlags,
+				const D3D12_RESOURCE_DESC1& pDesc,
+				D3D12_RESOURCE_STATES InitialResourceState,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				ID3D12ProtectedResourceSession* pProtectedSession)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource>>(&inner_type::CreateCommittedResource2, Self(),
+					&pHeapProperties,
+					HeapFlags,
+					&pDesc,
+					InitialResourceState,
+					pOptimizedClearValue,
+					pProtectedSession);
+			}
+
+			Wrapper<ID3D12Resource> CreatePlacedResource1(
+				ID3D12Heap& pHeap,
+				UINT64 HeapOffset,
+				const D3D12_RESOURCE_DESC& pDesc,
+				D3D12_RESOURCE_STATES InitialState,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource>>(&inner_type::CreatePlacedResource1, Self(),
+					&pHeap,
+					HeapOffset,
+					&pDesc,
+					InitialState,
+					pOptimizedClearValue);
+			}
+
+			void CreateSamplerFeedbackUnorderedAccessView(
+				ID3D12Resource* pTargetedResource,
+				ID3D12Resource* pFeedbackResource,
+				D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
+			{
+				Self().CreateSamplerFeedbackUnorderedAccessView(
+					pTargetedResource,
+					pFeedbackResource,
+					DestDescriptor);
+			}
+
+			void GetCopyableFootprints1(
+				const D3D12_RESOURCE_DESC1& pResourceDesc,
+				UINT FirstSubresource,
+				UINT NumSubresources,
+				UINT64 BaseOffset,
+				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
+				UINT* pNumRows,
+				UINT64* pRowSizeInBytes,
+				UINT64* pTotalBytes)
+			{
+				Self().GetCopyableFootprints1(
+					&pResourceDesc,
+					FirstSubresource,
+					NumSubresources,
+					BaseOffset,
+					pLayouts,
+					pNumRows,
+					pRowSizeInBytes,
+					pTotalBytes);
+			}
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device9>>
+	{
+		using inner_type = ID3D12Device9;
+
+		using inner_tag = ID3D12Device9;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device8>, Derived>
+		{
+			Wrapper<ID3D12ShaderCacheSession> CreateShaderCacheSession(
+				const D3D12_SHADER_CACHE_SESSION_DESC& pDesc)
+			{
+				return ForwardFunction<Wrapper<ID3D12ShaderCacheSession>>(&inner_type::CreateShaderCacheSession, Self(), &pDesc);
+			}
+
+			HRESULT ShaderCacheControl(
+				D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
+				D3D12_SHADER_CACHE_CONTROL_FLAGS Control)
+			{
+				return Self().ShaderCacheControl(Kinds, Control);
+			}
+
+			template<D3D12_COMMAND_LIST_TYPE Type>
+			Wrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandQueue>> CreateCommandQueue1(
+				D3D12_COMMAND_QUEUE_PRIORITY priority,
+				D3D12_COMMAND_QUEUE_FLAGS flags,
+				UINT nodeMask,
+				REFIID CreatorID)
+			{
+				D3D12_COMMAND_QUEUE_DESC desc
+				{
+					.Type = Type,
+					.Priority = priority,
+					.Flags = flags,
+					.NodeMask = nodeMask
+				};
+
+				return ForwardFunction<Wrapper<D3D12::CommandListTypeToTrait<Type, ID3D12CommandQueue>>>(&inner_type::CreateCommandQueue1, Self(), &desc, CreatorID);
+			}
+
+
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
+
+	template<>
+	struct Trait<Untagged<ID3D12Device10>>
+	{
+		using inner_type = ID3D12Device10;
+
+		using inner_tag = ID3D12Device10;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		struct Interface : TraitInterface<Untagged<ID3D12Device9>, Derived>
+		{
+			Wrapper<ID3D12Resource2> CreateCommittedResource3(
+				const D3D12_HEAP_PROPERTIES& pHeapProperties,
+				D3D12_HEAP_FLAGS HeapFlags,
+				const D3D12_RESOURCE_DESC1& pDesc,
+				D3D12_BARRIER_LAYOUT InitialLayout,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				ID3D12ProtectedResourceSession* pProtectedSession,
+				std::span<DXGI_FORMAT> CastableFormats)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource2>>(&inner_type::CreateCommittedResource3, Self(),
+					&pHeapProperties,
+					HeapFlags,
+					&pDesc,
+					InitialLayout,
+					pOptimizedClearValue,
+					pProtectedSession,
+					static_cast<UINT32>(CastableFormats.size()),
+					CastableFormats.data());
+			}
+
+			Wrapper<ID3D12Resource2> CreatePlacedResource2(
+				ID3D12Heap& pHeap,
+				UINT64 HeapOffset,
+				const D3D12_RESOURCE_DESC1& pDesc,
+				D3D12_BARRIER_LAYOUT InitialLayout,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				std::span<DXGI_FORMAT> CastableFormats)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource2>>(&inner_type::CreatePlacedResource2, Self(),
+					&pHeap,
+					HeapOffset,
+					pDesc,
+					InitialLayout,
+					pOptimizedClearValue,
+					static_cast<UINT32>(CastableFormats.size()),
+					CastableFormats.data());
+			}
+
+			Wrapper<ID3D12Resource2> CreateReservedResource2(
+				const D3D12_RESOURCE_DESC& pDesc,
+				D3D12_BARRIER_LAYOUT InitialLayout,
+				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
+				ID3D12ProtectedResourceSession* pProtectedSession,
+				std::span<DXGI_FORMAT> CastableFormats)
+			{
+				return ForwardFunction<Wrapper<ID3D12Resource2>>(&inner_type::CreateReservedResource2, Self(),
+					pDesc,
+					InitialLayout,
+					pOptimizedClearValue,
+					pProtectedSession,
+					static_cast<UINT32>(CastableFormats.size()),
+					CastableFormats.data());
+			}
+		private:
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
+		};
+	};
 }
 
-//
-//	class SetEventOnMultipleFenceCompletionData
-//	{
-//		UINT count;
-//		ID3D12Fence* const* fenceViews;
-//		const UINT64* fenceValues;
-//
-//	public:
-//		template<UINT Count>
-//		SetEventOnMultipleFenceCompletionData(std::span<ID3D12Fence*, Count> fences, std::span<UINT64, Count> fenceValues) :
-//			count{ Count },
-//			fenceViews{ fences.data() },
-//			fenceValues{ fenceValues.data() }
-//		{
-//
-//		}
-//
-//		SetEventOnMultipleFenceCompletionData(UINT count, ID3D12Fence*const* fences, UINT64* fenceValues) :
-//			count{ count },
-//			fenceViews{ fences },
-//			fenceValues{ fenceValues }
-//		{
-//
-//		}
-//
-//	public:
-//		UINT GetCount() const noexcept { return count; }
-//		ID3D12Fence* const* GetFences() const noexcept { return fenceViews; }
-//		const UINT64* GetFenceValues() const noexcept { return fenceValues; }
-//	};
-//
-//	class SetResidencyPriorityData
-//	{
-//		UINT count;
-//		ID3D12Pageable* const* pageables;
-//		const D3D12_RESIDENCY_PRIORITY* priorities;
-//
-//	public:
-//		template<UINT Count>
-//		SetResidencyPriorityData(std::span<ID3D12Pageable*, Count> pageables, std::span<D3D12_RESIDENCY_PRIORITY, Count> priorities) :
-//			count{ Count },
-//			pageables{ pageables.data() },
-//			priorities{ priorities.data() }
-//		{
-//
-//		}
-//
-//		SetResidencyPriorityData(UINT count, ID3D12Pageable* const* pageables, D3D12_RESIDENCY_PRIORITY* priorities) :
-//			count{ count },
-//			pageables{ pageables },
-//			priorities{ priorities }
-//		{
-//
-//		}
-//
-//	public:
-//		UINT GetCount() const noexcept { return count; }
-//		ID3D12Pageable* const* GetPageables() const noexcept { return pageables; }
-//		const D3D12_RESIDENCY_PRIORITY* GetPriorities() const noexcept { return priorities; }
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device1>
-//	{
-//		using value_type = ID3D12Device1;
-//		using pointer = ID3D12Device1*;
-//		using const_pointer = const ID3D12Device1*;
-//		using reference = ID3D12Device1&;
-//		using const_reference = const ID3D12Device1&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<ID3D12Device>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			ComPtr<ID3D12PipelineLibrary> CreatePipelineLibrary(
-//				const void* pLibraryBlob,
-//				SIZE_T BlobLength)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12PipelineLibrary>(ID3D12Device1::CreatePipelineLibrary, Get(), pLibraryBlob, BlobLength);
-//			}
-//
-//			void SetEventOnMultipleFenceCompletion(
-//				SetEventOnMultipleFenceCompletionData data,
-//				D3D12_MULTIPLE_FENCE_WAIT_FLAGS Flags,
-//				HANDLE hEvent)
-//			{
-//
-//				ThrowIfFailed(Self().SetEventOnMultipleFenceCompletion(
-//					data.GetFences(),
-//					data.GetFenceValues(),
-//					data.GetCount(),
-//					Flags,
-//					hEvent));
-//			}
-//
-//			void SetResidencyPriority(SetResidencyPriorityData data)
-//			{
-//				ThrowIfFailed(Self().SetResidencyPriority(
-//					data.GetCount(),
-//					data.GetPageables(),
-//					data.GetPriorities()));
-//			}
-//
-//			void SetResidencyPriority(ID3D12Pageable* page, D3D12_RESIDENCY_PRIORITY priority)
-//			{
-//				SetResidencyPriority({ 1, &page, &priority });
-//			}
-//
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device2>
-//	{
-//		using value_type = ID3D12Device2;
-//		using pointer = ID3D12Device2*;
-//		using const_pointer = const ID3D12Device2*;
-//		using reference = ID3D12Device2&;
-//		using const_reference = const ID3D12Device2&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<ID3D12Device1>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//
-//			template<class Ty>
-//			PipelineState_t<Ty> CreatePipelineState(
-//				const D3D12_PIPELINE_STATE_STREAM_DESC pDesc)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device2::CreatePipelineState, Get(), &pDesc);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device3>
-//	{
-//		using value_type = ID3D12Device3;
-//		using pointer = ID3D12Device3*;
-//		using const_pointer = const ID3D12Device3*;
-//		using reference = ID3D12Device3&;
-//		using const_reference = const ID3D12Device3&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<ID3D12Device2>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			ComPtr<ID3D12Heap> OpenExistingHeapFromAddress(
-//				const void* pAddress)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromAddress, Get(), pAddress);
-//			}
-//
-//			ComPtr<ID3D12Heap> OpenExistingHeapFromFileMapping(
-//				HANDLE hFileMapping)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device3::OpenExistingHeapFromFileMapping, Get(), hFileMapping);
-//			}
-//
-//			void EnqueueMakeResident(
-//				D3D12_RESIDENCY_FLAGS Flags,
-//				std::span<ID3D12Pageable*> ppObjects,
-//				ID3D12Fence& pFenceToSignal,
-//				UINT64 FenceValueToSignal)
-//			{
-//				ThrowIfFailed(Self().EnqueueMakeResident(
-//					Flags,
-//					static_cast<UINT>(ppObjects.size()),
-//					ppObjects.data(),
-//					&pFenceToSignal, FenceValueToSignal));
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device4>
-//	{
-//		using value_type = ID3D12Device4;
-//		using pointer = ID3D12Device4*;
-//		using const_pointer = const ID3D12Device4*;
-//		using reference = ID3D12Device4&;
-//		using const_reference = const ID3D12Device4&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<ID3D12Device3>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			template<D3D12_COMMAND_LIST_TYPE Type, std::derived_from<ID3D12CommandList> ListTy = ID3D12GraphicsCommandList>
-//			CommandList_t<ListTy, Type> CreateCommandList1(
-//				UINT nodeMask,
-//				D3D12_COMMAND_LIST_FLAGS flags)
-//			{
-//				return Helpers::D3D12::CreateCommandList<ListTy>(Get(), Type, flags, nodeMask);
-//			}
-//
-//			ComPtr<ID3D12ProtectedResourceSession> CreateProtectedResourceSession(
-//				const D3D12_PROTECTED_RESOURCE_SESSION_DESC& pDesc)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12ProtectedResourceSession>(&ID3D12Device4::CreateProtectedResourceSession, Get(), &pDesc);
-//			}
-//
-//			Wrapper<ID3D12Resource> CreateCommittedResource1(
-//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-//				D3D12_HEAP_FLAGS HeapFlags,
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialResourceState,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				ID3D12ProtectedResourceSession* pProtectedSession)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource>(
-//					&ID3D12Device4::CreateCommittedResource1,
-//					Get(),
-//					&pHeapProperties,
-//					HeapFlags,
-//					&pDesc,
-//					InitialResourceState,
-//					pOptimizedClearValue,
-//					pProtectedSession);
-//			}
-//
-//			ComPtr<ID3D12Heap> CreateHeap1(
-//				const D3D12_HEAP_DESC& pDesc,
-//				ID3D12ProtectedResourceSession* pProtectedSession)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Heap>(
-//					&ID3D12Device4::CreateHeap1,
-//					Get(),
-//					&pDesc,
-//					pProtectedSession);
-//			}
-//
-//			Wrapper<ID3D12Resource> CreateReservedResource1(
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialState,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				ID3D12ProtectedResourceSession* pProtectedSession)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Heap>(
-//					&ID3D12Device4::CreateReservedResource1,
-//					Get(),
-//					&pDesc,
-//					InitialState,
-//					pOptimizedClearValue,
-//					pProtectedSession);
-//			}
-//
-//			std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> GetResourceAllocationInfo1(
-//				UINT visibleMask,
-//				std::span<const D3D12_RESOURCE_DESC> pResourceDescs)
-//			{
-//				std::vector<D3D12_RESOURCE_ALLOCATION_INFO1> pResourceAllocationInfo1(pResourceDescs.size());
-//				Self().GetResourceAllocationInfo1(visibleMask, static_cast<UINT>(pResourceDescs.size()), pResourceDescs.data(), pResourceAllocationInfo1.data());
-//				return pResourceAllocationInfo1;
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device5>
-//	{
-//		using value_type = ID3D12Device5;
-//		using pointer = ID3D12Device5*;
-//		using const_pointer = const ID3D12Device5*;
-//		using reference = ID3D12Device5&;
-//		using const_reference = const ID3D12Device5&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<ID3D12Device4>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//		//TODO: Figure out how this works to update to a more modern API
-//			void CreateLifetimeTracker(
-//				ID3D12LifetimeOwner& pOwner,
-//				REFIID riid,
-//				void** ppvTracker)
-//			{
-//				ThrowIfFailed(Self().CreateLifetimeTracker(&pOwner, riid, ppvTracker));
-//			}
-//
-//			void RemoveDevice()
-//			{
-//				Self().RemoveDevice();
-//			}
-//
-//			UINT GetNumMetaCommands()
-//			{
-//				UINT pNumMetaCommands = 0;
-//				Self().EnumerateMetaCommands(&pNumMetaCommands, nullptr);
-//				return pNumMetaCommands;
-//			}
-//
-//			std::vector<D3D12_META_COMMAND_DESC> EnumerateMetaCommands(
-//				UINT pNumMetaCommands)
-//			{
-//				std::vector<D3D12_META_COMMAND_DESC> pDescs(pNumMetaCommands);
-//				ThrowIfFailed(Self().EnumerateMetaCommands(&pNumMetaCommands, pDescs.data()));
-//				return pDescs;
-//			}
-//
-//			UINT GetNumMetaCommandParameters(
-//				REFGUID CommandId,
-//				D3D12_META_COMMAND_PARAMETER_STAGE Stage)
-//			{
-//				UINT pNumMetaCommandParams = 0;
-//				Self().EnumerateMetaCommandParameters(CommandId, Stage, nullptr, &pNumMetaCommandParams, nullptr);
-//				return pNumMetaCommandParams;
-//			}
-//
-//			MetaCommandParameterInfo STDMETHODCALLTYPE EnumerateMetaCommandParameters(
-//				_In_  REFGUID CommandId,
-//				_In_  D3D12_META_COMMAND_PARAMETER_STAGE Stage,
-//				UINT parameterCount)
-//			{
-//				MetaCommandParameterInfo info{};
-//
-//				info.parameterCount = parameterCount;
-//				info.parameterDescs.resize(parameterCount);
-//
-//				ThrowIfFailed(Self().EnumerateMetaCommandParameters(
-//					CommandId,
-//					Stage,
-//					&info.totalStructureSizeInBytes,
-//					&info.parameterCount,
-//					info.parameterDescs.data()));
-//
-//				return info;
-//			}
-//
-//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-//				REFGUID CommandId,
-//				UINT NodeMask,
-//				const void* pCreationParametersData,
-//				SIZE_T CreationParametersDataSizeInBytes)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12MetaCommand>(
-//					&ID3D12Device5::CreateMetaCommand,
-//					Get(),
-//					CommandId,
-//					NodeMask,
-//					pCreationParametersData,
-//					CreationParametersDataSizeInBytes);
-//			}
-//
-//			template<class CreationParamStruct>
-//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-//				REFGUID CommandId,
-//				UINT NodeMask,
-//				const CreationParamStruct& pCreationParametersData)
-//			{
-//				return CreateMetaCommand(CommandId, NodeMask, &pCreationParametersData, sizeof(CreationParamStruct));
-//			}
-//
-//			ComPtr<ID3D12MetaCommand> CreateMetaCommand(
-//				REFGUID CommandId,
-//				UINT NodeMask)
-//			{
-//				return CreateMetaCommand(CommandId, NodeMask, nullptr, 0);
-//			}
-//
-//			ComPtr<ID3D12StateObject> CreateStateObject(
-//				const D3D12_STATE_OBJECT_DESC& pDesc)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12StateObject>(
-//					&ID3D12Device5::CreateStateObject,
-//					Get(),
-//					&pDesc);
-//			}
-//
-//			D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO GetRaytracingAccelerationStructurePrebuildInfo(
-//				const D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS& pDesc)
-//			{
-//				D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO prebuildInfo;
-//				Self().GetRaytracingAccelerationStructurePrebuildInfo(&pDesc, &prebuildInfo);
-//				return prebuildInfo;
-//			}
-//
-//			D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS CheckDriverMatchingIdentifier(
-//				D3D12_SERIALIZED_DATA_TYPE SerializedDataType,
-//				const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER& pIdentifierToCheck)
-//			{
-//				return Self().CheckDriverMatchingIdentifier(
-//					SerializedDataType,
-//					&pIdentifierToCheck);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device6>
-//	{
-//		using base_value_type = ID3D12Device5;
-//		using value_type = ID3D12Device6;
-//		using pointer = ID3D12Device6*;
-//		using const_pointer = const ID3D12Device6*;
-//		using reference = ID3D12Device6&;
-//		using const_reference = const ID3D12Device6&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//		//TODO: Figure out how this works to update to a more modern API
-//			HRESULT SetBackgroundProcessingMode(
-//				D3D12_BACKGROUND_PROCESSING_MODE Mode,
-//				D3D12_MEASUREMENTS_ACTION MeasurementsAction,
-//				_In_opt_  HANDLE hEventToSignalUponCompletion,
-//				_Out_opt_  BOOL* pbFurtherMeasurementsDesired)
-//			{
-//				return Self().SetBackgroundProcessingMode(
-//					Mode,
-//					MeasurementsAction,
-//					hEventToSignalUponCompletion,
-//					pbFurtherMeasurementsDesired);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device7>
-//	{
-//		using base_value_type = ID3D12Device6;
-//		using value_type = ID3D12Device7;
-//		using pointer = ID3D12Device7*;
-//		using const_pointer = const ID3D12Device7*;
-//		using reference = ID3D12Device7&;
-//		using const_reference = const ID3D12Device7&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			//TODO: Figure out how this works to update to a more modern API
-//			HRESULT AddToStateObject(
-//				const D3D12_STATE_OBJECT_DESC* pAddition,
-//				ID3D12StateObject* pStateObjectToGrowFrom,
-//				REFIID riid,
-//				_COM_Outptr_  void** ppNewStateObject)
-//			{
-//				return Self().AddToStateObject(
-//					pAddition,
-//					pStateObjectToGrowFrom,
-//					riid,
-//					ppNewStateObject);
-//			}
-//
-//			//TODO: Figure out how this works to update to a more modern API
-//			HRESULT CreateProtectedResourceSession1(
-//				const D3D12_PROTECTED_RESOURCE_SESSION_DESC1* pDesc,
-//				REFIID riid,
-//				void** ppSession)
-//			{
-//				return Self().CreateProtectedResourceSession1(
-//					pDesc,
-//					riid,
-//					ppSession);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device8>
-//	{
-//		using base_value_type = ID3D12Device7;
-//		using value_type = ID3D12Device8;
-//		using pointer = ID3D12Device8*;
-//		using const_pointer = const ID3D12Device8*;
-//		using reference = ID3D12Device8&;
-//		using const_reference = const ID3D12Device8&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//#if defined(_MSC_VER) || !defined(_WIN32)
-//			D3D12_RESOURCE_ALLOCATION_INFO GetResourceAllocationInfo2(
-//				UINT visibleMask,
-//				UINT numResourceDescs,
-//				const D3D12_RESOURCE_DESC1* pResourceDescs,
-//				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
-//			{
-//				return Self().GetResourceAllocationInfo2(visibleMask,
-//					numResourceDescs,
-//					pResourceDescs,
-//					pResourceAllocationInfo1);
-//			}
-//#else
-//			D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE GetResourceAllocationInfo2(
-//				D3D12_RESOURCE_ALLOCATION_INFO* RetVal,
-//				UINT visibleMask,
-//				UINT numResourceDescs,
-//				const D3D12_RESOURCE_DESC1* pResourceDescs,
-//				D3D12_RESOURCE_ALLOCATION_INFO1* pResourceAllocationInfo1)
-//			{
-//				return Self().GetResourceAllocationInfo2(RetVal,
-//					visibleMask,
-//					numResourceDescs,
-//					pResourceDescs,
-//					pResourceAllocationInfo1);
-//			}
-//#endif
-//
-//			TypedD3D::Wrapper<ID3D12Resource> CreateCommittedResource2(
-//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-//				D3D12_HEAP_FLAGS HeapFlags,
-//				const D3D12_RESOURCE_DESC1& pDesc,
-//				D3D12_RESOURCE_STATES InitialResourceState,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				ID3D12ProtectedResourceSession* pProtectedSession)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource>(&inner_type::CreateCommittedResource2, Get(),
-//					&pHeapProperties,
-//					HeapFlags,
-//					&pDesc,
-//					InitialResourceState,
-//					pOptimizedClearValue,
-//					pProtectedSession);
-//			}
-//
-//			TypedD3D::Wrapper<ID3D12Resource> CreatePlacedResource1(
-//				ID3D12Heap& pHeap,
-//				UINT64 HeapOffset,
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_RESOURCE_STATES InitialState,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource>(&inner_type::CreatePlacedResource1, Get(),
-//					&pHeap,
-//					HeapOffset,
-//					&pDesc,
-//					InitialState,
-//					pOptimizedClearValue);
-//			}
-//
-//			void CreateSamplerFeedbackUnorderedAccessView(
-//				ID3D12Resource* pTargetedResource,
-//				ID3D12Resource* pFeedbackResource,
-//				D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor)
-//			{
-//				Self().CreateSamplerFeedbackUnorderedAccessView(
-//					pTargetedResource,
-//					pFeedbackResource,
-//					DestDescriptor);
-//			}
-//
-//			void GetCopyableFootprints1(
-//				const D3D12_RESOURCE_DESC1& pResourceDesc,
-//				UINT FirstSubresource,
-//				UINT NumSubresources,
-//				UINT64 BaseOffset,
-//				D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
-//				UINT* pNumRows,
-//				UINT64* pRowSizeInBytes,
-//				UINT64* pTotalBytes)
-//			{
-//				Self().GetCopyableFootprints1(
-//					&pResourceDesc,
-//					FirstSubresource,
-//					NumSubresources,
-//					BaseOffset,
-//					pLayouts,
-//					pNumRows,
-//					pRowSizeInBytes,
-//					pTotalBytes);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device9>
-//	{
-//		using base_value_type = ID3D12Device8;
-//		using value_type = ID3D12Device9;
-//		using pointer = ID3D12Device9*;
-//		using const_pointer = const ID3D12Device9*;
-//		using reference = ID3D12Device9&;
-//		using const_reference = const ID3D12Device9&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			ComPtr<ID3D12ShaderCacheSession> CreateShaderCacheSession(
-//				const D3D12_SHADER_CACHE_SESSION_DESC& pDesc)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12ShaderCacheSession>(&inner_type::CreateShaderCacheSession, Get(), &pDesc);
-//			}
-//
-//			HRESULT ShaderCacheControl(
-//				D3D12_SHADER_CACHE_KIND_FLAGS Kinds,
-//				D3D12_SHADER_CACHE_CONTROL_FLAGS Control)
-//			{
-//				return Self().ShaderCacheControl(Kinds, Control);
-//			}
-//
-//			template<D3D12_COMMAND_LIST_TYPE Type>
-//			D3D12CommandQueue_t<Type> CreateCommandQueue1(
-//				D3D12_COMMAND_QUEUE_PRIORITY priority,
-//				D3D12_COMMAND_QUEUE_FLAGS flags,
-//				UINT nodeMask,
-//				REFIID CreatorID)
-//			{
-//				using queue_type = D3D12CommandQueue_t<Type>;
-//
-//				D3D12_COMMAND_QUEUE_DESC desc
-//				{
-//					.Type = Type,
-//					.Priority = priority,
-//					.Flags = flags,
-//					.NodeMask = nodeMask
-//				};
-//
-//				return IIDToObjectForwardFunction<ID3D12CommandQueue>(&inner_type::CreateCommandQueue1, Get(), &desc, CreatorID);
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	template<>
-//	struct DeviceTraits<ID3D12Device10>
-//	{
-//		using base_value_type = ID3D12Device9;
-//		using value_type = ID3D12Device10;
-//		using pointer = ID3D12Device10*;
-//		using const_pointer = const ID3D12Device10*;
-//		using reference = ID3D12Device10&;
-//		using const_reference = const ID3D12Device10&;
-//
-//		template<class DerivedSelf>
-//		class Interface : public DeviceTraits<base_value_type>::Interface<DerivedSelf>
-//		{
-//		private:
-//			using derived_self = DerivedSelf;
-//
-//		public:
-//			TypedD3D::Wrapper<ID3D12Resource2> CreateCommittedResource3(
-//				const D3D12_HEAP_PROPERTIES& pHeapProperties,
-//				D3D12_HEAP_FLAGS HeapFlags,
-//				const D3D12_RESOURCE_DESC1& pDesc,
-//				D3D12_BARRIER_LAYOUT InitialLayout,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				ID3D12ProtectedResourceSession* pProtectedSession,
-//				std::span<DXGI_FORMAT> CastableFormats)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource2>(&inner_type::CreateCommittedResource3, Get(),
-//					&pHeapProperties,
-//					HeapFlags,
-//					&pDesc,
-//					InitialLayout,
-//					pOptimizedClearValue,
-//					pProtectedSession,
-//					static_cast<UINT32>(CastableFormats.size()),
-//					CastableFormats.data());
-//			}
-//
-//			TypedD3D::Wrapper<ID3D12Resource2> CreatePlacedResource2(
-//				ID3D12Heap& pHeap,
-//				UINT64 HeapOffset,
-//				const D3D12_RESOURCE_DESC1& pDesc,
-//				D3D12_BARRIER_LAYOUT InitialLayout,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				std::span<DXGI_FORMAT> CastableFormats)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource2>(&inner_type::CreatePlacedResource2, Get(),
-//					&pHeap,
-//					HeapOffset,
-//					pDesc,
-//					InitialLayout,
-//					pOptimizedClearValue,
-//					static_cast<UINT32>(CastableFormats.size()),
-//					CastableFormats.data());
-//			}
-//
-//			TypedD3D::Wrapper<ID3D12Resource1> CreateReservedResource2(
-//				const D3D12_RESOURCE_DESC& pDesc,
-//				D3D12_BARRIER_LAYOUT InitialLayout,
-//				const D3D12_CLEAR_VALUE* pOptimizedClearValue,
-//				ID3D12ProtectedResourceSession* pProtectedSession,
-//				std::span<DXGI_FORMAT> CastableFormats)
-//			{
-//				return IIDToObjectForwardFunction<ID3D12Resource1>(&inner_type::CreateReservedResource2, Get(),
-//					pDesc,
-//					InitialLayout,
-//					pOptimizedClearValue,
-//					pProtectedSession,
-//					static_cast<UINT32>(CastableFormats.size()),
-//					CastableFormats.data());
-//			}
-//
-//		private:
-//			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//			reference Get() { return *ToDerived().derived_self::Get(); }
-//		};
-//	};
-//
-//	namespace Aliases
-//	{
-//		export using Device = Device_t<ID3D12Device>;
-//		export using Device1 = Device_t<ID3D12Device1>;
-//		export using Device2 = Device_t<ID3D12Device2>;
-//		export using Device3 = Device_t<ID3D12Device3>;
-//		export using Device4 = Device_t<ID3D12Device4>;
-//		export using Device5 = Device_t<ID3D12Device5>;
-//		export using Device6 = Device_t<ID3D12Device6>;
-//		export using Device7 = Device_t<ID3D12Device7>;
-//		export using Device8 = Device_t<ID3D12Device8>;
-//		export using Device9 = Device_t<ID3D12Device9>;
-//		export using Device10 = Device_t<ID3D12Device10>;
-//	}
-//
-//	export template<class DeviceTy = Aliases::Device>
-//	Device_t<DeviceTy> CreateDevice(D3D_FEATURE_LEVEL minimumFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
-//	{
-//		if constexpr(std::is_base_of_v<ID3D12Device, DeviceTy>)
-//		{
-//			return Helpers::D3D12::CreateDevice<DeviceTy>(minimumFeatureLevel, optAdapter);
-//		}
-//		else
-//		{
-//			return Helpers::D3D12::CreateDevice<typename DeviceTy::value_type>(minimumFeatureLevel, optAdapter);
-//		}
-//	}
-//}
-//
-//namespace TypedD3D
-//{
-//	template<std::derived_from<ID3D12Device> Ty>
-//	struct UntaggedTraits<Ty>
-//	{
-//		using value_type = Ty;
-//		using pointer = Ty*;
-//		using const_pointer = const Ty*;
-//		using reference = Ty&;
-//		using const_reference = const Ty&;
-//
-//		template<class DerivedSelf>
-//		using Interface = typename D3D12::DeviceTraits<Ty>::template Interface<DerivedSelf>;
-//	};
-//}
+namespace TypedD3D::D3D12
+{
+	export template<class DeviceTy = ID3D12Device>
+		Wrapper<DeviceTy> CreateDevice(D3D_FEATURE_LEVEL minimumFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
+	{
+		return ForwardFunction<Wrapper<DeviceTy>>(&D3D12CreateDevice, optAdapter, minimumFeatureLevel);
+	}
+}

--- a/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
+++ b/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
@@ -18,13 +18,16 @@ namespace TypedD3D::D3D12
 {
 	struct DeviceChildTraits
 	{
-		using value_type = ID3D12DeviceChild;
-		using pointer = ID3D12DeviceChild*;
-		using const_pointer = const ID3D12DeviceChild*;
-		using reference = ID3D12DeviceChild&;
-		using const_reference = const ID3D12DeviceChild&;
-
 		using inner_type = ID3D12DeviceChild;
+
+		using inner_tag = ID3D12DeviceChild;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<IUnknownTrait Derived>
 		class Interface : public InterfaceBase<Derived>
 		{
@@ -35,7 +38,7 @@ namespace TypedD3D::D3D12
 			template<std::derived_from<ID3D12Device> DeviceTy = ID3D12Device>
 			Wrapper<DeviceTy> GetDevice()
 			{
-				return ForwardFunction<DeviceTy>(&value_type::GetDevice, Self());
+				return ForwardFunction<DeviceTy>(&inner_type::GetDevice, Self());
 			}
 
 		private:
@@ -43,4 +46,34 @@ namespace TypedD3D::D3D12
 			using InterfaceBase<Derived>::ToDerived;
 		};
 	};
+}
+
+namespace TypedD3D
+{
+	//template<>
+	//struct Trait<Untagged<ID3D12DeviceChild>>
+	//{
+	//	using inner_type = ID3D12CommandAllocator;
+
+	//	template<class NewInner>
+	//	using trait_template = Untagged<NewInner>;
+
+	//	template<class Derived>
+	//	class Interface : public InterfaceBase<Untagged<Derived>>
+	//	{
+	//	private:
+	//		using derived_self = Derived;
+
+	//	public:
+	//		template<std::derived_from<ID3D12Device> DeviceTy = ID3D12Device>
+	//		Wrapper<DeviceTy> GetDevice()
+	//		{
+	//			return ForwardFunction<DeviceTy>(&inner_type::GetDevice, Self());
+	//		}
+
+	//	private:
+	//		using InterfaceBase<Untagged<Derived>>::Self;
+	//		using InterfaceBase<Untagged<Derived>>::ToDerived;
+	//	};
+	//};
 }

--- a/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
+++ b/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
@@ -24,6 +24,7 @@ namespace TypedD3D::D3D12
 		using reference = ID3D12DeviceChild&;
 		using const_reference = const ID3D12DeviceChild&;
 
+		using inner_type = ID3D12DeviceChild;
 		template<IUnknownTrait Derived>
 		class Interface : public InterfaceBase<Derived>
 		{

--- a/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
+++ b/TypedD3D/source/D3D12/D3D12DeviceChild.ixx
@@ -3,7 +3,7 @@ module;
 #include <d3d12.h>
 #include <array>
 #include <span>
-#include <wrl/client.h>
+
 #include <assert.h>
 #include <optional>
 
@@ -24,22 +24,22 @@ namespace TypedD3D::D3D12
 		using reference = ID3D12DeviceChild&;
 		using const_reference = const ID3D12DeviceChild&;
 
-		template<class DerivedSelf>
-		class Interface
+		template<IUnknownTrait Derived>
+		class Interface : public InterfaceBase<Derived>
 		{
 		private:
-			using derived_self = DerivedSelf;
+			using derived_self = Derived;
 
 		public:
 			template<std::derived_from<ID3D12Device> DeviceTy = ID3D12Device>
 			Wrapper<DeviceTy> GetDevice()
 			{
-				return IIDToObjectForwardFunction<DeviceTy>(&value_type::GetDevice, Get());
+				return ForwardFunction<DeviceTy>(&value_type::GetDevice, Self());
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<Derived>::Self;
+			using InterfaceBase<Derived>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/D3D12/D3D12Object.ixx
+++ b/TypedD3D/source/D3D12/D3D12Object.ixx
@@ -8,9 +8,18 @@ import	TypedD3D.Shared;
 namespace TypedD3D
 {
 	template<std::derived_from<ID3D12Object> Ty>
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
 		using inner_type = Ty;
+
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
 		using Interface = Ty*;
 	};

--- a/TypedD3D/source/D3D12/D3D12Object.ixx
+++ b/TypedD3D/source/D3D12/D3D12Object.ixx
@@ -1,16 +1,13 @@
 module;
-
 #include <concepts>
-#include <dxgi1_6.h>
+#include <d3d12.h>
 
-#include <utility>
-
-export module TypedDXGI:DXGIObject;
-import TypedD3D.Shared;
+export module TypedD3D12:D3D12Object;
+import	TypedD3D.Shared;
 
 namespace TypedD3D
 {
-	template<std::derived_from<IDXGIObject> Ty>
+	template<std::derived_from<ID3D12Object> Ty>
 	struct UntaggedTraits<Ty>
 	{
 		using inner_type = Ty;

--- a/TypedD3D/source/D3D12/D3D12Object.ixx
+++ b/TypedD3D/source/D3D12/D3D12Object.ixx
@@ -23,4 +23,21 @@ namespace TypedD3D
 		template<class Derived>
 		using Interface = Ty*;
 	};
+
+	template<>
+	struct Trait<Untagged<ID3D12LifetimeOwner>>
+	{
+		using inner_type = ID3D12LifetimeOwner;
+
+		using inner_tag = ID3D12LifetimeOwner;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
+		template<class Derived>
+		using Interface = ID3D12LifetimeOwner*;
+	};
 }

--- a/TypedD3D/source/D3D12/D3D12Object.ixx
+++ b/TypedD3D/source/D3D12/D3D12Object.ixx
@@ -7,7 +7,7 @@ import	TypedD3D.Shared;
 
 namespace TypedD3D
 {
-	template<std::derived_from<ID3D12Object> Ty>
+	template<DerivedFromExcept<ID3D12Object, ID3D12CommandList> Ty>
 	struct Trait<Untagged<Ty>>
 	{
 		using inner_type = Ty;

--- a/TypedD3D/source/D3D12/D3D12Resource.ixx
+++ b/TypedD3D/source/D3D12/D3D12Resource.ixx
@@ -20,6 +20,7 @@ namespace TypedD3D
         using reference = ID3D12Resource&;
         using const_reference = const ID3D12Resource&;
 
+        using inner_type = ID3D12Resource;
         template<class Derived>
         class Interface : public InterfaceBase<UntaggedTraits<Derived>>
         {

--- a/TypedD3D/source/D3D12/D3D12Resource.ixx
+++ b/TypedD3D/source/D3D12/D3D12Resource.ixx
@@ -3,7 +3,7 @@ module;
 #include <utility>
 #include <d3d12.h>
 
-#include <assert.h>
+#include <cassert>
 #include <cstddef>
 
 export module TypedD3D12:Resource;
@@ -12,17 +12,20 @@ import TypedD3D.Shared;
 namespace TypedD3D
 {
     template<>
-    struct UntaggedTraits<ID3D12Resource>
+    struct Trait<Untagged<ID3D12Resource>>
     {
-        using value_type = ID3D12Resource;
-        using pointer = ID3D12Resource*;
-        using const_pointer = const ID3D12Resource*;
-        using reference = ID3D12Resource&;
-        using const_reference = const ID3D12Resource&;
-
         using inner_type = ID3D12Resource;
+
+        using inner_tag = ID3D12Resource;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
+
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
+
         template<class Derived>
-        class Interface : public InterfaceBase<UntaggedTraits<Derived>>
+        class Interface : public InterfaceBase<Untagged<Derived>>
         {
         private:
             using derived_self = Derived;
@@ -72,13 +75,14 @@ namespace TypedD3D
             }
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
+
     template<>
-    struct UntaggedTraits<ID3D12Resource1>
+    struct Trait<Untagged<ID3D12Resource1>>
     {
         using value_type = ID3D12Resource1;
         using pointer = ID3D12Resource1*;
@@ -86,8 +90,11 @@ namespace TypedD3D
         using reference = ID3D12Resource1&;
         using const_reference = const ID3D12Resource1&;
 
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
+
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D12Resource>>::Interface<Derived>
         {
 		public:
 			//TODO: Figure out how this works to update to a more modern API
@@ -99,13 +106,13 @@ namespace TypedD3D
 			}
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 
     template<>
-    struct UntaggedTraits<ID3D12Resource2>
+    struct Trait<Untagged<ID3D12Resource2>>
     {
         using value_type = ID3D12Resource2;
         using pointer = ID3D12Resource2*;
@@ -113,8 +120,11 @@ namespace TypedD3D
         using reference = ID3D12Resource2&;
         using const_reference = const ID3D12Resource2&;
 
+        template<class NewInner>
+        using trait_template = Untagged<NewInner>;
+
         template<class Derived>
-        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D12Resource>>::Interface<Derived>
         {
         private:
             using derived_self = Derived;
@@ -126,8 +136,8 @@ namespace TypedD3D
 			}
 
         private:
-            using InterfaceBase<UntaggedTraits<Derived>>::Self;
-            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+            using InterfaceBase<Untagged<Derived>>::Self;
+            using InterfaceBase<Untagged<Derived>>::ToDerived;
         };
     };
 }

--- a/TypedD3D/source/D3D12/D3D12Resource.ixx
+++ b/TypedD3D/source/D3D12/D3D12Resource.ixx
@@ -84,11 +84,12 @@ namespace TypedD3D
     template<>
     struct Trait<Untagged<ID3D12Resource1>>
     {
-        using value_type = ID3D12Resource1;
-        using pointer = ID3D12Resource1*;
-        using const_pointer = const ID3D12Resource1*;
-        using reference = ID3D12Resource1&;
-        using const_reference = const ID3D12Resource1&;
+        using inner_type = ID3D12Resource1;
+
+        using inner_tag = ID3D12Resource1;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
 
         template<class NewInner>
         using trait_template = Untagged<NewInner>;
@@ -114,17 +115,18 @@ namespace TypedD3D
     template<>
     struct Trait<Untagged<ID3D12Resource2>>
     {
-        using value_type = ID3D12Resource2;
-        using pointer = ID3D12Resource2*;
-        using const_pointer = const ID3D12Resource2*;
-        using reference = ID3D12Resource2&;
-        using const_reference = const ID3D12Resource2&;
+        using inner_type = ID3D12Resource2;
+
+        using inner_tag = ID3D12Resource2;
+
+        template<class NewInner>
+        using ReplaceInnerType = Untagged<NewInner>;
 
         template<class NewInner>
         using trait_template = Untagged<NewInner>;
 
         template<class Derived>
-        class Interface : public Trait<Untagged<ID3D12Resource>>::Interface<Derived>
+        class Interface : public Trait<Untagged<ID3D12Resource1>>::Interface<Derived>
         {
         private:
             using derived_self = Derived;

--- a/TypedD3D/source/D3D12/D3D12Resource.ixx
+++ b/TypedD3D/source/D3D12/D3D12Resource.ixx
@@ -2,7 +2,7 @@ module;
 
 #include <utility>
 #include <d3d12.h>
-#include <wrl/client.h>
+
 #include <assert.h>
 #include <cstddef>
 
@@ -20,28 +20,28 @@ namespace TypedD3D
         using reference = ID3D12Resource&;
         using const_reference = const ID3D12Resource&;
 
-        template<class DerivedSelf>
-        class Interface
+        template<class Derived>
+        class Interface : public InterfaceBase<UntaggedTraits<Derived>>
         {
         private:
-            using derived_self = DerivedSelf;
+            using derived_self = Derived;
 
         public:
             std::byte* Map(UINT Subresource, const D3D12_RANGE* optReadRange)
             {
                 void* dataPtr;
-                ThrowIfFailed(Get().Map(Subresource, optReadRange, &dataPtr));
+                ThrowIfFailed(Self().Map(Subresource, optReadRange, &dataPtr));
                 return static_cast<std::byte*>(dataPtr);
             }
 
             void Unmap(UINT Subresource, const D3D12_RANGE* optWrittenRange)
             {
-                Get().Unmap(0, nullptr);
+                Self().Unmap(0, nullptr);
             }
 
-            D3D12_RESOURCE_DESC GetDesc() { return Get().GetDesc(); }
+            D3D12_RESOURCE_DESC GetDesc() { return Self().GetDesc(); }
 
-            D3D12_GPU_VIRTUAL_ADDRESS GetGPUVirtualAddress() { return Get().GetGPUVirtualAddress(); }
+            D3D12_GPU_VIRTUAL_ADDRESS GetGPUVirtualAddress() { return Self().GetGPUVirtualAddress(); }
 
             HRESULT WriteToSubresource(
                 UINT DstSubresource,
@@ -50,7 +50,7 @@ namespace TypedD3D
                 UINT SrcRowPitch,
                 UINT SrcDepthPitch)
             {
-                return Get().WriteToSubresource(DstSubresource, optDstBox, &pSrcData, SrcRowPitch, SrcDepthPitch);
+                return Self().WriteToSubresource(DstSubresource, optDstBox, &pSrcData, SrcRowPitch, SrcDepthPitch);
             }
 
             HRESULT STDMETHODCALLTYPE ReadFromSubresource(
@@ -60,18 +60,19 @@ namespace TypedD3D
                 UINT SrcSubresource,
                 const D3D12_BOX* optSrcBox)
             {
-                return Get().ReadFromSubresource(pDstData, DstRowPitch, DstDepthPitch, SrcSubresource, optSrcBox);
+                return Self().ReadFromSubresource(pDstData, DstRowPitch, DstDepthPitch, SrcSubresource, optSrcBox);
             }
 
             std::pair<D3D12_HEAP_PROPERTIES, D3D12_HEAP_FLAGS> GetHeapProperties()
             {
                 std::pair<D3D12_HEAP_PROPERTIES, D3D12_HEAP_FLAGS> properties;
-                Get().GetHeapProperties(&properties.first, &properties.second);
+                Self().GetHeapProperties(&properties.first, &properties.second);
                 return properties;
             }
+
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -84,24 +85,21 @@ namespace TypedD3D
         using reference = ID3D12Resource1&;
         using const_reference = const ID3D12Resource1&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<Derived>
         {
-        private:
-            using derived_self = DerivedSelf;
-
 		public:
 			//TODO: Figure out how this works to update to a more modern API
 			HRESULT GetProtectedResourceSession(
 				REFIID riid,
 				_COM_Outptr_opt_  void** ppProtectedSession)
 			{
-				return Get().GetProtectedResourceSession(riid, ppProtectedSession);
+				return Self().GetProtectedResourceSession(riid, ppProtectedSession);
 			}
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
 
@@ -114,31 +112,21 @@ namespace TypedD3D
         using reference = ID3D12Resource2&;
         using const_reference = const ID3D12Resource2&;
 
-        template<class DerivedSelf>
-        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<DerivedSelf>
+        template<class Derived>
+        class Interface : public UntaggedTraits<ID3D12Resource>::Interface<Derived>
         {
         private:
-            using derived_self = DerivedSelf;
+            using derived_self = Derived;
 
 		public:
 			D3D12_RESOURCE_DESC1 GetDesc1()
 			{
-				return Get().GetDesc1();
+				return Self().GetDesc1();
 			}
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<UntaggedTraits<Derived>>::Self;
+            using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
         };
     };
-}
-
-namespace TypedD3D::D3D12
-{
-    namespace Aliases
-    {
-        export using D3D12Resource = IUnknownWrapper<ID3D12Resource, UntaggedTraits>;
-        export using D3D12Resource1 = IUnknownWrapper<ID3D12Resource1, UntaggedTraits>;
-        export using D3D12Resource2 = IUnknownWrapper<ID3D12Resource2, UntaggedTraits>;
-    }
 }

--- a/TypedD3D/source/D3D12/D3D12Wrappers.ixx
+++ b/TypedD3D/source/D3D12/D3D12Wrappers.ixx
@@ -6,7 +6,7 @@ module;
 export module TypedD3D12:Wrappers; 
 import TypedD3D.Shared;
 
-namespace TypedD3D::D3D12
+namespace TypedD3D
 {
     export template<class Ty>
     struct DirectTraits;
@@ -44,108 +44,259 @@ namespace TypedD3D::D3D12
     template<class Ty>
     struct DirectMapper
     {
-        using type = IUnknownWrapper<Ty, DirectTraits>;
+        using type = StrongWrapper<DirectTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<DirectTraits<Ty>>
+    struct DirectMapper<Ty>
+    {
+        using type = TypedStruct<DirectTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct DirectViewMapper
+    {
+        using type = ReplaceOuterType<typename DirectMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct ComputeMapper
     {
-        using type = IUnknownWrapper<Ty, ComputeTraits>;
+        using type = StrongWrapper<ComputeTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<ComputeTraits<Ty>>
+    struct ComputeMapper<Ty>
+    {
+        using type = TypedStruct<ComputeTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct ComputeViewMapper
+    {
+        using type = ReplaceOuterType<typename ComputeMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct CopyMapper
     {
-        using type = IUnknownWrapper<Ty, CopyTraits>;
+        using type = StrongWrapper<CopyTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<CopyTraits<Ty>>
+    struct CopyMapper<Ty>
+    {
+        using type = TypedStruct<CopyTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct CopyViewMapper
+    {
+        using type = ReplaceOuterType<typename CopyMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct BundleMapper
     {
-        using type = IUnknownWrapper<Ty, BundleTraits>;
+        using type = StrongWrapper<BundleTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<BundleTraits<Ty>>
+    struct BundleMapper<Ty>
+    {
+        using type = TypedStruct<BundleTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct BundleViewMapper
+    {
+        using type = ReplaceOuterType<typename BundleMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct CBV_SRV_UAVMapper
     {
-        using type = IUnknownWrapper<Ty, CBV_SRV_UAVTraits>;
+        using type = StrongWrapper<CBV_SRV_UAVTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<CBV_SRV_UAVTraits<Ty>>
+    struct CBV_SRV_UAVMapper<Ty>
+    {
+        using type = TypedStruct<CBV_SRV_UAVTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct CBV_SRV_UAVViewMapper
+    {
+        using type = ReplaceOuterType<typename CBV_SRV_UAVMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct SamplerMapper
     {
-        using type = IUnknownWrapper<Ty, SamplerTraits>;
+        using type = StrongWrapper<SamplerTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<SamplerTraits<Ty>>
+    struct SamplerMapper<Ty>
+    {
+        using type = TypedStruct<SamplerTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct SamplerViewMapper
+    {
+        using type = ReplaceOuterType<typename SamplerMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct RTVMapper
     {
-        using type = IUnknownWrapper<Ty, RTVTraits>;
+        using type = StrongWrapper<RTVTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<RTVTraits<Ty>>
+    struct RTVMapper<Ty>
+    {
+        using type = TypedStruct<RTVTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct RTVViewMapper
+    {
+        using type = ReplaceOuterType<typename RTVMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct DSVMapper
     {
-        using type = IUnknownWrapper<Ty, DSVTraits>;
+        using type = StrongWrapper<DSVTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<DSVTraits<Ty>>
+    struct DSVMapper<Ty>
+    {
+        using type = TypedStruct<DSVTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct DSVViewMapper
+    {
+        using type = ReplaceOuterType<typename DSVMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct GraphicsMapper
     {
-        using type = IUnknownWrapper<Ty, GraphicsTraits>;
+        using type = StrongWrapper<GraphicsTraits<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<GraphicsTraits<Ty>>
+    struct GraphicsMapper<Ty>
+    {
+        using type = TypedStruct<GraphicsTraits<Ty>>;
+    };
+
+    template<class Ty>
+    struct GraphicsViewMapper
+    {
+        using type = ReplaceOuterType<typename GraphicsMapper<Ty>::type, WeakWrapper>;
     };
 
     template<class Ty>
     struct RenderPassMapper
     {
-        using type = IUnknownWrapper<Ty, RenderPassTraits>;
+        using type = StrongWrapper<RenderPassTraits<Ty>>;
     };
 
     template<class Ty>
-	struct ShaderVisibleMapper
-	{
-		using type = Ty;
-	};
-
-    template<std::derived_from<IUnknown> Ty, template<class> class WrapperTraitTy>
-    struct ShaderVisibleMapper<IUnknownWrapper<Ty, WrapperTraitTy>>
+        requires TypedStructTrait<RenderPassTraits<Ty>>
+    struct RenderPassMapper<Ty>
     {
-        template<class Ty>
-        using Trait = ShaderVisibleTraits<IUnknownWrapper<Ty, WrapperTraitTy>>;
-
-        using type = IUnknownWrapper<Ty, Trait>;
+        using type = TypedStruct<RenderPassTraits<Ty>>;
     };
 
-    export template<class Ty>
-    using Wrapper = TypedD3D::Wrapper<Ty>;
+    template<class Ty>
+    struct RenderPassViewMapper
+    {
+        using type = ReplaceOuterType<typename RenderPassMapper<Ty>::type, WeakWrapper>;
+    };
+
+    template<class Ty>
+    struct ShaderVisibleMapper;
+
+    template<class Ty>
+    struct ShaderVisibleViewMapper
+    {
+        using type = ReplaceOuterType<typename ShaderVisibleMapper<Ty>::type, WeakWrapper>;
+    };
 
     export template<class Ty>
     using Direct = DirectMapper<Ty>::type;
 
     export template<class Ty>
+    using DirectView = DirectViewMapper<Ty>::type;
+
+    export template<class Ty>
     using Compute = ComputeMapper<Ty>::type;
+
+    export template<class Ty>
+    using ComputeView = ComputeViewMapper<Ty>::type;
 
     export template<class Ty>
     using Copy = CopyMapper<Ty>::type;
 
     export template<class Ty>
+    using CopyView = CopyViewMapper<Ty>::type;
+
+    export template<class Ty>
     using Bundle = BundleMapper<Ty>::type;
+
+    export template<class Ty>
+    using BundleView = BundleViewMapper<Ty>::type;
 
     export template<class Ty>
     using CBV_SRV_UAV = CBV_SRV_UAVMapper<Ty>::type;
 
     export template<class Ty>
+    using CBV_SRV_UAVView = CBV_SRV_UAVViewMapper<Ty>::type;
+
+    export template<class Ty>
     using Sampler = SamplerMapper<Ty>::type;
+
+    export template<class Ty>
+    using SamplerView = SamplerViewMapper<Ty>::type;
 
     export template<class Ty>
     using RTV = RTVMapper<Ty>::type;
 
     export template<class Ty>
+    using RTVView = RTVViewMapper<Ty>::type;
+
+    export template<class Ty>
     using DSV = DSVMapper<Ty>::type;
+
+    export template<class Ty>
+    using DSVView = DSVViewMapper<Ty>::type;
 
     export template<class Ty>
     using Graphics = GraphicsMapper<Ty>::type;
 
     export template<class Ty>
+    using GraphicsView = GraphicsViewMapper<Ty>::type;
+
+    export template<class Ty>
     using ShaderVisible = ShaderVisibleMapper<Ty>::type;
+
+    export template<class Ty>
+    using ShaderVisibleView = ShaderVisibleViewMapper<Ty>::type;
 }

--- a/TypedD3D/source/D3D12/D3D12Wrappers.ixx
+++ b/TypedD3D/source/D3D12/D3D12Wrappers.ixx
@@ -9,49 +9,49 @@ import TypedD3D.Shared;
 namespace TypedD3D
 {
     export template<class Ty>
-    struct DirectTraits;
+    struct DirectTag;
 
 	export template<class Ty>
-    struct ComputeTraits;
+    struct ComputeTag;
 
 	export template<class Ty>
-    struct CopyTraits;
+    struct CopyTag;
 
 	export template<class Ty>
-    struct BundleTraits;
+    struct BundleTag;
 
 	export template<class Ty>
-    struct CBV_SRV_UAVTraits;
+    struct CBV_SRV_UAVTag;
 
 	export template<class Ty>
-    struct SamplerTraits;
+    struct SamplerTag;
 
 	export template<class Ty>
-    struct RTVTraits;
+    struct RTVTag;
 
 	export template<class Ty>
-    struct DSVTraits;
+    struct DSVTag;
 
 	export template<class Ty>
-    struct GraphicsTraits;
+    struct GraphicsTag;
 
 	export template<class Ty>
-    struct RenderPassTraits;
+    struct RenderPassTag;
 
 	export template<class Ty>
-    struct ShaderVisibleTraits;
+    struct ShaderVisibleTag;
 
     template<class Ty>
     struct DirectMapper
     {
-        using type = StrongWrapper<DirectTraits<Ty>>;
+        using type = StrongWrapper<DirectTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<DirectTraits<Ty>>
+        requires TypedStructTrait<DirectTag<Ty>>
     struct DirectMapper<Ty>
     {
-        using type = TypedStruct<DirectTraits<Ty>>;
+        using type = TypedStruct<DirectTag<Ty>>;
     };
 
     template<class Ty>
@@ -63,14 +63,14 @@ namespace TypedD3D
     template<class Ty>
     struct ComputeMapper
     {
-        using type = StrongWrapper<ComputeTraits<Ty>>;
+        using type = StrongWrapper<ComputeTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<ComputeTraits<Ty>>
+        requires TypedStructTrait<ComputeTag<Ty>>
     struct ComputeMapper<Ty>
     {
-        using type = TypedStruct<ComputeTraits<Ty>>;
+        using type = TypedStruct<ComputeTag<Ty>>;
     };
 
     template<class Ty>
@@ -82,14 +82,14 @@ namespace TypedD3D
     template<class Ty>
     struct CopyMapper
     {
-        using type = StrongWrapper<CopyTraits<Ty>>;
+        using type = StrongWrapper<CopyTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<CopyTraits<Ty>>
+        requires TypedStructTrait<CopyTag<Ty>>
     struct CopyMapper<Ty>
     {
-        using type = TypedStruct<CopyTraits<Ty>>;
+        using type = TypedStruct<CopyTag<Ty>>;
     };
 
     template<class Ty>
@@ -101,14 +101,14 @@ namespace TypedD3D
     template<class Ty>
     struct BundleMapper
     {
-        using type = StrongWrapper<BundleTraits<Ty>>;
+        using type = StrongWrapper<BundleTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<BundleTraits<Ty>>
+        requires TypedStructTrait<BundleTag<Ty>>
     struct BundleMapper<Ty>
     {
-        using type = TypedStruct<BundleTraits<Ty>>;
+        using type = TypedStruct<BundleTag<Ty>>;
     };
 
     template<class Ty>
@@ -120,14 +120,14 @@ namespace TypedD3D
     template<class Ty>
     struct CBV_SRV_UAVMapper
     {
-        using type = StrongWrapper<CBV_SRV_UAVTraits<Ty>>;
+        using type = StrongWrapper<CBV_SRV_UAVTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<CBV_SRV_UAVTraits<Ty>>
+        requires TypedStructTrait<CBV_SRV_UAVTag<Ty>>
     struct CBV_SRV_UAVMapper<Ty>
     {
-        using type = TypedStruct<CBV_SRV_UAVTraits<Ty>>;
+        using type = TypedStruct<CBV_SRV_UAVTag<Ty>>;
     };
 
     template<class Ty>
@@ -139,14 +139,14 @@ namespace TypedD3D
     template<class Ty>
     struct SamplerMapper
     {
-        using type = StrongWrapper<SamplerTraits<Ty>>;
+        using type = StrongWrapper<SamplerTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<SamplerTraits<Ty>>
+        requires TypedStructTrait<SamplerTag<Ty>>
     struct SamplerMapper<Ty>
     {
-        using type = TypedStruct<SamplerTraits<Ty>>;
+        using type = TypedStruct<SamplerTag<Ty>>;
     };
 
     template<class Ty>
@@ -158,14 +158,14 @@ namespace TypedD3D
     template<class Ty>
     struct RTVMapper
     {
-        using type = StrongWrapper<RTVTraits<Ty>>;
+        using type = StrongWrapper<RTVTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<RTVTraits<Ty>>
+        requires TypedStructTrait<RTVTag<Ty>>
     struct RTVMapper<Ty>
     {
-        using type = TypedStruct<RTVTraits<Ty>>;
+        using type = TypedStruct<RTVTag<Ty>>;
     };
 
     template<class Ty>
@@ -177,14 +177,14 @@ namespace TypedD3D
     template<class Ty>
     struct DSVMapper
     {
-        using type = StrongWrapper<DSVTraits<Ty>>;
+        using type = StrongWrapper<DSVTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<DSVTraits<Ty>>
+        requires TypedStructTrait<DSVTag<Ty>>
     struct DSVMapper<Ty>
     {
-        using type = TypedStruct<DSVTraits<Ty>>;
+        using type = TypedStruct<DSVTag<Ty>>;
     };
 
     template<class Ty>
@@ -196,14 +196,14 @@ namespace TypedD3D
     template<class Ty>
     struct GraphicsMapper
     {
-        using type = StrongWrapper<GraphicsTraits<Ty>>;
+        using type = StrongWrapper<GraphicsTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<GraphicsTraits<Ty>>
+        requires TypedStructTrait<GraphicsTag<Ty>>
     struct GraphicsMapper<Ty>
     {
-        using type = TypedStruct<GraphicsTraits<Ty>>;
+        using type = TypedStruct<GraphicsTag<Ty>>;
     };
 
     template<class Ty>
@@ -215,14 +215,14 @@ namespace TypedD3D
     template<class Ty>
     struct RenderPassMapper
     {
-        using type = StrongWrapper<RenderPassTraits<Ty>>;
+        using type = StrongWrapper<RenderPassTag<Ty>>;
     };
 
     template<class Ty>
-        requires TypedStructTrait<RenderPassTraits<Ty>>
+        requires TypedStructTrait<RenderPassTag<Ty>>
     struct RenderPassMapper<Ty>
     {
-        using type = TypedStruct<RenderPassTraits<Ty>>;
+        using type = TypedStruct<RenderPassTag<Ty>>;
     };
 
     template<class Ty>
@@ -232,7 +232,17 @@ namespace TypedD3D
     };
 
     template<class Ty>
-    struct ShaderVisibleMapper;
+    struct ShaderVisibleMapper
+    {
+        using type = StrongWrapper<ShaderVisibleTag<Ty>>;
+    };
+
+    template<class Ty>
+        requires TypedStructTrait<ShaderVisibleTag<Ty>>
+    struct ShaderVisibleMapper<Ty>
+    {
+        using type = TypedStruct<ShaderVisibleTag<Ty>>;
+    };
 
     template<class Ty>
     struct ShaderVisibleViewMapper

--- a/TypedD3D/source/D3D12/D3D12Wrappers.ixx
+++ b/TypedD3D/source/D3D12/D3D12Wrappers.ixx
@@ -275,6 +275,12 @@ namespace TypedD3D
     using BundleView = BundleViewMapper<Ty>::type;
 
     export template<class Ty>
+    using RenderPass = RenderPassMapper<Ty>::type;
+
+    export template<class Ty>
+    using RenderPassView = RenderPassViewMapper<Ty>::type;
+
+    export template<class Ty>
     using CBV_SRV_UAV = CBV_SRV_UAVMapper<Ty>::type;
 
     export template<class Ty>

--- a/TypedD3D/source/D3D12/DescriptorHeap.ixx
+++ b/TypedD3D/source/D3D12/DescriptorHeap.ixx
@@ -7,9 +7,42 @@ export module TypedD3D12:DescriptorHeap;
 import TypedD3D.Shared;
 import :Wrappers;
 
+namespace TypedD3D
+{
+    template<class Ty>
+    struct ShaderVisibleCBV_SRV_UAVTrait;
+
+    template<class Ty>
+    struct ShaderVisibleSamplerTrait;
+}
+
 namespace TypedD3D::D3D12
 {
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS Flags>
+    struct HeapTypeToTraitMap;
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> { template<class Ty> using type = CBV_SRV_UAVTraits<Ty>; };
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> { template<class Ty> using type = DSVTraits<Ty>; };
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> { template<class Ty> using type = RTVTraits<Ty>; };
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> { template<class Ty> using type = SamplerTraits<Ty>; };
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> { template<class Ty> using type = ShaderVisibleCBV_SRV_UAVTrait<Ty>; };
+
+    template<>
+    struct HeapTypeToTraitMap<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> { template<class Ty> using type = ShaderVisibleSamplerTrait<Ty>; };
+
+    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS Flags, class Inner>
+    using HeapTypeToTrait = typename HeapTypeToTraitMap<HeapType, Flags>::template type<Inner>;
+
+	template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
     struct GPU_DESCRIPTOR_HANDLE : private D3D12_GPU_DESCRIPTOR_HANDLE
     {
         using D3D12_GPU_DESCRIPTOR_HANDLE::ptr;
@@ -36,9 +69,10 @@ namespace TypedD3D::D3D12
             return copy;
         }
 
-        D3D12_GPU_DESCRIPTOR_HANDLE& Get() { return *this; }
-        const D3D12_GPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
-        explicit operator D3D12_GPU_DESCRIPTOR_HANDLE() { return *this; }
+        D3D12_GPU_DESCRIPTOR_HANDLE& Raw() { return *this; }
+        const D3D12_GPU_DESCRIPTOR_HANDLE& Raw() const { return *this; }
+        explicit operator D3D12_GPU_DESCRIPTOR_HANDLE&() { return *this; }
+        explicit operator const D3D12_GPU_DESCRIPTOR_HANDLE&() const { return *this; }
     };
 
     template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
@@ -68,115 +102,11 @@ namespace TypedD3D::D3D12
             return copy;
         }
 
-        D3D12_CPU_DESCRIPTOR_HANDLE& Get() { return *this; }
-        const D3D12_CPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
-        explicit operator D3D12_CPU_DESCRIPTOR_HANDLE() { return *this; }
+        D3D12_CPU_DESCRIPTOR_HANDLE& Raw() { return *this; }
+        const D3D12_CPU_DESCRIPTOR_HANDLE& Raw() const { return *this; }
+        explicit operator D3D12_CPU_DESCRIPTOR_HANDLE&() { return *this; }
+        explicit operator const D3D12_CPU_DESCRIPTOR_HANDLE&() const { return *this; }
     };
-
-    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-
-    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    struct is_descriptor_heap_flag_compatible : std::false_type {};
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type>
-    struct is_descriptor_heap_flag_compatible<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> : std::true_type {};
-
-    template<>
-    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
-
-    template<>
-    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    concept Descriptor_Heap_Flag_Compatible = is_descriptor_heap_flag_compatible<Type, HeapFlags>::value;
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-    struct HeapTypeToTrait;
-
-    template<>
-    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAVTraits<Ty>; };
-
-    template<>
-    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSVTraits<Ty>; };
-
-    template<>
-    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTVTraits<Ty>; };
-
-    template<>
-    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = SamplerTraits<Ty>; };
-
-    template<template<class> class Ty>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<CBV_SRV_UAVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<DSVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<RTVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<SamplerTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-    struct HeapTypeToWrapper;
-
-    template<>
-    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAV<Ty>; };
-
-    template<>
-    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSV<Ty>; };
-
-    template<>
-    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTV<Ty>; };
-
-    template<>
-    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = Sampler<Ty>; };
-
-    template<template<class> class Ty>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<CBV_SRV_UAV> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<DSV> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<RTV> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-
-    template<>
-    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<Sampler> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    struct HeapTraitMapper;    
-    
-    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
-    {
-        template<class Ty>
-        using type = HeapTypeToTrait<HeapType>::template type<Ty>;
-    };
-    
-    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>
-    {
-        template<class Ty>
-        using type = ShaderVisibleTraits<typename HeapTypeToWrapper<HeapType>::template type<Ty>>;
-    };
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    using GetTraitType = HeapTraitMapper<Type, HeapFlags>::type;
 
     template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
     struct DescriptorHeapTraits
@@ -186,108 +116,522 @@ namespace TypedD3D::D3D12
         using const_pointer = const ID3D12DescriptorHeap*;
         using reference = ID3D12DescriptorHeap&;
         using const_reference = const ID3D12DescriptorHeap&;
-        using CPU_DESCRIPTOR_HANDLE = CPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
-        using GPU_DESCRIPTOR_HANDLE = GPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
 
-        template<class DerivedSelf>
-        class Interface
+
+        template<class Derived>
+        class Interface : public InterfaceBase<HeapTypeToTrait<Type, HeapFlags, Derived>>
         {
-        private:
-            using derived_self = DerivedSelf;
-
         public:
-            D3D12_DESCRIPTOR_HEAP_DESC GetDesc() { return Get().GetDesc(); }
-            CPU_DESCRIPTOR_HANDLE GetCPUDescriptorHandleForHeapStart() { return CPU_DESCRIPTOR_HANDLE(Get().GetCPUDescriptorHandleForHeapStart()); }
-            GPU_DESCRIPTOR_HANDLE GetGPUDescriptorHandleForHeapStart() { return GPU_DESCRIPTOR_HANDLE(Get().GetGPUDescriptorHandleForHeapStart()); }
+            D3D12_DESCRIPTOR_HEAP_DESC GetDesc() { return Self().GetDesc(); }
+            auto GetCPUDescriptorHandleForHeapStart();
+            auto GetGPUDescriptorHandleForHeapStart();
 
         private:
-            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-            reference Get() { return *ToDerived().derived_self::Get(); }
+            using InterfaceBase<HeapTypeToTrait<Type, HeapFlags, Derived>>::Self;
+            using InterfaceBase<HeapTypeToTrait<Type, HeapFlags, Derived>>::ToDerived;
         };
     };
+};
 
+namespace TypedD3D
+{
     template<>
-    struct CBV_SRV_UAVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-
-    template<>
-    struct DSVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-
-    template<>
-    struct RTVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-
-    template<>
-    struct SamplerTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-
-    template<>
-    struct ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
-
-    template<>
-    struct ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
-
-    export template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    using DescriptorHeap_t = IUnknownWrapper<ID3D12DescriptorHeap, HeapTraitMapper<Type, HeapFlags>::template type>;
-
-    template<>
-    struct CBV_SRV_UAVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct DSVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct RTVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct SamplerMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct CBV_SRV_UAVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct DSVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct RTVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct SamplerMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-
-    template<>
-    struct ShaderVisibleMapper<CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE>>
+    struct CBV_SRV_UAVTraits<D3D12_CPU_DESCRIPTOR_HANDLE> 
     {
-        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct CBV_SRV_UAVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = CBV_SRV_UAVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct DSVTraits<D3D12_CPU_DESCRIPTOR_HANDLE> 
+    {
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct DSVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = DSVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct RTVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct RTVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = RTVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct SamplerTraits<D3D12_CPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct SamplerMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = SamplerTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct ShaderVisibleCBV_SRV_UAVTrait<D3D12_CPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+    };
+
+    //template<>
+    //struct ShaderVisibleMapper<CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE>>
+    //{
+    //    using type = ShaderVisibleCBV_SRV_UAVTrait<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct ShaderVisibleSamplerTrait<D3D12_CPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+    };
+
+    //template<>
+    //struct ShaderVisibleMapper<Sampler<D3D12_CPU_DESCRIPTOR_HANDLE>>
+    //{
+    //    using type = ShaderVisibleSamplerTrait<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+
+
+
+    template<>
+    struct CBV_SRV_UAVTraits<D3D12_GPU_DESCRIPTOR_HANDLE> 
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct CBV_SRV_UAVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = CBV_SRV_UAVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct DSVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct DSVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = DSVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct RTVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct RTVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = RTVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct SamplerTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    };
+
+    //template<>
+    //struct SamplerMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
+    //{
+    //    using type = SamplerTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
+    //};
+
+    template<>
+    struct ShaderVisibleCBV_SRV_UAVTrait<D3D12_GPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
     };
 
     template<>
-    struct ShaderVisibleMapper<Sampler<::D3D12_GPU_DESCRIPTOR_HANDLE>>
+    struct ShaderVisibleMapper<CBV_SRV_UAV<D3D12_GPU_DESCRIPTOR_HANDLE>>
     {
-        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        using type = TypedStruct<ShaderVisibleCBV_SRV_UAVTrait<D3D12_GPU_DESCRIPTOR_HANDLE>>;
+    };
+
+    template<>
+    struct ShaderVisibleSamplerTrait<D3D12_GPU_DESCRIPTOR_HANDLE>
+    {
+        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+    };
+
+    template<>
+    struct ShaderVisibleMapper<Sampler<D3D12_GPU_DESCRIPTOR_HANDLE>>
+    {
+        using type = TypedStruct<ShaderVisibleSamplerTrait<D3D12_GPU_DESCRIPTOR_HANDLE>>;
     };
 
 
 
-
-	static_assert(std::same_as<ShaderVisible<Sampler<ID3D12DescriptorHeap>>, IUnknownWrapperImpl<ID3D12DescriptorHeap, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>>);
-	static_assert(std::same_as<typename ShaderVisible<Sampler<ID3D12DescriptorHeap>>::traits_type, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>);
-
-	static_assert(std::convertible_to<CBV_SRV_UAVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-	static_assert(std::same_as<DSVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-	static_assert(std::same_as<RTVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-	static_assert(std::same_as<SamplerTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-
-	static_assert(std::same_as<ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
-	static_assert(std::same_as<ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
-
-
-    namespace Aliases
+    template<>
+    struct CBV_SRV_UAVTraits<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> 
     {
-        export using D3D12ShaderVisibleCBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-        export using D3D12ShaderVisibleSamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-        export using D3D12ShaderVisibleRTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-        export using D3D12ShaderVisibleDSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+    };
 
-        export using D3D12CBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-        export using D3D12SamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-        export using D3D12RTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-        export using D3D12DSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+    template<>
+    struct DSVTraits<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
+    {
+    };
+
+    template<>
+    struct RTVTraits<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
+    {
+    };
+
+    template<>
+    struct SamplerTraits<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
+    {
+    };
+
+    template<>
+    struct ShaderVisibleCBV_SRV_UAVTrait<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>
+    {
+
+    };
+
+    template<>
+    struct ShaderVisibleMapper<CBV_SRV_UAV<ID3D12DescriptorHeap>>
+    {
+        using type = StrongWrapper<ShaderVisibleCBV_SRV_UAVTrait<ID3D12DescriptorHeap>>;
+    };
+
+    template<>
+    struct ShaderVisibleSamplerTrait<ID3D12DescriptorHeap> : public D3D12::DescriptorHeapTraits<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>
+    {
+
+    };
+
+    template<>
+    struct ShaderVisibleMapper<Sampler<ID3D12DescriptorHeap>>
+    {
+        using type = StrongWrapper<ShaderVisibleSamplerTrait<ID3D12DescriptorHeap>>;
+    };
+}
+
+namespace TypedD3D::D3D12
+{
+
+    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+    template<class Derived>
+    auto DescriptorHeapTraits<Type, HeapFlags>::Interface<Derived>::GetGPUDescriptorHandleForHeapStart()
+    {
+        using GPU_DESCRIPTOR_HANDLE = TypedStruct<HeapTypeToTrait<Type, HeapFlags, D3D12_GPU_DESCRIPTOR_HANDLE>>;
+        return GPU_DESCRIPTOR_HANDLE(Self().GetGPUDescriptorHandleForHeapStart()); 
+    }
+
+    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+    template<class Derived>
+    auto DescriptorHeapTraits<Type, HeapFlags>::Interface<Derived>::GetCPUDescriptorHandleForHeapStart()
+    {
+        using CPU_DESCRIPTOR_HANDLE = TypedStruct<HeapTypeToTrait<Type, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>>;
+        return CPU_DESCRIPTOR_HANDLE(Self().GetCPUDescriptorHandleForHeapStart()); 
     }
 }
+
+
+//
+//namespace TypedD3D::D3D12
+//{
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    struct GPU_DESCRIPTOR_HANDLE : private D3D12_GPU_DESCRIPTOR_HANDLE
+//    {
+//        using D3D12_GPU_DESCRIPTOR_HANDLE::ptr;
+//
+//    public:
+//        GPU_DESCRIPTOR_HANDLE() = default;
+//        GPU_DESCRIPTOR_HANDLE(D3D12_GPU_DESCRIPTOR_HANDLE handle) :
+//            D3D12_GPU_DESCRIPTOR_HANDLE(handle)
+//        {
+//
+//        }
+//
+//    public:
+//        GPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
+//        {
+//            auto copy = *this;
+//            copy.ptr += incrementSize * offsetInDescriptors;
+//            return copy;
+//        }
+//        GPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
+//        {
+//            auto copy = *this;
+//            copy.ptr += offset;
+//            return copy;
+//        }
+//
+//        D3D12_GPU_DESCRIPTOR_HANDLE& Get() { return *this; }
+//        const D3D12_GPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
+//        explicit operator D3D12_GPU_DESCRIPTOR_HANDLE() { return *this; }
+//    };
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    struct CPU_DESCRIPTOR_HANDLE : private D3D12_CPU_DESCRIPTOR_HANDLE
+//    {
+//        using ::D3D12_CPU_DESCRIPTOR_HANDLE::ptr;
+//
+//    public:
+//        CPU_DESCRIPTOR_HANDLE() = default;
+//        CPU_DESCRIPTOR_HANDLE(D3D12_CPU_DESCRIPTOR_HANDLE handle) :
+//            D3D12_CPU_DESCRIPTOR_HANDLE(handle)
+//        {
+//
+//        }
+//
+//    public:
+//        CPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
+//        {
+//            auto copy = *this;
+//            copy.ptr += incrementSize * offsetInDescriptors;
+//            return copy;
+//        }
+//        CPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
+//        {
+//            auto copy = *this;
+//            copy.ptr += offset;
+//            return copy;
+//        }
+//
+//        D3D12_CPU_DESCRIPTOR_HANDLE& Get() { return *this; }
+//        const D3D12_CPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
+//        explicit operator D3D12_CPU_DESCRIPTOR_HANDLE() { return *this; }
+//    };
+//
+//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//
+//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    struct is_descriptor_heap_flag_compatible : std::false_type {};
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type>
+//    struct is_descriptor_heap_flag_compatible<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> : std::true_type {};
+//
+//    template<>
+//    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
+//
+//    template<>
+//    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    concept Descriptor_Heap_Flag_Compatible = is_descriptor_heap_flag_compatible<Type, HeapFlags>::value;
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
+//    struct HeapTypeToTrait;
+//
+//    template<>
+//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAVTraits<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSVTraits<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTVTraits<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = SamplerTraits<Ty>; };
+//
+//    template<template<class> class Ty>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<CBV_SRV_UAVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<DSVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<RTVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<SamplerTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
+//    struct HeapTypeToWrapper;
+//
+//    template<>
+//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAV<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSV<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTV<Ty>; };
+//
+//    template<>
+//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = Sampler<Ty>; };
+//
+//    template<template<class> class Ty>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<CBV_SRV_UAV> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<DSV> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<RTV> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+//
+//    template<>
+//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<Sampler> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    struct HeapTraitMapper;    
+//    
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
+//    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
+//    {
+//        template<class Ty>
+//        using type = HeapTypeToTrait<HeapType>::template type<Ty>;
+//    };
+//    
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
+//    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>
+//    {
+//        template<class Ty>
+//        using type = ShaderVisibleTraits<typename HeapTypeToWrapper<HeapType>::template type<Ty>>;
+//    };
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    using GetTraitType = HeapTraitMapper<Type, HeapFlags>::type;
+//
+//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    struct DescriptorHeapTraits
+//    {
+//        using value_type = ID3D12DescriptorHeap;
+//        using pointer = ID3D12DescriptorHeap*;
+//        using const_pointer = const ID3D12DescriptorHeap*;
+//        using reference = ID3D12DescriptorHeap&;
+//        using const_reference = const ID3D12DescriptorHeap&;
+//        using CPU_DESCRIPTOR_HANDLE = CPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
+//        using GPU_DESCRIPTOR_HANDLE = GPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
+//
+//        template<class DerivedSelf>
+//        class Interface
+//        {
+//        private:
+//            using derived_self = DerivedSelf;
+//
+//        public:
+//            D3D12_DESCRIPTOR_HEAP_DESC GetDesc() { return Get().GetDesc(); }
+//            CPU_DESCRIPTOR_HANDLE GetCPUDescriptorHandleForHeapStart() { return CPU_DESCRIPTOR_HANDLE(Get().GetCPUDescriptorHandleForHeapStart()); }
+//            GPU_DESCRIPTOR_HANDLE GetGPUDescriptorHandleForHeapStart() { return GPU_DESCRIPTOR_HANDLE(Get().GetGPUDescriptorHandleForHeapStart()); }
+//
+//        private:
+//            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
+//            reference Get() { return *ToDerived().derived_self::Get(); }
+//        };
+//    };
+//
+//    template<>
+//    struct CBV_SRV_UAVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
+//
+//    template<>
+//    struct DSVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
+//
+//    template<>
+//    struct RTVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
+//
+//    template<>
+//    struct SamplerTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
+//
+//    template<>
+//    struct ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
+//
+//    template<>
+//    struct ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
+//
+//    export template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+//    using DescriptorHeap_t = IUnknownWrapper<ID3D12DescriptorHeap, HeapTraitMapper<Type, HeapFlags>::template type>;
+//
+//    template<>
+//    struct CBV_SRV_UAVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct DSVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct RTVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct SamplerMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct CBV_SRV_UAVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct DSVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct RTVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct SamplerMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
+//
+//    template<>
+//    struct ShaderVisibleMapper<CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE>>
+//    {
+//        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//    };
+//
+//    template<>
+//    struct ShaderVisibleMapper<Sampler<::D3D12_GPU_DESCRIPTOR_HANDLE>>
+//    {
+//        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//    };
+//
+//
+//
+//
+//	static_assert(std::same_as<ShaderVisible<Sampler<ID3D12DescriptorHeap>>, IUnknownWrapperImpl<ID3D12DescriptorHeap, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>>);
+//	static_assert(std::same_as<typename ShaderVisible<Sampler<ID3D12DescriptorHeap>>::traits_type, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>);
+//
+//	static_assert(std::convertible_to<CBV_SRV_UAVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
+//	static_assert(std::same_as<DSVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
+//	static_assert(std::same_as<RTVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
+//	static_assert(std::same_as<SamplerTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
+//
+//	static_assert(std::same_as<ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
+//	static_assert(std::same_as<ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
+//
+//
+//    namespace Aliases
+//    {
+//        export using D3D12ShaderVisibleCBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//        export using D3D12ShaderVisibleSamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//        export using D3D12ShaderVisibleRTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//        export using D3D12ShaderVisibleDSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+//
+//        export using D3D12CBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+//        export using D3D12SamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+//        export using D3D12RTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+//        export using D3D12DSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+//    }
+//}

--- a/TypedD3D/source/D3D12/DescriptorHeap.ixx
+++ b/TypedD3D/source/D3D12/DescriptorHeap.ixx
@@ -44,6 +44,7 @@ namespace TypedD3D::D3D12
         || std::same_as<Ty, DSVTag<InnerType<Ty>>>
         || std::same_as<Ty, RTVTag<InnerType<Ty>>>
         || std::same_as<Ty, SamplerTag<InnerType<Ty>>>
+        || std::same_as<Ty, Untagged<InnerType<Ty>>>
         || std::same_as<Ty, ShaderVisibleCBV_SRV_UAVTag<InnerType<InnerType<Ty>>>>
         || std::same_as<Ty, ShaderVisibleSamplerTag<InnerType<InnerType<Ty>>>>;
 }

--- a/TypedD3D/source/D3D12/DescriptorHeap.ixx
+++ b/TypedD3D/source/D3D12/DescriptorHeap.ixx
@@ -76,13 +76,18 @@ namespace TypedD3D::D3D12
         using reference = ID3D12DescriptorHeap&;
         using const_reference = const ID3D12DescriptorHeap&;
 
+        using inner_type = ID3D12DescriptorHeap;
 
         template<class Derived>
         class Interface : public InterfaceBase<HeapTypeToTrait<Type, HeapFlags, Derived>>
         {
         public:
             D3D12_DESCRIPTOR_HEAP_DESC GetDesc() { return Self().GetDesc(); }
-            auto GetCPUDescriptorHandleForHeapStart();
+            auto GetCPUDescriptorHandleForHeapStart()
+            {
+                using CPU_DESCRIPTOR_HANDLE = TypedStruct<HeapTypeToTrait<Type, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>>;
+                return CPU_DESCRIPTOR_HANDLE(Self().GetCPUDescriptorHandleForHeapStart());
+            }
             auto GetGPUDescriptorHandleForHeapStart();
 
         private:
@@ -251,11 +256,11 @@ namespace TypedD3D::D3D12
         return GPU_DESCRIPTOR_HANDLE(Self().GetGPUDescriptorHandleForHeapStart()); 
     }
 
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    template<class Derived>
-    auto DescriptorHeapTraits<Type, HeapFlags>::Interface<Derived>::GetCPUDescriptorHandleForHeapStart()
-    {
-        using CPU_DESCRIPTOR_HANDLE = TypedStruct<HeapTypeToTrait<Type, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>>;
-        return CPU_DESCRIPTOR_HANDLE(Self().GetCPUDescriptorHandleForHeapStart()); 
-    }
+    //template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+    //template<class Derived>
+    //auto DescriptorHeapTraits<Type, HeapFlags>::Interface<Derived>::GetCPUDescriptorHandleForHeapStart()
+    //{
+    //    using CPU_DESCRIPTOR_HANDLE = TypedStruct<HeapTypeToTrait<Type, HeapFlags, D3D12_CPU_DESCRIPTOR_HANDLE>>;
+    //    return CPU_DESCRIPTOR_HANDLE(Self().GetCPUDescriptorHandleForHeapStart()); 
+    //}
 }

--- a/TypedD3D/source/D3D12/DescriptorHeap.ixx
+++ b/TypedD3D/source/D3D12/DescriptorHeap.ixx
@@ -42,70 +42,29 @@ namespace TypedD3D::D3D12
     template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS Flags, class Inner>
     using HeapTypeToTrait = typename HeapTypeToTraitMap<HeapType, Flags>::template type<Inner>;
 
-	template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    struct GPU_DESCRIPTOR_HANDLE : private D3D12_GPU_DESCRIPTOR_HANDLE
+
+    template<class Derived, D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
+    struct DescriptorHandleInterface : TypedStructInterfaceBase<Derived>
     {
-        using D3D12_GPU_DESCRIPTOR_HANDLE::ptr;
+        auto& Ptr() { return Self().ptr; }
+        const auto& Ptr() const { return Self().ptr; }
 
-    public:
-        GPU_DESCRIPTOR_HANDLE() = default;
-        GPU_DESCRIPTOR_HANDLE(D3D12_GPU_DESCRIPTOR_HANDLE handle) :
-            D3D12_GPU_DESCRIPTOR_HANDLE(handle)
+        auto Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
         {
-
-        }
-
-    public:
-        GPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
-        {
-            auto copy = *this;
-            copy.ptr += incrementSize * offsetInDescriptors;
+            auto copy = ToDerived();
+            copy.Ptr() += incrementSize * offsetInDescriptors;
             return copy;
         }
-        GPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
+        auto Offset(INT64 offset)
         {
-            auto copy = *this;
-            copy.ptr += offset;
+            auto copy = ToDerived();
+            copy.Ptr() += offset;
             return copy;
         }
 
-        D3D12_GPU_DESCRIPTOR_HANDLE& Raw() { return *this; }
-        const D3D12_GPU_DESCRIPTOR_HANDLE& Raw() const { return *this; }
-        explicit operator D3D12_GPU_DESCRIPTOR_HANDLE&() { return *this; }
-        explicit operator const D3D12_GPU_DESCRIPTOR_HANDLE&() const { return *this; }
-    };
-
-    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-    struct CPU_DESCRIPTOR_HANDLE : private D3D12_CPU_DESCRIPTOR_HANDLE
-    {
-        using ::D3D12_CPU_DESCRIPTOR_HANDLE::ptr;
-
-    public:
-        CPU_DESCRIPTOR_HANDLE() = default;
-        CPU_DESCRIPTOR_HANDLE(D3D12_CPU_DESCRIPTOR_HANDLE handle) :
-            D3D12_CPU_DESCRIPTOR_HANDLE(handle)
-        {
-
-        }
-
-    public:
-        CPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
-        {
-            auto copy = *this;
-            copy.ptr += incrementSize * offsetInDescriptors;
-            return copy;
-        }
-        CPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
-        {
-            auto copy = *this;
-            copy.ptr += offset;
-            return copy;
-        }
-
-        D3D12_CPU_DESCRIPTOR_HANDLE& Raw() { return *this; }
-        const D3D12_CPU_DESCRIPTOR_HANDLE& Raw() const { return *this; }
-        explicit operator D3D12_CPU_DESCRIPTOR_HANDLE&() { return *this; }
-        explicit operator const D3D12_CPU_DESCRIPTOR_HANDLE&() const { return *this; }
+    private:
+        using TypedStructInterfaceBase<Derived>::Self;
+        using TypedStructInterfaceBase<Derived>::ToDerived;
     };
 
     template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
@@ -138,74 +97,44 @@ namespace TypedD3D
     template<>
     struct CBV_SRV_UAVTraits<D3D12_CPU_DESCRIPTOR_HANDLE> 
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct CBV_SRV_UAVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = CBV_SRV_UAVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct DSVTraits<D3D12_CPU_DESCRIPTOR_HANDLE> 
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct DSVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = DSVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct RTVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct RTVMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = RTVTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct SamplerTraits<D3D12_CPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct SamplerMapper<D3D12_CPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = SamplerTraits<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct ShaderVisibleCBV_SRV_UAVTrait<D3D12_CPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
     };
-
-    //template<>
-    //struct ShaderVisibleMapper<CBV_SRV_UAV<D3D12_CPU_DESCRIPTOR_HANDLE>>
-    //{
-    //    using type = ShaderVisibleCBV_SRV_UAVTrait<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct ShaderVisibleSamplerTrait<D3D12_CPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
     };
-
-    //template<>
-    //struct ShaderVisibleMapper<Sampler<D3D12_CPU_DESCRIPTOR_HANDLE>>
-    //{
-    //    using type = ShaderVisibleSamplerTrait<D3D12_CPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
 
 
@@ -213,55 +142,36 @@ namespace TypedD3D
     template<>
     struct CBV_SRV_UAVTraits<D3D12_GPU_DESCRIPTOR_HANDLE> 
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct CBV_SRV_UAVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = CBV_SRV_UAVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct DSVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct DSVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = DSVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct RTVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct RTVMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = RTVTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct SamplerTraits<D3D12_GPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
     };
-
-    //template<>
-    //struct SamplerMapper<D3D12_GPU_DESCRIPTOR_HANDLE>
-    //{
-    //    using type = SamplerTraits<D3D12_GPU_DESCRIPTOR_HANDLE>::Interface;
-    //};
 
     template<>
     struct ShaderVisibleCBV_SRV_UAVTrait<D3D12_GPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
     };
 
     template<>
@@ -273,7 +183,8 @@ namespace TypedD3D
     template<>
     struct ShaderVisibleSamplerTrait<D3D12_GPU_DESCRIPTOR_HANDLE>
     {
-        using Interface = D3D12::GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
+        template<class Derived>
+        using Interface = D3D12::DescriptorHandleInterface<Derived, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
     };
 
     template<>
@@ -348,290 +259,3 @@ namespace TypedD3D::D3D12
         return CPU_DESCRIPTOR_HANDLE(Self().GetCPUDescriptorHandleForHeapStart()); 
     }
 }
-
-
-//
-//namespace TypedD3D::D3D12
-//{
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    struct GPU_DESCRIPTOR_HANDLE : private D3D12_GPU_DESCRIPTOR_HANDLE
-//    {
-//        using D3D12_GPU_DESCRIPTOR_HANDLE::ptr;
-//
-//    public:
-//        GPU_DESCRIPTOR_HANDLE() = default;
-//        GPU_DESCRIPTOR_HANDLE(D3D12_GPU_DESCRIPTOR_HANDLE handle) :
-//            D3D12_GPU_DESCRIPTOR_HANDLE(handle)
-//        {
-//
-//        }
-//
-//    public:
-//        GPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
-//        {
-//            auto copy = *this;
-//            copy.ptr += incrementSize * offsetInDescriptors;
-//            return copy;
-//        }
-//        GPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
-//        {
-//            auto copy = *this;
-//            copy.ptr += offset;
-//            return copy;
-//        }
-//
-//        D3D12_GPU_DESCRIPTOR_HANDLE& Get() { return *this; }
-//        const D3D12_GPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
-//        explicit operator D3D12_GPU_DESCRIPTOR_HANDLE() { return *this; }
-//    };
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    struct CPU_DESCRIPTOR_HANDLE : private D3D12_CPU_DESCRIPTOR_HANDLE
-//    {
-//        using ::D3D12_CPU_DESCRIPTOR_HANDLE::ptr;
-//
-//    public:
-//        CPU_DESCRIPTOR_HANDLE() = default;
-//        CPU_DESCRIPTOR_HANDLE(D3D12_CPU_DESCRIPTOR_HANDLE handle) :
-//            D3D12_CPU_DESCRIPTOR_HANDLE(handle)
-//        {
-//
-//        }
-//
-//    public:
-//        CPU_DESCRIPTOR_HANDLE Offset(INT64 offsetInDescriptors, UINT64 incrementSize)
-//        {
-//            auto copy = *this;
-//            copy.ptr += incrementSize * offsetInDescriptors;
-//            return copy;
-//        }
-//        CPU_DESCRIPTOR_HANDLE Offset(INT64 offset)
-//        {
-//            auto copy = *this;
-//            copy.ptr += offset;
-//            return copy;
-//        }
-//
-//        D3D12_CPU_DESCRIPTOR_HANDLE& Get() { return *this; }
-//        const D3D12_CPU_DESCRIPTOR_HANDLE& Get() const { return *this; }
-//        explicit operator D3D12_CPU_DESCRIPTOR_HANDLE() { return *this; }
-//    };
-//
-//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(CPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//
-//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//    static_assert(sizeof(GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>) == sizeof(D3D12_CPU_DESCRIPTOR_HANDLE));
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    struct is_descriptor_heap_flag_compatible : std::false_type {};
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type>
-//    struct is_descriptor_heap_flag_compatible<Type, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> : std::true_type {};
-//
-//    template<>
-//    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
-//
-//    template<>
-//    struct is_descriptor_heap_flag_compatible<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> : std::true_type {};
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    concept Descriptor_Heap_Flag_Compatible = is_descriptor_heap_flag_compatible<Type, HeapFlags>::value;
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-//    struct HeapTypeToTrait;
-//
-//    template<>
-//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAVTraits<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSVTraits<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTVTraits<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToTrait<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = SamplerTraits<Ty>; };
-//
-//    template<template<class> class Ty>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<CBV_SRV_UAVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<DSVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<RTVTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE TraitToHeapType<SamplerTraits> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-//    struct HeapTypeToWrapper;
-//
-//    template<>
-//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV> { template<class Ty> using type = CBV_SRV_UAV<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV> { template<class Ty> using type = DSV<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV> { template<class Ty> using type = RTV<Ty>; };
-//
-//    template<>
-//    struct HeapTypeToWrapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER> { template<class Ty> using type = Sampler<Ty>; };
-//
-//    template<template<class> class Ty>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<CBV_SRV_UAV> = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<DSV> = D3D12_DESCRIPTOR_HEAP_TYPE_DSV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<RTV> = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
-//
-//    template<>
-//    constexpr D3D12_DESCRIPTOR_HEAP_TYPE WrapperToHeapType<Sampler> = D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER;
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    struct HeapTraitMapper;    
-//    
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-//    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>
-//    {
-//        template<class Ty>
-//        using type = HeapTypeToTrait<HeapType>::template type<Ty>;
-//    };
-//    
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE HeapType>
-//    struct HeapTraitMapper<HeapType, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>
-//    {
-//        template<class Ty>
-//        using type = ShaderVisibleTraits<typename HeapTypeToWrapper<HeapType>::template type<Ty>>;
-//    };
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    using GetTraitType = HeapTraitMapper<Type, HeapFlags>::type;
-//
-//    template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    struct DescriptorHeapTraits
-//    {
-//        using value_type = ID3D12DescriptorHeap;
-//        using pointer = ID3D12DescriptorHeap*;
-//        using const_pointer = const ID3D12DescriptorHeap*;
-//        using reference = ID3D12DescriptorHeap&;
-//        using const_reference = const ID3D12DescriptorHeap&;
-//        using CPU_DESCRIPTOR_HANDLE = CPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
-//        using GPU_DESCRIPTOR_HANDLE = GPU_DESCRIPTOR_HANDLE<Type, HeapFlags>;
-//
-//        template<class DerivedSelf>
-//        class Interface
-//        {
-//        private:
-//            using derived_self = DerivedSelf;
-//
-//        public:
-//            D3D12_DESCRIPTOR_HEAP_DESC GetDesc() { return Get().GetDesc(); }
-//            CPU_DESCRIPTOR_HANDLE GetCPUDescriptorHandleForHeapStart() { return CPU_DESCRIPTOR_HANDLE(Get().GetCPUDescriptorHandleForHeapStart()); }
-//            GPU_DESCRIPTOR_HANDLE GetGPUDescriptorHandleForHeapStart() { return GPU_DESCRIPTOR_HANDLE(Get().GetGPUDescriptorHandleForHeapStart()); }
-//
-//        private:
-//            derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-//            reference Get() { return *ToDerived().derived_self::Get(); }
-//        };
-//    };
-//
-//    template<>
-//    struct CBV_SRV_UAVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-//
-//    template<>
-//    struct DSVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-//
-//    template<>
-//    struct RTVTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-//
-//    template<>
-//    struct SamplerTraits<ID3D12DescriptorHeap> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE> {};
-//
-//    template<>
-//    struct ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
-//
-//    template<>
-//    struct ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>> : DescriptorHeapTraits<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE> {};
-//
-//    export template<D3D12_DESCRIPTOR_HEAP_TYPE Type, D3D12_DESCRIPTOR_HEAP_FLAGS HeapFlags>
-//    using DescriptorHeap_t = IUnknownWrapper<ID3D12DescriptorHeap, HeapTraitMapper<Type, HeapFlags>::template type>;
-//
-//    template<>
-//    struct CBV_SRV_UAVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct DSVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct RTVMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct SamplerMapper<::D3D12_CPU_DESCRIPTOR_HANDLE> { using type = CPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct CBV_SRV_UAVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<CBV_SRV_UAVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct DSVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<DSVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct RTVMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<RTVTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct SamplerMapper<::D3D12_GPU_DESCRIPTOR_HANDLE> { using type = GPU_DESCRIPTOR_HANDLE<TraitToHeapType<SamplerTraits>, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>; };
-//
-//    template<>
-//    struct ShaderVisibleMapper<CBV_SRV_UAV<::D3D12_GPU_DESCRIPTOR_HANDLE>>
-//    {
-//        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//    };
-//
-//    template<>
-//    struct ShaderVisibleMapper<Sampler<::D3D12_GPU_DESCRIPTOR_HANDLE>>
-//    {
-//        using type = GPU_DESCRIPTOR_HANDLE<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//    };
-//
-//
-//
-//
-//	static_assert(std::same_as<ShaderVisible<Sampler<ID3D12DescriptorHeap>>, IUnknownWrapperImpl<ID3D12DescriptorHeap, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>>);
-//	static_assert(std::same_as<typename ShaderVisible<Sampler<ID3D12DescriptorHeap>>::traits_type, ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>>);
-//
-//	static_assert(std::convertible_to<CBV_SRV_UAVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-//	static_assert(std::same_as<DSVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-//	static_assert(std::same_as<RTVTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-//	static_assert(std::same_as<SamplerTraits<ID3D12DescriptorHeap>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>::template type<ID3D12DescriptorHeap>>);
-//
-//	static_assert(std::same_as<ShaderVisibleTraits<CBV_SRV_UAV<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
-//	static_assert(std::same_as<ShaderVisibleTraits<Sampler<ID3D12DescriptorHeap>>, HeapTraitMapper<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>::template type<ID3D12DescriptorHeap>>);
-//
-//
-//    namespace Aliases
-//    {
-//        export using D3D12ShaderVisibleCBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//        export using D3D12ShaderVisibleSamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//        export using D3D12ShaderVisibleRTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//        export using D3D12ShaderVisibleDSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE>;
-//
-//        export using D3D12CBV_SRV_UAVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-//        export using D3D12SamplerDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-//        export using D3D12RTVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_RTV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-//        export using D3D12DSVDescriptorHeap = DescriptorHeap_t<D3D12_DESCRIPTOR_HEAP_TYPE_DSV, D3D12_DESCRIPTOR_HEAP_FLAG_NONE>;
-//    }
-//}

--- a/TypedD3D/source/D3D12/PipelineState.ixx
+++ b/TypedD3D/source/D3D12/PipelineState.ixx
@@ -33,6 +33,7 @@ namespace TypedD3D::D3D12
         using reference = ID3D12PipelineState&;
         using const_reference = const ID3D12PipelineState&;
 
+        using inner_type = ID3D12PipelineState;
         template<class DerivedSelf>
         class Interface : public InterfaceBase<PiplineStateTypeToTrait<DescriptionType, DerivedSelf>>
         {

--- a/TypedD3D/source/DXGI/Adapter.ixx
+++ b/TypedD3D/source/DXGI/Adapter.ixx
@@ -20,6 +20,7 @@ namespace TypedD3D
 		using reference = IDXGIAdapter&;
 		using cosnt_reference = const IDXGIAdapter&;
 
+		using inner_type = IDXGIAdapter;
 		template<class DerivedSelf>
 		class Interface : public InterfaceBase<UntaggedTraits<DerivedSelf>>
 		{

--- a/TypedD3D/source/DXGI/Adapter.ixx
+++ b/TypedD3D/source/DXGI/Adapter.ixx
@@ -11,25 +11,30 @@ import TypedD3D.Shared;
 
 namespace TypedD3D
 {
+	static_assert(IUnknownTrait<Untagged<IDXGIOutput>>);
 	template<>
-	struct UntaggedTraits<IDXGIAdapter> 
+	struct Trait<Untagged<IDXGIAdapter>>
 	{
-		using value_type = IDXGIAdapter;
-		using pointer = IDXGIAdapter*;
-		using const_pointer = const IDXGIAdapter*;
-		using reference = IDXGIAdapter&;
-		using cosnt_reference = const IDXGIAdapter&;
 
 		using inner_type = IDXGIAdapter;
+
+		using inner_tag = IDXGIAdapter;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class DerivedSelf>
-		class Interface : public InterfaceBase<UntaggedTraits<DerivedSelf>>
+		class Interface : public InterfaceBase<Trait<Untagged<DerivedSelf>>>
 		{
 			using derived_self = DerivedSelf;
 
 		public:
 			Wrapper<IDXGIOutput> EnumOutputs(UINT Output)
 			{
-				return ForwardFunction<Wrapper<IDXGIOutput>>(&value_type::EnumOutputs, Self(), Output);
+				return ForwardFunction<Wrapper<IDXGIOutput>>(&inner_type::EnumOutputs, Self(), Output);
 			}
 
 			DXGI_ADAPTER_DESC GetDesc()
@@ -47,8 +52,8 @@ namespace TypedD3D
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<DerivedSelf>>::Self;
-			using InterfaceBase<UntaggedTraits<DerivedSelf>>::ToDerived;
+			using InterfaceBase<Trait<Untagged<DerivedSelf>>>::Self;
+			using InterfaceBase<Trait<Untagged<DerivedSelf>>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/DXGI/DXGIObject.ixx
+++ b/TypedD3D/source/DXGI/DXGIObject.ixx
@@ -1,0 +1,19 @@
+module;
+
+#include <concepts>
+#include <dxgi1_6.h>
+
+#include <utility>
+
+export module TypedDXGI:DXGIObject;
+import TypedD3D.Shared;
+
+namespace TypedD3D
+{
+	template<std::derived_from<IDXGIObject> Ty>
+	struct UntaggedTraits<Ty>
+	{
+		template<class Derived>
+		using Interface = Ty*;
+	};
+}

--- a/TypedD3D/source/DXGI/DXGIObject.ixx
+++ b/TypedD3D/source/DXGI/DXGIObject.ixx
@@ -11,10 +11,22 @@ import TypedD3D.Shared;
 namespace TypedD3D
 {
 	template<std::derived_from<IDXGIObject> Ty>
-	struct UntaggedTraits<Ty>
+	struct Trait<Untagged<Ty>>
 	{
 		using inner_type = Ty;
+
+		using inner_tag = Ty;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
 		template<class Derived>
 		using Interface = Ty*;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 	};
+
+	static_assert(IUnknownTrait<Untagged<IDXGIOutput>>);
 }

--- a/TypedD3D/source/DXGI/Factory.ixx
+++ b/TypedD3D/source/DXGI/Factory.ixx
@@ -22,6 +22,7 @@ namespace TypedD3D
 		using reference = IDXGIFactory&;
 		using cosnt_reference = const IDXGIFactory&;
 
+		using inner_type = IDXGIFactory;
 		template<class Derived>
 		class Interface : public InterfaceBase<UntaggedTraits<Derived>>
 		{
@@ -80,6 +81,8 @@ namespace TypedD3D
 		using reference = IDXGIFactory1&;
 		using cosnt_reference = const IDXGIFactory1&;
 
+		using inner_type = IDXGIFactory1;
+
 		template<class Derived>
 		class Interface : public UntaggedTraits<IDXGIFactory>::Interface<Derived>
 		{
@@ -107,6 +110,8 @@ namespace TypedD3D
 		using const_pointer = const IDXGIFactory2*;
 		using reference = IDXGIFactory2&;
 		using cosnt_reference = const IDXGIFactory2&;
+
+		using inner_type = IDXGIFactory2;
 
 		template<class Derived>
 		class Interface : public UntaggedTraits<IDXGIFactory1>::Interface<Derived>

--- a/TypedD3D/source/DXGI/Factory.ixx
+++ b/TypedD3D/source/DXGI/Factory.ixx
@@ -14,17 +14,19 @@ struct ID3D12CommandQueue;
 namespace TypedD3D
 {
 	template<>
-	struct UntaggedTraits<IDXGIFactory>
+	struct Trait<Untagged<IDXGIFactory>>
 	{
-		using value_type = IDXGIFactory;
-		using pointer = IDXGIFactory*;
-		using const_pointer = const IDXGIFactory*;
-		using reference = IDXGIFactory&;
-		using cosnt_reference = const IDXGIFactory&;
-
 		using inner_type = IDXGIFactory;
+
+		using inner_tag = IDXGIFactory;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public InterfaceBase<UntaggedTraits<Derived>>
+		class Interface : public InterfaceBase<Untagged<Derived>>
 		{
 		private:
 			using derived_self = Derived;
@@ -33,7 +35,7 @@ namespace TypedD3D
 			template<std::derived_from<IDXGIAdapter> AdapterTy = IDXGIAdapter>
 			Wrapper<AdapterTy> EnumAdapters(UINT Adapter)
 			{
-				return ForwardFunction<AdapterTy, IDXGIAdapter>(&value_type::EnumAdapters, Self(), Adapter);
+				return ForwardFunction<AdapterTy, IDXGIAdapter>(&inner_type::EnumAdapters, Self(), Adapter);
 			}
 
 			void MakeWindowAssociation(HWND WindowHandle, UINT Flags)
@@ -51,70 +53,74 @@ namespace TypedD3D
 			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D11Device> Device = ID3D11Device>
 			Wrapper<SwapChainTy> CreateSwapChain(Wrapper<Device> pDevice, const DXGI_SWAP_CHAIN_DESC& pDesc)
 			{
-				return ForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Self(), pDevice.Get(), &pDesc);
+				return ForwardFunction<SwapChainTy>(&inner_type::CreateSwapChain, Self(), pDevice.Get(), &pDesc);
 			}
 
 			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
 			//Wrapper<SwapChainTy> CreateSwapChain(TypedD3D12::Direct<QueueTy> commandQueue, const DXGI_SWAP_CHAIN_DESC& pDesc)
 			//{
-			//	return ForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Self(), commandQueue.Get(), &pDesc);
+			//	return ForwardFunction<SwapChainTy>(&inner_type::CreateSwapChain, Self(), commandQueue.Get(), &pDesc);
 			//}
 
 			template<std::derived_from<IDXGIAdapter> AdapterTy>
 			Wrapper<AdapterTy> CreateSoftwareAdapter(HMODULE Module)
 			{
-				return ForwardFunction<IDXGIAdapter>(&value_type::CreateSoftwareAdapter, Self(), Module);
+				return ForwardFunction<IDXGIAdapter>(&inner_type::CreateSoftwareAdapter, Self(), Module);
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 
 	template<>
-	struct UntaggedTraits<IDXGIFactory1>
+	struct Trait<Untagged<IDXGIFactory1>>
 	{
-		using value_type = IDXGIFactory1;
-		using pointer = IDXGIFactory1*;
-		using const_pointer = const IDXGIFactory1*;
-		using reference = IDXGIFactory1&;
-		using cosnt_reference = const IDXGIFactory1&;
-
 		using inner_type = IDXGIFactory1;
 
+		using inner_tag = IDXGIFactory1;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		class Interface : public UntaggedTraits<IDXGIFactory>::Interface<Derived>
+		class Interface : public Trait<Untagged<IDXGIFactory>>::Interface<Derived>
 		{
 		public:
 			template<std::derived_from<IDXGIAdapter> AdapterTy>
 			Wrapper<AdapterTy> EnumAdapters1(UINT Adapter)
 			{
-				return ForwardFunction<AdapterTy, IDXGIAdapter1>(&value_type::EnumAdapters1, Self(), Adapter);
+				return ForwardFunction<AdapterTy, IDXGIAdapter1>(&inner_type::EnumAdapters1, Self(), Adapter);
 			}
 
 			BOOL IsCurrent() { return Self().IsCurrent(); }
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 
 	};
 
 	template<>
-	struct UntaggedTraits<IDXGIFactory2>
+	struct Trait<Untagged<IDXGIFactory2>>
 	{
-		using value_type = IDXGIFactory2;
-		using pointer = IDXGIFactory2*;
-		using const_pointer = const IDXGIFactory2*;
-		using reference = IDXGIFactory2&;
-		using cosnt_reference = const IDXGIFactory2&;
-
 		using inner_type = IDXGIFactory2;
 
+		using inner_tag = IDXGIFactory2;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
+
 		template<class Derived>
-		class Interface : public UntaggedTraits<IDXGIFactory1>::Interface<Derived>
+		class Interface : public Trait<Untagged<IDXGIFactory1>>::Interface<Derived>
 		{
 		private:
 			using derived_self = Derived;
@@ -132,7 +138,7 @@ namespace TypedD3D
 				const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return ForwardFunction<Wrapper<SwapChain>, IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, Self(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
+				return ForwardFunction<Wrapper<SwapChain>, IDXGISwapChain1>(&inner_type::CreateSwapChainForHwnd, Self(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
 			}
 
 			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
@@ -144,7 +150,7 @@ namespace TypedD3D
 			//	const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc,
 			//	IDXGIOutput* optRestrictToOutput)
 			//{
-			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, &Get(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
+			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&inner_type::CreateSwapChainForHwnd, &Get(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
 			//}
 
 			template<class SwapChain = IDXGISwapChain, class Device = ID3D11Device>
@@ -155,7 +161,7 @@ namespace TypedD3D
 				const DXGI_SWAP_CHAIN_DESC1& pDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
+				return ForwardFunction<SwapChain, IDXGISwapChain1>(&inner_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
 			}
 
 			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
@@ -166,7 +172,7 @@ namespace TypedD3D
 			//	const DXGI_SWAP_CHAIN_DESC1& pDesc,
 			//	IDXGIOutput* optRestrictToOutput)
 			//{
-			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
+			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&inner_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
 			//}
 
 			LUID GetSharedResourceAdapterLuid(HANDLE hResource)
@@ -221,7 +227,7 @@ namespace TypedD3D
 				const DXGI_SWAP_CHAIN_DESC1& pDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput);
+				return ForwardFunction<SwapChain, IDXGISwapChain1>(&inner_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput);
 			}
 
 			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
@@ -230,12 +236,12 @@ namespace TypedD3D
 			//	const DXGI_SWAP_CHAIN_DESC1& pDesc,
 			//	IDXGIOutput* optRestrictToOutput)
 			//{
-			//	return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput));
+			//	return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&inner_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput));
 			//}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/DXGI/Factory.ixx
+++ b/TypedD3D/source/DXGI/Factory.ixx
@@ -5,22 +5,16 @@ module;
 
 export module TypedDXGI:Factory;
 import TypedD3D.Shared;
-import TypedD3D12;
+//import TypedD3D12;
 //import :Wrappers;
 
 struct ID3D11Device;
 struct ID3D12CommandQueue;
 
-namespace TypedD3D::DXGI
+namespace TypedD3D
 {
-	export template<class Ty>
-	using Factory_t = IUnknownWrapper<Ty, UntaggedTraits>;
-
-	template<class Ty>
-	struct FactoryTraits;
-
 	template<>
-	struct FactoryTraits<IDXGIFactory>
+	struct UntaggedTraits<IDXGIFactory>
 	{
 		using value_type = IDXGIFactory;
 		using pointer = IDXGIFactory*;
@@ -28,65 +22,57 @@ namespace TypedD3D::DXGI
 		using reference = IDXGIFactory&;
 		using cosnt_reference = const IDXGIFactory&;
 
-		template<class DerivedSelf>
-		class Interface
+		template<class Derived>
+		class Interface : public InterfaceBase<UntaggedTraits<Derived>>
 		{
 		private:
-			using derived_self = DerivedSelf;
+			using derived_self = Derived;
 
 		public:
-			template<class AdapterTy = IDXGIAdapter>
-				requires std::derived_from<AdapterTy, IDXGIAdapter>
+			template<std::derived_from<IDXGIAdapter> AdapterTy = IDXGIAdapter>
 			Wrapper<AdapterTy> EnumAdapters(UINT Adapter)
 			{
-				auto adapter = UnknownObjectForwardFunction<IDXGIAdapter>(&value_type::EnumAdapters, Get(), Adapter);
-				if(!adapter.has_value())
-					return nullptr;
-
-				if constexpr(std::same_as<AdapterTy, IDXGIAdapter>)
-					return Wrapper<AdapterTy>(adapter.value());
-				else
-					return Wrapper<AdapterTy>(Cast<AdapterTy>(adapter.value()));
+				return ForwardFunction<AdapterTy, IDXGIAdapter>(&value_type::EnumAdapters, Self(), Adapter);
 			}
 
 			void MakeWindowAssociation(HWND WindowHandle, UINT Flags)
 			{
-				ThrowIfFailed(Get().MakeWindowAssociation(Flags));
+				ThrowIfFailed(Self().MakeWindowAssociation(Flags));
 			}
 
 			HWND GetWindowAssociation()
 			{
 				HWND hwnd;
-				ThrowIfFailed(Get().GetWindowAssociation(&hwnd));
+				ThrowIfFailed(Self().GetWindowAssociation(&hwnd));
 				return hwnd;
 			}
 
 			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D11Device> Device = ID3D11Device>
 			Wrapper<SwapChainTy> CreateSwapChain(Wrapper<Device> pDevice, const DXGI_SWAP_CHAIN_DESC& pDesc)
 			{
-				return UnknownObjectForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Get(), pDevice.Get(), &pDesc);
+				return ForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Self(), pDevice.Get(), &pDesc);
 			}
 
-			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
-			Wrapper<SwapChainTy> CreateSwapChain(TypedD3D12::Direct<QueueTy> commandQueue, const DXGI_SWAP_CHAIN_DESC& pDesc)
-			{
-				return UnknownObjectForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Get(), commandQueue.Get(), &pDesc);
-			}
+			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
+			//Wrapper<SwapChainTy> CreateSwapChain(TypedD3D12::Direct<QueueTy> commandQueue, const DXGI_SWAP_CHAIN_DESC& pDesc)
+			//{
+			//	return ForwardFunction<SwapChainTy>(&value_type::CreateSwapChain, Self(), commandQueue.Get(), &pDesc);
+			//}
 
 			template<std::derived_from<IDXGIAdapter> AdapterTy>
 			Wrapper<AdapterTy> CreateSoftwareAdapter(HMODULE Module)
 			{
-				return UnknownObjectForwardFunction<IDXGIAdapter>(&value_type::CreateSoftwareAdapter, Get(), Module);
+				return ForwardFunction<IDXGIAdapter>(&value_type::CreateSoftwareAdapter, Self(), Module);
 			}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
 
 	template<>
-	struct FactoryTraits<IDXGIFactory1>
+	struct UntaggedTraits<IDXGIFactory1>
 	{
 		using value_type = IDXGIFactory1;
 		using pointer = IDXGIFactory1*;
@@ -94,38 +80,27 @@ namespace TypedD3D::DXGI
 		using reference = IDXGIFactory1&;
 		using cosnt_reference = const IDXGIFactory1&;
 
-		template<class DerivedSelf>
-		class Interface : public FactoryTraits<IDXGIFactory>::Interface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<IDXGIFactory>::Interface<Derived>
 		{
-		private:
-			using derived_self = DerivedSelf;
-
 		public:
-			template<class AdapterTy>
-				requires std::derived_from<AdapterTy, IDXGIAdapter>
+			template<std::derived_from<IDXGIAdapter> AdapterTy>
 			Wrapper<AdapterTy> EnumAdapters1(UINT Adapter)
 			{
-				return UnknownObjectForwardFunction<AdapterTy>(&value_type::EnumAdapters1, Get(), Adapter).value_or(nullptr);
-				auto adapter = UnknownObjectForwardFunction<IDXGIAdapter1>(&value_type::EnumAdapters1, Get(), Adapter);
-				if(!adapter.has_value())
-					return nullptr;
-
-				if constexpr(std::same_as<AdapterTy, IDXGIAdapter>)
-					return Wrapper<AdapterTy>(adapter.value());
-				else
-					return Wrapper<AdapterTy>(Cast<AdapterTy>(adapter.value()));
+				return ForwardFunction<AdapterTy, IDXGIAdapter1>(&value_type::EnumAdapters1, Self(), Adapter);
 			}
 
-			BOOL IsCurrent() { return Get().IsCurrent(); }
+			BOOL IsCurrent() { return Self().IsCurrent(); }
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
+
 	};
 
 	template<>
-	struct FactoryTraits<IDXGIFactory2>
+	struct UntaggedTraits<IDXGIFactory2>
 	{
 		using value_type = IDXGIFactory2;
 		using pointer = IDXGIFactory2*;
@@ -133,14 +108,14 @@ namespace TypedD3D::DXGI
 		using reference = IDXGIFactory2&;
 		using cosnt_reference = const IDXGIFactory2&;
 
-		template<class DerivedSelf>
-		class Interface : public FactoryTraits<IDXGIFactory1>::Interface<DerivedSelf>
+		template<class Derived>
+		class Interface : public UntaggedTraits<IDXGIFactory1>::Interface<Derived>
 		{
 		private:
-			using derived_self = DerivedSelf;
+			using derived_self = Derived;
 
 		public:
-			BOOL IsWindowedStereoEnabled() { return Get().IsWindowedStereoEnabled(); }
+			BOOL IsWindowedStereoEnabled() { return Self().IsWindowedStereoEnabled(); }
 
 
 			//TODO: Temporary fix, make sure only ID3D11Devices can be accepted here
@@ -152,20 +127,20 @@ namespace TypedD3D::DXGI
 				const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return TypedD3D::Cast<SwapChain>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, Get(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput));
+				return ForwardFunction<Wrapper<SwapChain>, IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, Self(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
 			}
 
-			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
-				requires std::same_as<typename QueueTy::value_type, ID3D12CommandQueue>
-			Wrapper<SwapChainTy> CreateSwapChainForHwnd(
-				QueueTy pDevice,
-				HWND hWnd,
-				const DXGI_SWAP_CHAIN_DESC1& pDesc,
-				const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc,
-				IDXGIOutput* optRestrictToOutput)
-			{
-				return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, &Get(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput));
-			}
+			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
+			//	requires std::same_as<typename QueueTy::value_type, ID3D12CommandQueue>
+			//Wrapper<SwapChainTy> CreateSwapChainForHwnd(
+			//	QueueTy pDevice,
+			//	HWND hWnd,
+			//	const DXGI_SWAP_CHAIN_DESC1& pDesc,
+			//	const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc,
+			//	IDXGIOutput* optRestrictToOutput)
+			//{
+			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForHwnd, &Get(), pDevice.Get(), hWnd, &pDesc, optFullscreenDesc, optRestrictToOutput);
+			//}
 
 			template<class SwapChain = IDXGISwapChain, class Device = ID3D11Device>
 				requires std::derived_from<Device, ID3D11Device>&& std::derived_from<SwapChain, IDXGISwapChain>
@@ -175,63 +150,63 @@ namespace TypedD3D::DXGI
 				const DXGI_SWAP_CHAIN_DESC1& pDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return TypedD3D::Cast<SwapChain>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Get(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput));
+				return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
 			}
 
-			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
-				requires std::same_as<typename QueueTy::value_type, ID3D12CommandQueue>
-			Wrapper<SwapChainTy> CreateSwapChainForCoreWindow(
-				QueueTy pDevice,
-				IUnknown& pWindow,
-				const DXGI_SWAP_CHAIN_DESC1& pDesc,
-				IDXGIOutput* optRestrictToOutput)
-			{
-				return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Get(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput));
-			}
+			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, class QueueTy>
+			//	requires std::same_as<typename QueueTy::value_type, ID3D12CommandQueue>
+			//Wrapper<SwapChainTy> CreateSwapChainForCoreWindow(
+			//	QueueTy pDevice,
+			//	IUnknown& pWindow,
+			//	const DXGI_SWAP_CHAIN_DESC1& pDesc,
+			//	IDXGIOutput* optRestrictToOutput)
+			//{
+			//	return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForCoreWindow, Self(), pDevice.Get(), &pWindow, &pDesc, optRestrictToOutput);
+			//}
 
 			LUID GetSharedResourceAdapterLuid(HANDLE hResource)
 			{
 				LUID luid;
-				ThrowIfFailed(Get().GetSharedResourceAdapterLuid(hResource, &luid));
+				ThrowIfFailed(Self().GetSharedResourceAdapterLuid(hResource, &luid));
 				return luid;
 			}
 
 			DWORD RegisterStereoStatusWindow(HWND WindowHandle, UINT wMsg)
 			{
 				DWORD pdwCookie;
-				ThrowIfFailed(Get().RegisterStereoStatusWindow(WindowHandle, wMsg, &pdwCookie));
+				ThrowIfFailed(Self().RegisterStereoStatusWindow(WindowHandle, wMsg, &pdwCookie));
 				return pdwCookie;
 			}
 
 			DWORD RegisterStereoStatusEvent(HANDLE hEvent)
 			{
 				DWORD pdwCookie;
-				ThrowIfFailed(Get().RegisterStereoStatusEvent(hEvent, &pdwCookie));
+				ThrowIfFailed(Self().RegisterStereoStatusEvent(hEvent, &pdwCookie));
 				return pdwCookie;
 			}
 
 			void UnregisterStereoStatus(DWORD dwCookie)
 			{
-				Get().UnregisterStereoStatus(dwCookie);
+				Self().UnregisterStereoStatus(dwCookie);
 			}
 
 			DWORD RegisterOcclusionStatusWindow(HWND WindowHandle, UINT wMsg)
 			{
 				DWORD pdwCookie;
-				ThrowIfFailed(Get().RegisterOcclusionStatusWindow(WindowHandle, wMsg, &pdwCookie));
+				ThrowIfFailed(Self().RegisterOcclusionStatusWindow(WindowHandle, wMsg, &pdwCookie));
 				return pdwCookie;
 			}
 
 			DWORD RegisterOcclusionStatusEvent(HANDLE hEvent)
 			{
 				DWORD pdwCookie;
-				ThrowIfFailed(Get().RegisterOcclusionStatusEvent(hEvent, &pdwCookie));
+				ThrowIfFailed(Self().RegisterOcclusionStatusEvent(hEvent, &pdwCookie));
 				return pdwCookie;
 			}
 
 			void UnregisterOcclusionStatus(DWORD dwCookie)
 			{
-				Get().UnregisterOcclusionStatus(dwCookie);
+				Self().UnregisterOcclusionStatus(dwCookie);
 			}
 
 			template<class SwapChain = IDXGISwapChain, class Device = ID3D11Device>
@@ -241,55 +216,42 @@ namespace TypedD3D::DXGI
 				const DXGI_SWAP_CHAIN_DESC1& pDesc,
 				IDXGIOutput* optRestrictToOutput)
 			{
-				return TypedD3D::Cast<SwapChain>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Get(), pDevice.Get(), &pDesc, optRestrictToOutput));
+				return ForwardFunction<SwapChain, IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput);
 			}
 
-			template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
-			Wrapper<SwapChainTy> CreateSwapChainForComposition(
-				TypedD3D12::Direct<QueueTy> pDevice,
-				const DXGI_SWAP_CHAIN_DESC1& pDesc,
-				IDXGIOutput* optRestrictToOutput)
-			{
-				return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Get(), pDevice.Get(), &pDesc, optRestrictToOutput));
-			}
+			//template<std::derived_from<IDXGISwapChain> SwapChainTy = IDXGISwapChain, std::derived_from<ID3D12CommandQueue> QueueTy>
+			//Wrapper<SwapChainTy> CreateSwapChainForComposition(
+			//	TypedD3D12::Direct<QueueTy> pDevice,
+			//	const DXGI_SWAP_CHAIN_DESC1& pDesc,
+			//	IDXGIOutput* optRestrictToOutput)
+			//{
+			//	return TypedD3D::Cast<SwapChainTy>(UnknownObjectForwardFunction<IDXGISwapChain1>(&value_type::CreateSwapChainForComposition, Self(), pDevice.Get(), &pDesc, optRestrictToOutput));
+			//}
 
 		private:
-			derived_self& ToDerived() { return static_cast<derived_self&>(*this); }
-			reference Get() { return *ToDerived().derived_self::Get(); }
+			using InterfaceBase<UntaggedTraits<Derived>>::Self;
+			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
 		};
 	};
-
-	export template<class FactoryTy = IDXGIFactory>
-	Wrapper<FactoryTy> CreateFactory()
-	{
-		return IIDToObjectForwardFunction<FactoryTy>(&::CreateDXGIFactory);
-	}
-
-	export template<class FactoryTy = IDXGIFactory>
-	Wrapper<FactoryTy> CreateFactory1()
-	{
-		return IIDToObjectForwardFunction<FactoryTy>(&::CreateDXGIFactory1);
-	}
-
-	export template<class FactoryTy = IDXGIFactory>
-	Wrapper<FactoryTy> CreateFactory2(UINT flags)
-	{
-		return IIDToObjectForwardFunction<FactoryTy>(&::CreateDXGIFactory2, flags);
-	}
 }
 
-namespace TypedD3D
+namespace TypedD3D::DXGI
 {
-	template<std::derived_from<IDXGIFactory> Ty>
-	struct UntaggedTraits<Ty>
+	export template<class FactoryTy = IDXGIFactory>
+		Wrapper<FactoryTy> CreateFactory()
 	{
-		using value_type = Ty;
-		using pointer = Ty*;
-		using const_pointer = const Ty*;
-		using reference = Ty&;
-		using cosnt_reference = const Ty&;
+		return ForwardFunction<Wrapper<FactoryTy>>(&::CreateDXGIFactory);
+	}
 
-		template<class DerivedSelf>
-		using Interface = DXGI::FactoryTraits<Ty>::template Interface<DerivedSelf>;
-	};
+	export template<class FactoryTy = IDXGIFactory>
+		Wrapper<FactoryTy> CreateFactory1()
+	{
+		return ForwardFunction<Wrapper<FactoryTy>>(&::CreateDXGIFactory1);
+	}
+
+	export template<class FactoryTy = IDXGIFactory>
+		Wrapper<FactoryTy> CreateFactory2(UINT flags)
+	{
+		return ForwardFunction<Wrapper<FactoryTy>>(&::CreateDXGIFactory2, flags);
+	}
 }

--- a/TypedD3D/source/DXGI/SwapChain.ixx
+++ b/TypedD3D/source/DXGI/SwapChain.ixx
@@ -26,17 +26,19 @@ namespace TypedD3D::DXGI
 namespace TypedD3D
 {
 	template<>
-	struct UntaggedTraits<IDXGISwapChain>
+	struct Trait<Untagged<IDXGISwapChain>>
 	{
-		using value_type = IDXGISwapChain;
-		using pointer = IDXGISwapChain*;
-		using const_pointer = const IDXGISwapChain*;
-		using reference = IDXGISwapChain&;
-		using cosnt_reference = const IDXGISwapChain&;
-
 		using inner_type = IDXGISwapChain;
+
+		using inner_tag = IDXGISwapChain;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public InterfaceBase<UntaggedTraits<Derived>>
+		class Interface : public InterfaceBase<Untagged<Derived>>
 		{
 		public:
 			void Present(UINT SyncInterval, UINT Flags)
@@ -47,7 +49,7 @@ namespace TypedD3D
 			template<Resource Ty>
 			Wrapper<Ty> GetBuffer(UINT buffer)
 			{
-				return ForwardFunction<Wrapper<Ty>>(&value_type::GetBuffer, Self(), buffer);
+				return ForwardFunction<Wrapper<Ty>>(&inner_type::GetBuffer, Self(), buffer);
 			}
 
 			void SetFullscreenState(BOOL Fullscreen, IDXGIOutput* optTarget)
@@ -86,7 +88,7 @@ namespace TypedD3D
 
 			Wrapper<IDXGIOutput> GetContainingOutput()
 			{
-				return ForwardFunction<IDXGIOutput>(&value_type::GetContainingOutput, Self());
+				return ForwardFunction<IDXGIOutput>(&inner_type::GetContainingOutput, Self());
 			}
 
 			DXGI_FRAME_STATISTICS GetFrameStatistics()
@@ -104,23 +106,25 @@ namespace TypedD3D
 			}
 
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 
 	template<>
-	struct UntaggedTraits<IDXGISwapChain1>
+	struct Trait<Untagged<IDXGISwapChain1>>
 	{
-		using value_type = IDXGISwapChain1;
-		using pointer = IDXGISwapChain1*;
-		using const_pointer = const IDXGISwapChain1*;
-		using reference = IDXGISwapChain1&;
-		using cosnt_reference = const IDXGISwapChain1&;
-
 		using inner_type = IDXGISwapChain1;
+
+		using inner_tag = IDXGISwapChain1;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public UntaggedTraits<IDXGISwapChain>::Interface<Derived>
+		class Interface : public Trait<Untagged<IDXGISwapChain>>::Interface<Derived>
 		{
 		public:
 			DXGI_SWAP_CHAIN_DESC1 GetDesc1()
@@ -161,7 +165,7 @@ namespace TypedD3D
 
 			Wrapper<IDXGIOutput> GetRestrictToOutput()
 			{
-				return ForwardFunction<IDXGIOutput>(&value_type::GetRestrictToOutput, Self()).value();
+				return ForwardFunction<IDXGIOutput>(&inner_type::GetRestrictToOutput, Self()).value();
 			}
 
 			void SetBackgroundColor(DXGI_RGBA pColor)
@@ -188,8 +192,8 @@ namespace TypedD3D
 				return rotation;
 			}
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 
@@ -200,17 +204,19 @@ namespace TypedD3D
 	};
 
 	template<>
-	struct UntaggedTraits<IDXGISwapChain2>
+	struct Trait<Untagged<IDXGISwapChain2>>
 	{
-		using value_type = IDXGISwapChain2;
-		using pointer = IDXGISwapChain2*;
-		using const_pointer = const IDXGISwapChain2*;
-		using reference = IDXGISwapChain2&;
-		using cosnt_reference = const IDXGISwapChain2&;
-
 		using inner_type = IDXGISwapChain2;
+
+		using inner_tag = IDXGISwapChain2;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public UntaggedTraits<IDXGISwapChain1>::Interface<Derived>
+		class Interface : public Trait<Untagged<IDXGISwapChain1>>::Interface<Derived>
 		{
 		private:
 			using derived_self = Derived;
@@ -257,23 +263,26 @@ namespace TypedD3D
 				return matrix;
 			}
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};									   
 	};
 
 	template<>
-	struct UntaggedTraits<IDXGISwapChain3>
+	struct Trait<Untagged<IDXGISwapChain3>>
 	{
-		using value_type = IDXGISwapChain3;
-		using pointer = IDXGISwapChain3*;
-		using const_pointer = const IDXGISwapChain3*;
-		using reference = IDXGISwapChain3&;
-		using cosnt_reference = const IDXGISwapChain3&;
-
 		using inner_type = IDXGISwapChain3;
+
+		using inner_tag = IDXGISwapChain3;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 		template<class Derived>
-		class Interface : public UntaggedTraits<IDXGISwapChain2>::Interface<Derived>
+		class Interface : public Trait<Untagged<IDXGISwapChain2>>::Interface<Derived>
 		{
 		private:
 			using derived_self = Derived;
@@ -310,8 +319,8 @@ namespace TypedD3D
 				ThrowIfFailed(Self().ResizeBuffers1(BufferCount, Width, Height, Format, SwapChainFlags, pCreationNodeMask.data(), ppPresentQueue.data()));
 			}
 		private:
-			using InterfaceBase<UntaggedTraits<Derived>>::Self;
-			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;
+			using InterfaceBase<Untagged<Derived>>::Self;
+			using InterfaceBase<Untagged<Derived>>::ToDerived;
 		};
 	};
 }

--- a/TypedD3D/source/DXGI/SwapChain.ixx
+++ b/TypedD3D/source/DXGI/SwapChain.ixx
@@ -5,11 +5,13 @@ module;
 #include <dxgi1_6.h>
 #include <span>
 #include <d3d12.h>
+#include <cassert>
 
 export module TypedDXGI:SwapChain;
-//struct ID3D12CommandQueue;
+struct ID3D12CommandQueue;
 import TypedD3D.Shared;
-//import TypedD3D12;
+import TypedD3D12;
+import :DXGIObject;
 
 struct ID3D11Resource;
 struct ID3D12Resource;
@@ -32,6 +34,7 @@ namespace TypedD3D
 		using reference = IDXGISwapChain&;
 		using cosnt_reference = const IDXGISwapChain&;
 
+		using inner_type = IDXGISwapChain;
 		template<class Derived>
 		class Interface : public InterfaceBase<UntaggedTraits<Derived>>
 		{
@@ -115,6 +118,7 @@ namespace TypedD3D
 		using reference = IDXGISwapChain1&;
 		using cosnt_reference = const IDXGISwapChain1&;
 
+		using inner_type = IDXGISwapChain1;
 		template<class Derived>
 		class Interface : public UntaggedTraits<IDXGISwapChain>::Interface<Derived>
 		{
@@ -204,6 +208,7 @@ namespace TypedD3D
 		using reference = IDXGISwapChain2&;
 		using cosnt_reference = const IDXGISwapChain2&;
 
+		using inner_type = IDXGISwapChain2;
 		template<class Derived>
 		class Interface : public UntaggedTraits<IDXGISwapChain1>::Interface<Derived>
 		{
@@ -266,6 +271,7 @@ namespace TypedD3D
 		using reference = IDXGISwapChain3&;
 		using cosnt_reference = const IDXGISwapChain3&;
 
+		using inner_type = IDXGISwapChain3;
 		template<class Derived>
 		class Interface : public UntaggedTraits<IDXGISwapChain2>::Interface<Derived>
 		{
@@ -290,25 +296,19 @@ namespace TypedD3D
 				ThrowIfFailed(Self().SetColorSpace1(ColorSpace));
 			}
 
-			//template<std::derived_from<ID3D12CommandQueue> QueueTy>
-			//void ResizeBuffers1(
-			//	UINT BufferCount,
-			//	UINT Width,
-			//	UINT Height,
-			//	DXGI_FORMAT Format,
-			//	UINT SwapChainFlags,
-			//	std::span<UINT> pCreationNodeMask,
-			//	std::span<TypedD3D12::Direct<QueueTy>> ppPresentQueue)
-			//{
-			//	std::unique_ptr<IUnknown[]> queues = std::make_unique<IUnknown[]>(ppPresentQueue.size());
-
-			//	for(size_t i = 0; i < ppPresentQueue.size(); i++)
-			//	{
-			//		queues[i] = ppPresentQueue[i].Get();
-			//	}
-
-			//	ThrowIfFailed(Self().ResizeBuffers1(BufferCount, Width, Height, Format, SwapChainFlags, pCreationNodeMask.data(), queues.get()));
-			//}
+			template<std::derived_from<ID3D12CommandQueue> QueueTy>
+			void ResizeBuffers1(
+				UINT BufferCount,
+				UINT Width,
+				UINT Height,
+				DXGI_FORMAT Format,
+				UINT SwapChainFlags,
+				std::span<UINT> pCreationNodeMask,
+				Span<const TypedD3D::DirectView<QueueTy>> ppPresentQueue)
+			{
+				assert(BufferCount == pCreationNodeMask.size() && BufferCount == ppPresentQueue.size());
+				ThrowIfFailed(Self().ResizeBuffers1(BufferCount, Width, Height, Format, SwapChainFlags, pCreationNodeMask.data(), ppPresentQueue.data()));
+			}
 		private:
 			using InterfaceBase<UntaggedTraits<Derived>>::Self;
 			using InterfaceBase<UntaggedTraits<Derived>>::ToDerived;

--- a/TypedD3D/source/Legacy/D3D12LegacyHelpers.ixx
+++ b/TypedD3D/source/Legacy/D3D12LegacyHelpers.ixx
@@ -12,136 +12,136 @@ module;
 #include <dxgi1_6.h>
 
 export module TypedD3D.Legacy.D3D12Helpers;
-import TypedD3D.Legacy.DXGIHelpers;
+//import TypedD3D.Legacy.DXGIHelpers;
 import TypedD3D.Shared;
 
 export namespace TypedD3D::Helpers::D3D12
 {
     using Microsoft::WRL::ComPtr;
 
-    template<std::derived_from<ID3D12Device> Device = ID3D12Device>
-    ComPtr<Device> CreateDevice(D3D_FEATURE_LEVEL minFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
-    {
-        static_assert(std::derived_from<Device, ID3D12Device>, "This function requires it's type to inherit from ID3D12Device");
-        return IIDToObjectForwardFunction<Device>(&D3D12CreateDevice, optAdapter, minFeatureLevel);
-    }
+    //template<std::derived_from<ID3D12Device> Device = ID3D12Device>
+    //ComPtr<Device> CreateDevice(D3D_FEATURE_LEVEL minFeatureLevel, IDXGIAdapter* optAdapter = nullptr)
+    //{
+    //    static_assert(std::derived_from<Device, ID3D12Device>, "This function requires it's type to inherit from ID3D12Device");
+    //    return IIDToObjectForwardFunction<Device>(&D3D12CreateDevice, optAdapter, minFeatureLevel);
+    //}
 
-    //Creates a open command list
-    template<class CommandList = ID3D12GraphicsCommandList>
-    ComPtr<CommandList> CreateCommandList(ID3D12Device& device, D3D12_COMMAND_LIST_TYPE type, ID3D12CommandAllocator& allocator, UINT nodeMask = 0, ID3D12PipelineState* optInitialPipeline = nullptr)
-    {
-        static_assert(std::derived_from<CommandList, ID3D12CommandList>, "This function requires it's type to inherit from ID3D12CommandList");
-        return IIDToObjectForwardFunction<CommandList>(&ID3D12Device::CreateCommandList, device, nodeMask, type, &allocator, optInitialPipeline);
-    }
+    ////Creates a open command list
+    //template<class CommandList = ID3D12GraphicsCommandList>
+    //ComPtr<CommandList> CreateCommandList(ID3D12Device& device, D3D12_COMMAND_LIST_TYPE type, ID3D12CommandAllocator& allocator, UINT nodeMask = 0, ID3D12PipelineState* optInitialPipeline = nullptr)
+    //{
+    //    static_assert(std::derived_from<CommandList, ID3D12CommandList>, "This function requires it's type to inherit from ID3D12CommandList");
+    //    return IIDToObjectForwardFunction<CommandList>(&ID3D12Device::CreateCommandList, device, nodeMask, type, &allocator, optInitialPipeline);
+    //}
 
-    //Creates a closed command list
-    template<class CommandList = ID3D12GraphicsCommandList>
-    ComPtr<CommandList> CreateCommandList(ID3D12Device4& device, D3D12_COMMAND_LIST_TYPE type, D3D12_COMMAND_LIST_FLAGS flags, UINT nodeMask = 0)
-    {
-        static_assert(std::is_base_of_v<ID3D12CommandList, CommandList>, "This function requires it's type to inherit from ID3D12CommandList");
-        return IIDToObjectForwardFunction<CommandList>(&ID3D12Device4::CreateCommandList1, device, nodeMask, type, flags);
-    }
+    ////Creates a closed command list
+    //template<class CommandList = ID3D12GraphicsCommandList>
+    //ComPtr<CommandList> CreateCommandList(ID3D12Device4& device, D3D12_COMMAND_LIST_TYPE type, D3D12_COMMAND_LIST_FLAGS flags, UINT nodeMask = 0)
+    //{
+    //    static_assert(std::is_base_of_v<ID3D12CommandList, CommandList>, "This function requires it's type to inherit from ID3D12CommandList");
+    //    return IIDToObjectForwardFunction<CommandList>(&ID3D12Device4::CreateCommandList1, device, nodeMask, type, flags);
+    //}
 
-    inline ComPtr<ID3D12CommandAllocator> CreateCommandAllocator(ID3D12Device& device, D3D12_COMMAND_LIST_TYPE type)
-    {
-        return IIDToObjectForwardFunction<ID3D12CommandAllocator>(&ID3D12Device::CreateCommandAllocator, device, type);
-    }
+    //inline ComPtr<ID3D12CommandAllocator> CreateCommandAllocator(ID3D12Device& device, D3D12_COMMAND_LIST_TYPE type)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12CommandAllocator>(&ID3D12Device::CreateCommandAllocator, device, type);
+    //}
 
-    inline ComPtr<ID3D12PipelineState> CreateGraphicsPipelineState(ID3D12Device& device, const D3D12_GRAPHICS_PIPELINE_STATE_DESC& desc)
-    {
-        return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device::CreateGraphicsPipelineState, device, &desc);
-    }
+    //inline ComPtr<ID3D12PipelineState> CreateGraphicsPipelineState(ID3D12Device& device, const D3D12_GRAPHICS_PIPELINE_STATE_DESC& desc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device::CreateGraphicsPipelineState, device, &desc);
+    //}
 
-    inline ComPtr<ID3D12PipelineState> CreateComputePipelineState(ID3D12Device& device, const D3D12_COMPUTE_PIPELINE_STATE_DESC& desc)
-    {
-        return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device::CreateComputePipelineState, device, &desc);
-    }
+    //inline ComPtr<ID3D12PipelineState> CreateComputePipelineState(ID3D12Device& device, const D3D12_COMPUTE_PIPELINE_STATE_DESC& desc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12PipelineState>(&ID3D12Device::CreateComputePipelineState, device, &desc);
+    //}
 
-    inline ComPtr<ID3D12CommandQueue> CreateCommandQueue(ID3D12Device& device, const D3D12_COMMAND_QUEUE_DESC& desc)
-    {
-        return IIDToObjectForwardFunction<ID3D12CommandQueue>(&ID3D12Device::CreateCommandQueue, device, &desc);
-    }
+    //inline ComPtr<ID3D12CommandQueue> CreateCommandQueue(ID3D12Device& device, const D3D12_COMMAND_QUEUE_DESC& desc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12CommandQueue>(&ID3D12Device::CreateCommandQueue, device, &desc);
+    //}
 
-    inline ComPtr<ID3D12Fence> CreateFence(ID3D12Device& device, D3D12_FENCE_FLAGS flags, UINT64 initialValue = 0)
-    {
-        return IIDToObjectForwardFunction<ID3D12Fence>(&ID3D12Device::CreateFence, device, initialValue, flags);
-    }
+    //inline ComPtr<ID3D12Fence> CreateFence(ID3D12Device& device, D3D12_FENCE_FLAGS flags, UINT64 initialValue = 0)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12Fence>(&ID3D12Device::CreateFence, device, initialValue, flags);
+    //}
 
-    inline ComPtr<ID3D12DescriptorHeap> CreateDescriptorHeap(ID3D12Device& device, const D3D12_DESCRIPTOR_HEAP_DESC& descriptorHeapDesc)
-    {
-        return IIDToObjectForwardFunction<ID3D12DescriptorHeap>(&ID3D12Device::CreateDescriptorHeap, device, &descriptorHeapDesc);
-    }
+    //inline ComPtr<ID3D12DescriptorHeap> CreateDescriptorHeap(ID3D12Device& device, const D3D12_DESCRIPTOR_HEAP_DESC& descriptorHeapDesc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12DescriptorHeap>(&ID3D12Device::CreateDescriptorHeap, device, &descriptorHeapDesc);
+    //}
 
-    inline ComPtr<ID3D12RootSignature> CreateRootSignature(ID3D12Device& device, UINT nodeMask, const void* pBlobWithRootSignature, SIZE_T blobLengthInBytes)
-    {
-        return IIDToObjectForwardFunction<ID3D12RootSignature>(&ID3D12Device::CreateRootSignature, device, nodeMask, pBlobWithRootSignature, blobLengthInBytes);
-    }
+    //inline ComPtr<ID3D12RootSignature> CreateRootSignature(ID3D12Device& device, UINT nodeMask, const void* pBlobWithRootSignature, SIZE_T blobLengthInBytes)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12RootSignature>(&ID3D12Device::CreateRootSignature, device, nodeMask, pBlobWithRootSignature, blobLengthInBytes);
+    //}
 
-    inline ComPtr<ID3D12QueryHeap> CreateQueryHeap(ID3D12Device& device, const D3D12_QUERY_HEAP_DESC& desc)
-    {
-        return IIDToObjectForwardFunction<ID3D12QueryHeap>(&ID3D12Device::CreateQueryHeap, device, &desc);
-    }
+    //inline ComPtr<ID3D12QueryHeap> CreateQueryHeap(ID3D12Device& device, const D3D12_QUERY_HEAP_DESC& desc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12QueryHeap>(&ID3D12Device::CreateQueryHeap, device, &desc);
+    //}
 
-    inline ComPtr<ID3D12CommandSignature> CreateCommandSignature(ID3D12Device& device,
-        const D3D12_COMMAND_SIGNATURE_DESC& pDesc,
-        ID3D12RootSignature* optRootSignature)
-    {
-        return IIDToObjectForwardFunction<ID3D12CommandSignature>(&ID3D12Device::CreateCommandSignature, device, &pDesc, optRootSignature);
-    }
+    //inline ComPtr<ID3D12CommandSignature> CreateCommandSignature(ID3D12Device& device,
+    //    const D3D12_COMMAND_SIGNATURE_DESC& pDesc,
+    //    ID3D12RootSignature* optRootSignature)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12CommandSignature>(&ID3D12Device::CreateCommandSignature, device, &pDesc, optRootSignature);
+    //}
 
-    inline ComPtr<ID3D12Resource> CreateCommittedResource(ID3D12Device& device,
-        const D3D12_HEAP_PROPERTIES& pHeapProperties,
-        D3D12_HEAP_FLAGS HeapFlags,
-        const D3D12_RESOURCE_DESC& pDesc,
-        D3D12_RESOURCE_STATES InitialResourceState,
-        const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-    {
-        return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreateCommittedResource, device, &pHeapProperties, HeapFlags, &pDesc, InitialResourceState, optOptimizedClearValue);
-    }
+    //inline ComPtr<ID3D12Resource> CreateCommittedResource(ID3D12Device& device,
+    //    const D3D12_HEAP_PROPERTIES& pHeapProperties,
+    //    D3D12_HEAP_FLAGS HeapFlags,
+    //    const D3D12_RESOURCE_DESC& pDesc,
+    //    D3D12_RESOURCE_STATES InitialResourceState,
+    //    const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreateCommittedResource, device, &pHeapProperties, HeapFlags, &pDesc, InitialResourceState, optOptimizedClearValue);
+    //}
 
-    inline ComPtr<ID3D12Heap> CreateHeap(
-        ID3D12Device& device,
-        const D3D12_HEAP_DESC& pDesc)
-    {
-        return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device::CreateHeap, device, &pDesc);
-    }
+    //inline ComPtr<ID3D12Heap> CreateHeap(
+    //    ID3D12Device& device,
+    //    const D3D12_HEAP_DESC& pDesc)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12Heap>(&ID3D12Device::CreateHeap, device, &pDesc);
+    //}
 
-    inline ComPtr<ID3D12Resource> CreatePlacedResource(ID3D12Device& device,
-        ID3D12Heap& pHeap,
-        UINT64 HeapOffset,
-        const D3D12_RESOURCE_DESC& pDesc,
-        D3D12_RESOURCE_STATES InitialState,
-        const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-    {
-        return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreatePlacedResource, device, &pHeap, HeapOffset, &pDesc, InitialState, optOptimizedClearValue);
-    }
+    //inline ComPtr<ID3D12Resource> CreatePlacedResource(ID3D12Device& device,
+    //    ID3D12Heap& pHeap,
+    //    UINT64 HeapOffset,
+    //    const D3D12_RESOURCE_DESC& pDesc,
+    //    D3D12_RESOURCE_STATES InitialState,
+    //    const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreatePlacedResource, device, &pHeap, HeapOffset, &pDesc, InitialState, optOptimizedClearValue);
+    //}
 
-    inline ComPtr<ID3D12Resource> CreateReservedResource(ID3D12Device& device,
-        const D3D12_RESOURCE_DESC& pDesc,
-        D3D12_RESOURCE_STATES InitialState,
-        const D3D12_CLEAR_VALUE* optOptimizedClearValue)
-    {
-        return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreateReservedResource, device, &pDesc, InitialState, optOptimizedClearValue);
-    }
+    //inline ComPtr<ID3D12Resource> CreateReservedResource(ID3D12Device& device,
+    //    const D3D12_RESOURCE_DESC& pDesc,
+    //    D3D12_RESOURCE_STATES InitialState,
+    //    const D3D12_CLEAR_VALUE* optOptimizedClearValue)
+    //{
+    //    return IIDToObjectForwardFunction<ID3D12Resource>(&ID3D12Device::CreateReservedResource, device, &pDesc, InitialState, optOptimizedClearValue);
+    //}
 
-    template<class Resource = ID3D12Resource>
-    std::vector<ComPtr<Resource>> CreateSwapChainRenderTargets(ID3D12Device& device, IDXGISwapChain1& swapChain, ID3D12DescriptorHeap& descriptor)
-    {
-        UINT rtvOffset = device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-        D3D12_CPU_DESCRIPTOR_HANDLE handle = descriptor.GetCPUDescriptorHandleForHeapStart();
-        DXGI_SWAP_CHAIN_DESC1 desc = TypedD3D::GetDescription(swapChain);
+    //template<class Resource = ID3D12Resource>
+    //std::vector<ComPtr<Resource>> CreateSwapChainRenderTargets(ID3D12Device& device, IDXGISwapChain1& swapChain, ID3D12DescriptorHeap& descriptor)
+    //{
+    //    UINT rtvOffset = device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+    //    D3D12_CPU_DESCRIPTOR_HANDLE handle = descriptor.GetCPUDescriptorHandleForHeapStart();
+    //    DXGI_SWAP_CHAIN_DESC1 desc = TypedD3D::GetDescription(swapChain);
 
-        std::vector<ComPtr<Resource>> buffers(desc.BufferCount);
-        for(UINT i = 0; i < desc.BufferCount; i++)
-        {
-            buffers[i] = Helpers::DXGI::SwapChain::GetBuffer<Resource>(swapChain, i).value();
+    //    std::vector<ComPtr<Resource>> buffers(desc.BufferCount);
+    //    for(UINT i = 0; i < desc.BufferCount; i++)
+    //    {
+    //        buffers[i] = Helpers::DXGI::SwapChain::GetBuffer<Resource>(swapChain, i).value();
 
-            device.CreateRenderTargetView(buffers[i].Get(), nullptr, handle);
-            handle.ptr += rtvOffset;
-        }
+    //        device.CreateRenderTargetView(buffers[i].Get(), nullptr, handle);
+    //        handle.ptr += rtvOffset;
+    //    }
 
-        return buffers;
-    }
+    //    return buffers;
+    //}
 
     /// <summary>
     /// Tells a given command queue to update the fence value to the currentFenceValue + 1 when it is done executing it's command lists
@@ -369,14 +369,14 @@ export namespace TypedD3D::Helpers::D3D12
     D3D12_RESOURCE_BARRIER AliasingBarrier(ID3D12Resource* optResourceBefore, ID3D12Resource* optResourceAfter, D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE);
     D3D12_RESOURCE_BARRIER UAVBarrier(ID3D12Resource& resource, D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE);
 
-    template<class DebugTy = ID3D12Debug>
-    ComPtr<DebugTy> GetDebugInterface()
-    {
-        if constexpr(std::same_as<DebugTy, ID3D12Debug>)
-            return IIDToObjectForwardFunction<ID3D12Debug>(&D3D12GetDebugInterface);
-        else
-        {
-            return Cast<DebugTy>(GetDebugInterface<ID3D12Debug>());
-        }
-    }
+    //template<class DebugTy = ID3D12Debug>
+    //ComPtr<DebugTy> GetDebugInterface()
+    //{
+    //    if constexpr(std::same_as<DebugTy, ID3D12Debug>)
+    //        return IIDToObjectForwardFunction<ID3D12Debug>(&D3D12GetDebugInterface);
+    //    else
+    //    {
+    //        return Cast<DebugTy>(GetDebugInterface<ID3D12Debug>());
+    //    }
+    //}
 }

--- a/TypedD3D/source/Legacy/DXGILegacyHelpers.ixx
+++ b/TypedD3D/source/Legacy/DXGILegacyHelpers.ixx
@@ -1,94 +1,94 @@
-module;
-
-#include <dxgi1_6.h>
-#include <type_traits>
-
-#include <d3d12.h>
-#include <wrl/client.h>
-
-export module TypedD3D.Legacy.DXGIHelpers;
-import TypedD3D.Shared;
-
-export namespace TypedD3D::Helpers::DXGI
-{
-    using Microsoft::WRL::ComPtr;
-    namespace Factory
-    {
-        enum class CreationFlags
-        {
-            None = 0,
-            Enable_Debug = DXGI_CREATE_FACTORY_DEBUG
-        };
-
-        DEFINE_ENUM_FLAG_OPERATORS(CreationFlags);
-
-        template<class Factory = IDXGIFactory>
-        ComPtr<Factory> Create(CreationFlags flags)
-        {
-
-            if constexpr(std::is_same_v<Factory, IDXGIFactory>)
-            {
-                return IIDToObjectForwardFunction<IDXGIFactory>(&CreateDXGIFactory);
-            }
-            else if constexpr(std::is_same_v<Factory, IDXGIFactory1>)
-            {
-                return IIDToObjectForwardFunction<IDXGIFactory1>(&CreateDXGIFactory1);
-            }
-            else
-            {
-                if constexpr(std::is_same_v<Factory, IDXGIFactory2>)
-                {
-                    return IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory2, static_cast<UINT>(flags));
-                }
-                else
-                {
-                    return Cast<Factory>(IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory2, static_cast<UINT>(flags)));
-                }
-            }
-        }
-    }
-
-    namespace SwapChain
-    {
-        template<class SwapChain = IDXGISwapChain1>
-        ComPtr<SwapChain> Create(IDXGIFactory2& factory, IUnknown& device, HWND hWnd, const DXGI_SWAP_CHAIN_DESC1& desc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc = nullptr, IDXGIOutput* optRestrictToOutput = nullptr)
-        {
-            ComPtr<IDXGISwapChain1> swapChain;
-            return Cast<SwapChain>(factory.CreateSwapChainForHwnd(&device, hWnd, &desc, optFullscreenDesc, optRestrictToOutput, &swapChain));
-        }
-
-        template<class SwapChain = IDXGISwapChain1>
-        ComPtr<SwapChain> CreateFlipDiscard(IDXGIFactory2& factory, IUnknown& device, HWND hWnd, DXGI_FORMAT format, UINT bufferCount, DXGI_SWAP_CHAIN_FLAG flags, bool fullScreen, IDXGIOutput* optRestrictToOutput = nullptr)
-        {
-            DXGI_SWAP_CHAIN_DESC1 desc{};
-            desc.Width = 0;
-            desc.Height = 0;
-            desc.Format = format;
-            desc.Stereo = false;
-            desc.SampleDesc.Count = 1;
-            desc.SampleDesc.Quality = 0;
-            desc.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT;
-            desc.BufferCount = (bufferCount < 2) ? 2 : bufferCount;
-            desc.Scaling = DXGI_SCALING_NONE;
-            desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-
-            //Through testing, this value with flip discard can only work with DXGI_ALPHA_MODE_UNSPECIFIED or DXGI_ALPHA_MODE_IGNORE
-            desc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
-            desc.Flags = flags | DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
-
-            DXGI_SWAP_CHAIN_FULLSCREEN_DESC fullscreenDesc{};
-            fullscreenDesc.RefreshRate.Denominator = fullscreenDesc.RefreshRate.Numerator = 0;
-            fullscreenDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
-            fullscreenDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
-            fullscreenDesc.Windowed = !fullScreen;
-
-            return Create<SwapChain>(factory, device, hWnd, desc, &fullscreenDesc, optRestrictToOutput);
-        }
-
-        template<class Resource = ID3D12Resource>
-        ComPtr<Resource> GetBuffer(IDXGISwapChain& swapChain, UINT index)
-        {
-            return IIDToObjectForwardFunction<Resource>(&IDXGISwapChain::GetBuffer, swapChain, index);
-        }
-    };
-}
+//module;
+//
+//#include <dxgi1_6.h>
+//#include <type_traits>
+//
+//#include <d3d12.h>
+//
+//
+//export module TypedD3D.Legacy.DXGIHelpers;
+//import TypedD3D.Shared;
+//
+//export namespace TypedD3D::Helpers::DXGI
+//{
+//    using Microsoft::WRL::ComPtr;
+//    namespace Factory
+//    {
+//        enum class CreationFlags
+//        {
+//            None = 0,
+//            Enable_Debug = DXGI_CREATE_FACTORY_DEBUG
+//        };
+//
+//        DEFINE_ENUM_FLAG_OPERATORS(CreationFlags);
+//
+//        template<class Factory = IDXGIFactory>
+//        ComPtr<Factory> Create(CreationFlags flags)
+//        {
+//
+//            if constexpr(std::is_same_v<Factory, IDXGIFactory>)
+//            {
+//                return IIDToObjectForwardFunction<IDXGIFactory>(&CreateDXGIFactory);
+//            }
+//            else if constexpr(std::is_same_v<Factory, IDXGIFactory1>)
+//            {
+//                return IIDToObjectForwardFunction<IDXGIFactory1>(&CreateDXGIFactory1);
+//            }
+//            else
+//            {
+//                if constexpr(std::is_same_v<Factory, IDXGIFactory2>)
+//                {
+//                    return IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory2, static_cast<UINT>(flags));
+//                }
+//                else
+//                {
+//                    return Cast<Factory>(IIDToObjectForwardFunction<IDXGIFactory2>(&CreateDXGIFactory2, static_cast<UINT>(flags)));
+//                }
+//            }
+//        }
+//    }
+//
+//    namespace SwapChain
+//    {
+//        template<class SwapChain = IDXGISwapChain1>
+//        ComPtr<SwapChain> Create(IDXGIFactory2& factory, IUnknown& device, HWND hWnd, const DXGI_SWAP_CHAIN_DESC1& desc, const DXGI_SWAP_CHAIN_FULLSCREEN_DESC* optFullscreenDesc = nullptr, IDXGIOutput* optRestrictToOutput = nullptr)
+//        {
+//            ComPtr<IDXGISwapChain1> swapChain;
+//            return Cast<SwapChain>(factory.CreateSwapChainForHwnd(&device, hWnd, &desc, optFullscreenDesc, optRestrictToOutput, &swapChain));
+//        }
+//
+//        template<class SwapChain = IDXGISwapChain1>
+//        ComPtr<SwapChain> CreateFlipDiscard(IDXGIFactory2& factory, IUnknown& device, HWND hWnd, DXGI_FORMAT format, UINT bufferCount, DXGI_SWAP_CHAIN_FLAG flags, bool fullScreen, IDXGIOutput* optRestrictToOutput = nullptr)
+//        {
+//            DXGI_SWAP_CHAIN_DESC1 desc{};
+//            desc.Width = 0;
+//            desc.Height = 0;
+//            desc.Format = format;
+//            desc.Stereo = false;
+//            desc.SampleDesc.Count = 1;
+//            desc.SampleDesc.Quality = 0;
+//            desc.BufferUsage = DXGI_USAGE_BACK_BUFFER | DXGI_USAGE_RENDER_TARGET_OUTPUT;
+//            desc.BufferCount = (bufferCount < 2) ? 2 : bufferCount;
+//            desc.Scaling = DXGI_SCALING_NONE;
+//            desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+//
+//            //Through testing, this value with flip discard can only work with DXGI_ALPHA_MODE_UNSPECIFIED or DXGI_ALPHA_MODE_IGNORE
+//            desc.AlphaMode = DXGI_ALPHA_MODE_UNSPECIFIED;
+//            desc.Flags = flags | DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+//
+//            DXGI_SWAP_CHAIN_FULLSCREEN_DESC fullscreenDesc{};
+//            fullscreenDesc.RefreshRate.Denominator = fullscreenDesc.RefreshRate.Numerator = 0;
+//            fullscreenDesc.ScanlineOrdering = DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED;
+//            fullscreenDesc.Scaling = DXGI_MODE_SCALING_UNSPECIFIED;
+//            fullscreenDesc.Windowed = !fullScreen;
+//
+//            return Create<SwapChain>(factory, device, hWnd, desc, &fullscreenDesc, optRestrictToOutput);
+//        }
+//
+//        template<class Resource = ID3D12Resource>
+//        ComPtr<Resource> GetBuffer(IDXGISwapChain& swapChain, UINT index)
+//        {
+//            return IIDToObjectForwardFunction<Resource>(&IDXGISwapChain::GetBuffer, swapChain, index);
+//        }
+//    };
+//}

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -32,7 +32,7 @@ namespace TypedD3D
 			throw std::runtime_error("Failed\n");
 	}
 
-	export template<IUnknownWrapper Wrapper, class BaseType = typename Wrapper::unknown_type, class Func, class... Args>
+	export template<IUnknownWrapper Wrapper, class BaseType = typename Wrapper::inner_type, class Func, class... Args>
 	Wrapper ForwardFunction(Func function, Args&&... args)
 	{
 		using BaseTrait = ReplaceInnerType<typename Wrapper::trait_type, BaseType>;
@@ -57,28 +57,21 @@ namespace TypedD3D
 		{
 			BaseWrapper unknown;
 			ThrowIfFailed(std::invoke(function, std::forward<Args>(args)..., OutPtr{ unknown }));
-			if constexpr(std::same_as<typename Wrapper::unknown_type, BaseType>)
+			if constexpr(std::same_as<typename Wrapper::inner_type, BaseType>)
 				return unknown;
 			else
-				return Cast<typename Wrapper::unknown_type>(std::move(unknown));
+				return Cast<typename Wrapper::inner_type>(std::move(unknown));
 		}
 		else
 		{
 			BaseWrapper unknown;
 			std::invoke(function, std::forward<Args>(args)..., OutPtr{ unknown });
-			if constexpr(std::same_as<typename Wrapper::unknown_type, BaseType>)
+			if constexpr(std::same_as<typename Wrapper::inner_type, BaseType>)
 				return unknown;
 			else
-				return Cast<typename Wrapper::unknown_type>(std::move(unknown));
+				return Cast<typename Wrapper::inner_type>(std::move(unknown));
 		}
 	}
-
-	export template<IUnknownTrait Trait>
-	struct InterfaceBase
-	{
-		InterfaceProxy<Trait>& ToDerived() { return static_cast<InterfaceProxy<Trait>&>(*this); }
-		InnerType<Trait>& Self() { return *ToDerived().InterfaceProxy<Trait>::Get(); }
-	};
 
 	export template<class Ty>
 	struct UntaggedTraits;

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -79,6 +79,7 @@ namespace TypedD3D
 	template<>
 	struct UntaggedTraits<ID3DBlob>
 	{
+		using inner_type = ID3DBlob;
 		template<class Derived>
 		using Interface = ID3DBlob*;
 	};
@@ -86,6 +87,7 @@ namespace TypedD3D
 	template<>
 	struct UntaggedTraits<IUnknown>
 	{
+		using inner_type = IUnknown;
 		template<class Derived>
 		using Interface = IUnknown*;
 	};

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -18,6 +18,9 @@ namespace TypedD3D
 	export template<class Base, class Ty, class Ty2>
 	concept DefineTraitRange = std::derived_from<Ty2, Ty> && ((std::derived_from<Base, Ty> && !std::derived_from<Base, Ty2>) || std::same_as<Base, Ty2>);
 
+	export template<template<class> class Ty, template<class> class Ty2>
+	concept SameTagAs = std::same_as<Ty<void>, Ty2<void>>;
+
 	export template<std::derived_from<IUnknown> To, std::derived_from<IUnknown> From>
 	To* Cast(From* from)
 	{
@@ -73,23 +76,63 @@ namespace TypedD3D
 		}
 	}
 
-	export template<class Ty>
-	struct UntaggedTraits;
+	//export template<class Ty>
+	//struct UntaggedTraits;
+
+	//template<>
+	//struct UntaggedTraits<ID3DBlob>
+	//{
+	//	using inner_type = ID3DBlob;
+	//	template<class Derived>
+	//	using Interface = ID3DBlob*;
+
+	//	template<class NewInner>
+	//	using trait_template = UntaggedTraits<NewInner>;
+	//};
+
+	//template<>
+	//struct UntaggedTraits<IUnknown>
+	//{
+	//	using inner_type = IUnknown;
+	//	template<class Derived>
+	//	using Interface = IUnknown*;
+
+	//	template<class NewInner>
+	//	using trait_template = UntaggedTraits<NewInner>;
+	//};
 
 	template<>
-	struct UntaggedTraits<ID3DBlob>
+	struct Trait<Untagged<ID3DBlob>>
 	{
 		using inner_type = ID3DBlob;
+
+		using inner_tag = ID3DBlob;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
 		template<class Derived>
 		using Interface = ID3DBlob*;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 	};
 
 	template<>
-	struct UntaggedTraits<IUnknown>
+	struct Trait<Untagged<IUnknown>>
 	{
 		using inner_type = IUnknown;
+
+		using inner_tag = IUnknown;
+
+		template<class NewInner>
+		using ReplaceInnerType = Untagged<NewInner>;
+
 		template<class Derived>
 		using Interface = IUnknown*;
+
+		template<class NewInner>
+		using trait_template = Untagged<NewInner>;
 	};
 
 	export template<class Ty>
@@ -101,7 +144,7 @@ namespace TypedD3D
 	export template<std::derived_from<IUnknown> Ty>
 	struct WrapperMapper<Ty>
 	{
-		using type = StrongWrapper<UntaggedTraits<Ty>>;
+		using type = StrongWrapper<Untagged<Ty>>;
 	};
 
 	export template<std::derived_from<IUnknown> Ty>

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -1,932 +1,114 @@
 module;
 
 #include <format>
-#include <wrl/client.h>
+#include <Unknwn.h>
 #include <minwindef.h>
 #include <concepts>
 #include <stdexcept>
-#include <array>
-#include <span>
-#include <vector>
+#include <d3dcommon.h>
 
 export module TypedD3D.Shared;
-import xk.Exceptions;
+export import :Containers;
 
 namespace TypedD3D
 {
-	export class ErrorModule
-	{
-	public:
-		using exception_tag = xk::ErrorModuleTag;
-	};
-}
+	export template<class Derived, class Base, class... Exceptions>
+	concept DerivedFromExcept = std::derived_from<Derived, Base> && ((!std::derived_from<Derived, Exceptions>) && ...);
 
-namespace xk
-{
-	template<>
-	struct ExceptionData<TypedD3D::ErrorModule>
-	{
-		HRESULT result;
-		std::string what;
+	export template<class Base, class Ty, class Ty2>
+	concept DefineTraitRange = std::derived_from<Ty2, Ty> && ((std::derived_from<Base, Ty> && !std::derived_from<Base, Ty2>) || std::same_as<Base, Ty2>);
 
-		ExceptionData(HRESULT result, std::string context) :
-			result{ result },
-			what{ std::format("HRESULT: {:x}. {}", result, context) }
-		{
-
-		}
-
-		std::string_view What() const noexcept { return what; }
-	};
-}
-
-namespace TypedD3D
-{
-	using Microsoft::WRL::ComPtr;
-
-	template<class T>
-	concept AlwaysFalse = false;
-
-	export template<class To, class From>
-		ComPtr<To> Cast(const ComPtr<From>& from)
-	{
-		ComPtr<To> to;
-		from.As(&to);
-		return to;
-	}
-
-	export template<class To, class From>
-		ComPtr<To> Cast(ComPtr<From>&& from) noexcept
-	{
-		ComPtr<To> to;
-		from.As(&to);
-		return to;
-	}
-
-	export template<class To, class From>
-		To* Cast(From* from)
+	export template<std::derived_from<IUnknown> To, std::derived_from<IUnknown> From>
+	To* Cast(From* from)
 	{
 		To* to;
 		from->QueryInterface(&to);
 		return to;
 	}
 
-	export void ThrowIfFailed(HRESULT hr, std::string context = "")
+	export void ThrowIfFailed(HRESULT result)
 	{
-		if (FAILED(hr))
-			throw xk::Exception<ErrorModule>{ { hr, context } };
+		if(FAILED(result))
+			throw std::runtime_error("Failed\n");
 	}
 
-	/// <summary>
-	/// Forwards a function which creates or gets an COM object which would require querying it's IID
-	/// </summary>
-	/// <typeparam name="Unknown"></typeparam>
-	/// <typeparam name="Func"></typeparam>
-	/// <typeparam name="Obj"></typeparam>
-	/// <typeparam name="...Args"></typeparam>
-	/// <param name="function">Function who's last 2 parameters is IID riid and void** ppv</param>
-	/// <param name="...args">All arguments not including the IID and void**</param>
-	/// <returns></returns>
-	export template<class Unknown, class Func, class... Args>
-		ComPtr<Unknown> IIDToObjectForwardFunction(Func&& function, Args&&... args)
+	export template<IUnknownWrapper Wrapper, class BaseType = typename Wrapper::unknown_type, class Func, class... Args>
+	Wrapper ForwardFunction(Func function, Args&&... args)
 	{
-		ComPtr<Unknown> unknown;
+		using BaseTrait = ReplaceInnerType<typename Wrapper::trait_type, BaseType>;
+		using BaseWrapper = ReplaceInnerType<Wrapper, BaseTrait>;
+		static constexpr bool InvokeIID = requires(Wrapper w) { { std::invoke(function, std::forward<Args>(args)..., __uuidof(Wrapper), OutPtr{ w }) } -> std::convertible_to<HRESULT>; };
+		static constexpr bool InvokeVoidIID = requires(Wrapper w) { { std::invoke(function, std::forward<Args>(args)..., __uuidof(Wrapper), OutPtr{ w }) } -> std::same_as<void>; };
+		static constexpr bool InvokeHRESULT = requires(BaseWrapper w) { { std::invoke(function, std::forward<Args>(args)..., OutPtr{ w }) } -> std::convertible_to<HRESULT>; };
 
-		constexpr bool invocableHRESULT = requires() { { std::invoke(function, args..., IID_PPV_ARGS(&unknown)) } -> std::convertible_to<HRESULT>; };
-		constexpr bool invocableVoid = requires() { { std::invoke(function, args..., IID_PPV_ARGS(&unknown)) } -> std::same_as<void>; };
+		if constexpr(InvokeIID)
+		{
+			Wrapper unknown;
+			ThrowIfFailed(std::invoke(function, std::forward<Args>(args)..., __uuidof(unknown), OutPtr{ unknown }));
+			return unknown;
+		}
+		else if constexpr(InvokeVoidIID)
+		{
+			Wrapper unknown;
+			std::invoke(function, std::forward<Args>(args)..., __uuidof(unknown), OutPtr{ unknown });
+			return unknown;
+		}
 
-		if constexpr (invocableHRESULT)
-			ThrowIfFailed(std::invoke(function, args..., IID_PPV_ARGS(&unknown)));
-		else if constexpr (invocableVoid)
-			std::invoke(function, args..., IID_PPV_ARGS(&unknown));
+
+		BaseWrapper unknown;
+		if constexpr(InvokeHRESULT)
+		{
+			ThrowIfFailed(std::invoke(function, std::forward<Args>(args)..., OutPtr{ unknown }));
+		}
 		else
-			static_assert(std::invocable<Func, Args..., const IID&, void**> && AlwaysFalse<Func>, "Forward function has some different return type that isn't handled properly");
+		{
+			std::invoke(function, std::forward<Args>(args)..., OutPtr{ unknown });
+		}
 
-		return unknown;
-	}
-
-	/// <summary>
-	/// Forwards a function which creates or gets an COM object
-	/// </summary>
-	/// <typeparam name="Unknown"></typeparam>
-	/// <typeparam name="Func"></typeparam>
-	/// <typeparam name="Obj"></typeparam>
-	/// <typeparam name="...Args"></typeparam>
-	/// <param name="function">Function who's last parameter inherits IUnknown</param>
-	/// <param name="...args">All arguments not including the IUnknown param</param>
-	/// <returns></returns>
-	export template<class Unknown, class Func, class... Args>
-		ComPtr<Unknown> UnknownObjectForwardFunction(Func&& function, Args&&... args)
-	{
-		ComPtr<Unknown> unknown;
-
-		constexpr bool invocableHRESULT = requires() { { std::invoke(function, args..., &unknown) } -> std::convertible_to<HRESULT>; };
-		constexpr bool invocableVoid = requires() { { std::invoke(function, args..., &unknown) } -> std::same_as<void>; };
-
-		if constexpr (invocableHRESULT)
-			ThrowIfFailed(std::invoke(function, args..., &unknown));
-		else if constexpr (invocableVoid)
-			std::invoke(function, args..., &unknown);
+		if constexpr(std::same_as<typename Wrapper::unknown_type, BaseType>)
+			return unknown;
 		else
-			static_assert(std::invocable<Func, Args..., const IID&, void**> && AlwaysFalse<Func>, "Forward function has some different return type that isn't handled properly");
-
-		return unknown;
+			return Cast<typename Wrapper::unknown_type>(std::move(unknown));
 	}
 
-	export template<class Ty>
-	constexpr bool is_unknown_wrapper = false;
-
-	template<class Ty>
-	struct GetTraitTemplate : std::false_type {};
-
-	template<template<class> class Trait, class Ty>
-	struct GetTraitTemplate<Trait<Ty>> : std::true_type
+	export template<IUnknownTrait Trait>
+	struct InterfaceBase
 	{
-		template<class T>
-		using type = Trait<T>;
-	};
-
-	template<class Ty>
-	concept IsTrait = (GetTraitTemplate<Ty>::value == true);
-
-	template<class A, class B, class Ty>
-	concept IsSameTrait = std::same_as<typename GetTraitTemplate<A>::template type<Ty>, typename GetTraitTemplate<B>::template type<Ty>>;
-
-	export template<class Ty, IsTrait Traits>
-	class IUnknownWrapperImpl
-	{
-		template<class OtherTy, IsTrait OtherTrait>
-		friend class IUnknownWrapperImpl;
-
-	public:
-		using value_type = Ty;
-		using pointer = Ty*;
-		using reference = Ty&;
-
-	public:
-		template<class Ty2>
-		using traits_template_type = GetTraitTemplate<Traits>::template type<Ty2>;
-		using traits_type = Traits;
-
-	private:
-		struct Impl;
-		using interface_type = traits_type::template Interface<Impl>;
-
-		struct Impl : public interface_type
-		{
-			ComPtr<value_type> ptr;
-
-			Impl() = default;
-
-			template<class U>
-			Impl(U* obj) : ptr{ obj }
-			{
-
-			}
-
-			Impl(const Microsoft::WRL::ComPtr<Ty>& other) : ptr{ other }
-			{
-			}
-
-			Impl(Microsoft::WRL::ComPtr<Ty>&& other) noexcept : ptr{ std::move(other) }
-			{
-			}
-
-			template<class OtherTy>
-			Impl(const Microsoft::WRL::ComPtr<OtherTy>& other) : ptr{ other }
-			{
-			}
-
-			template<class OtherTy>
-			Impl(Microsoft::WRL::ComPtr<OtherTy>&& other) noexcept : ptr{ std::move(other) }
-			{
-			}
-
-			pointer Get() { return ptr.Get(); }
-			pointer Get() const { return ptr.Get(); }
-		};
-
-		Impl impl;
-
-	public:
-		IUnknownWrapperImpl() = default;
-		IUnknownWrapperImpl(const IUnknownWrapperImpl& other) = default;
-		IUnknownWrapperImpl(IUnknownWrapperImpl&& other) noexcept = default;
-
-		template<class OtherTy, class OtherTraits>
-			requires IsSameTrait<Traits, OtherTraits, Ty>
-		IUnknownWrapperImpl(const IUnknownWrapperImpl<OtherTy, OtherTraits>& other) : impl{ other.impl.ptr }
-		{
-		}
-
-		template<class OtherTy, class OtherTraits>
-			requires IsSameTrait<Traits, OtherTraits, Ty>
-		IUnknownWrapperImpl(IUnknownWrapperImpl<OtherTy, OtherTraits>&& other) noexcept : impl{ std::move(other).impl.ptr }
-		{
-		}
-
-		IUnknownWrapperImpl(std::nullptr_t) {};
-
-		template<class U>
-		IUnknownWrapperImpl(U* obj) : impl{ obj }
-		{
-		}
-
-		IUnknownWrapperImpl(const Microsoft::WRL::ComPtr<Ty>& other) : impl{ other }
-		{
-		}
-
-		IUnknownWrapperImpl(Microsoft::WRL::ComPtr<Ty>&& other) noexcept : impl{ std::move(other) }
-		{
-		}
-
-		template<class OtherTy>
-		IUnknownWrapperImpl(const Microsoft::WRL::ComPtr<OtherTy>& other) : impl{ other }
-		{
-		}
-
-		template<class OtherTy>
-		IUnknownWrapperImpl(Microsoft::WRL::ComPtr<OtherTy>&& other) noexcept : impl{ std::move(other) }
-		{
-		}
-
-	public:
-		IUnknownWrapperImpl& operator=(const IUnknownWrapperImpl& other) = default;
-		IUnknownWrapperImpl& operator=(IUnknownWrapperImpl&& other) noexcept = default;
-
-		IUnknownWrapperImpl& operator=(std::nullptr_t)
-		{
-			impl.ptr = nullptr;
-			return *this;
-		}
-
-		template<class OtherTy>
-		IUnknownWrapperImpl& operator=(const IUnknownWrapperImpl<OtherTy, Traits>& other)
-		{
-			impl.ptr = other.impl.ptr;
-			return *this;
-		}
-
-		template<class OtherTy>
-		IUnknownWrapperImpl& operator=(IUnknownWrapperImpl<OtherTy, Traits>&& other) noexcept
-		{
-			impl.ptr = std::move(other).impl.ptr;
-			return *this;
-		}
-
-	public:
-		friend bool operator==(const IUnknownWrapperImpl& lh, std::nullptr_t)
-		{
-			//I dunno why, but for some reason in certain scenarios, the comparison of ComPtrs in this function instead calls ComPtr::operator Details::BoolType()
-			//instead of ComPtr::operator==, so I'll just manually compare pointers instead.
-			return lh.impl.ptr.Get() == nullptr;
-		}
-		friend bool operator!=(const IUnknownWrapperImpl& lh, std::nullptr_t)
-		{
-			//I dunno why, but for some reason in certain scenarios, the comparison of ComPtrs in this function instead calls ComPtr::operator Details::BoolType()
-			//instead of ComPtr::operator==, so I'll just manually compare pointers instead.
-			return lh.impl.ptr.Get() != nullptr;
-		}
-
-		template<class OtherTy, IsSameTrait<Traits, Ty> OtherTraits>
-		friend bool operator==(const IUnknownWrapperImpl& lh, const IUnknownWrapperImpl<OtherTy, OtherTraits>& rh)
-		{
-			//I dunno why, but for some reason in certain scenarios, the comparison of ComPtrs in this function instead calls ComPtr::operator Details::BoolType()
-			//instead of ComPtr::operator==, so I'll just manually compare pointers instead.
-			return lh.impl.ptr.Get() == rh.impl.ptr.Get();
-		}
-
-		template<class OtherTy, IsSameTrait<Traits, Ty> OtherTraits>
-		friend bool operator!=(const IUnknownWrapperImpl& lh, const IUnknownWrapperImpl<OtherTy, OtherTraits>& rh)
-		{
-			//I dunno why, but for some reason in certain scenarios, the comparison of ComPtrs in this function instead calls ComPtr::operator Details::BoolType()
-			//instead of ComPtr::operator==, so I'll just manually compare pointers instead.
-			return lh.impl.ptr.Get() != rh.impl.ptr.Get();
-		}
-
-		operator bool() const { return impl.ptr != nullptr; }
-
-	public:
-		pointer Detach() { return impl.ptr.Detach(); }
-
-		void Attach(pointer p)
-		{
-			impl.ptr.Attach(p);
-		}
-
-		pointer Get() { return impl.ptr.Get(); }
-		pointer Get() const { return impl.ptr.Get(); }
-
-		void Swap(IUnknownWrapperImpl& other) noexcept
-		{
-			impl.ptr.Swap(other.impl.ptr);
-		}
-		pointer* GetAddressOf() { return impl.ptr.GetAddressOf(); }
-		const pointer* GetAddressOf() const { return impl.ptr.GetAddressOf(); }
-		interface_type* operator->() { return &impl; }
-		const interface_type* operator->() const { return &impl; }
-		Microsoft::WRL::ComPtr<value_type> AsComPtr() const { return impl.ptr; }
-
-		template<std::derived_from<IUnknown> DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-		friend IUnknownWrapperImpl<DerivedTy, typename GetTraitTemplate<Traits>::template type<DerivedTy>> Cast(const IUnknownWrapperImpl<Ty, Traits>& other) noexcept;
-
-		template<std::derived_from<IUnknown> DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-		friend IUnknownWrapperImpl<DerivedTy, typename GetTraitTemplate<Traits>::template type<DerivedTy>> Cast(IUnknownWrapperImpl<Ty, Traits>&& other) noexcept;
-
-		template<class DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-			requires is_unknown_wrapper<DerivedTy> && IsSameTrait<typename DerivedTy::traits_type, Traits, Ty>
-		friend DerivedTy Cast(const IUnknownWrapperImpl<Ty, Traits>& other) noexcept;
-
-		template<class DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-			requires is_unknown_wrapper<DerivedTy> && IsSameTrait<typename DerivedTy::traits_type, Traits, Ty>
-		friend DerivedTy Cast(IUnknownWrapperImpl<Ty, Traits>&& other) noexcept;
-	};
-
-	export template<class Ty, class Traits>
-	constexpr bool is_unknown_wrapper<IUnknownWrapperImpl<Ty, Traits>> = true;
-
-	export template<class Ty, class Traits>
-	constexpr bool is_unknown_wrapper<const IUnknownWrapperImpl<Ty, Traits>> = true;
-
-	export template<class Ty, template<class> class Traits>
-	using IUnknownWrapper = IUnknownWrapperImpl<Ty, Traits<Ty>>;
-
-	
-	export template<std::derived_from<IUnknown> DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-	IUnknownWrapperImpl<DerivedTy, typename GetTraitTemplate<Traits>::template type<DerivedTy>> Cast(const IUnknownWrapperImpl<Ty, Traits>& other) noexcept
-	{
-		return { Cast<DerivedTy>(other.impl.ptr) };
-	}
-
-	export template<std::derived_from<IUnknown> DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-	IUnknownWrapperImpl<DerivedTy, typename GetTraitTemplate<Traits>::template type<DerivedTy>> Cast(IUnknownWrapperImpl<Ty, Traits>&& other) noexcept
-	{
-		return { Cast<DerivedTy>(std::move(other.impl.ptr)) };
-	}
-
-	export template<class DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-		requires is_unknown_wrapper<DerivedTy> && IsSameTrait<typename DerivedTy::traits_type, Traits, Ty>
-	DerivedTy Cast(const IUnknownWrapperImpl<Ty, Traits>& other) noexcept
-	{
-		return { Cast<typename DerivedTy::value_type>(other.impl.ptr) };
-	}
-
-	export template<class DerivedTy, std::derived_from<IUnknown> Ty, class Traits>
-		requires is_unknown_wrapper<DerivedTy> && IsSameTrait<typename DerivedTy::traits_type, Traits, Ty>
-	DerivedTy Cast(IUnknownWrapperImpl<Ty, Traits>&& other) noexcept
-	{
-		return { Cast<typename DerivedTy::value_type>(std::move(other.impl.ptr)) };
-	}
-
-	export template<class Ty, bool IsConst>
-		requires is_unknown_wrapper<Ty>
-	class ElementReferenceT
-	{
-		using value_type = Ty::value_type;
-		using pointer = Ty::pointer;
-		using reference = Ty::reference;
-
-		struct Ref;
-		using interface_type = Ty::traits_type::template Interface<Ref>;
-		struct Ref : public interface_type
-		{
-			pointer& ptr;
-
-			pointer Get() { return ptr; }
-			pointer Get() const { return ptr; }
-
-			Ref() = default;
-			Ref(pointer& ptr) :
-				ptr{ ptr }
-			{
-
-			}
-
-			Ref& operator=(std::nullptr_t) requires (!IsConst)
-			{
-				if (ptr)
-					ptr->Release();
-				ptr = nullptr;
-
-				return *this;
-			}
-
-			Ref& operator=(const Ty& other) requires (!IsConst)
-			{
-				if (ptr)
-					ptr->Release();
-				ptr = other.Get();
-				if (ptr)
-					ptr->AddRef();
-				return *this;
-			}
-
-			Ref& operator=(Ty&& other) noexcept requires (!IsConst)
-			{
-				if (ptr)
-					ptr->Release();
-				ptr = other.Detach();
-				return *this;
-			}
-
-			Ref& operator=(const Ref& other) requires (!IsConst)
-			{
-				if (ptr)
-					ptr->Release();
-				ptr = other.Get();
-				if (ptr)
-					ptr->AddRef();
-				return *this;
-			}
-
-			Ref& operator=(Ref&& other) noexcept requires (!IsConst)
-			{
-				if (ptr)
-					ptr->Release();
-				ptr = std::exchange(other.ptr, nullptr);
-				return *this;
-			}
-
-			void Swap(Ty& other) noexcept requires (!IsConst)
-			{
-				other.Attach(std::exchange(ptr, other.Detach()));
-			}
-		};
-
-
-		Ref ref;
-
-	public:
-		ElementReferenceT(pointer& ptr) :
-			ref{ ptr }
-		{
-		}
-
-		ElementReferenceT(Ty& ptr) :
-			ref{ ptr.GetAddressOf() }
-		{
-
-		}
-
-		ElementReferenceT& operator=(std::nullptr_t) requires (!IsConst)
-		{
-			ref = nullptr;
-			return *this;
-		}
-
-		ElementReferenceT& operator=(const Ty& other)  requires (!IsConst)
-		{
-			ref = other;
-			return *this;
-		}
-
-		ElementReferenceT& operator=(Ty&& other) noexcept requires (!IsConst)
-		{
-			ref = std::move(other);
-			return *this;
-		}
-
-		ElementReferenceT& operator=(const ElementReferenceT& other)  requires (!IsConst)
-		{
-			ref = other.ref;
-			return *this;
-		}
-
-		ElementReferenceT& operator=(ElementReferenceT&& other) noexcept requires (!IsConst)
-		{
-			ref = std::move(other).ref;
-			return *this;
-		}
-
-		void Swap(Ty& other) noexcept requires (!IsConst)
-		{
-			ref.Swap(other);
-		}
-
-		pointer Get() { return ref.ptr; }
-		pointer Get() const { return ref.ptr; }
-		pointer Detach()  requires (!IsConst) { return std::exchange(ref.ptr, nullptr); }
-
-		void Attach(pointer p) requires (!IsConst)
-		{
-			if (ref.ptr)
-				ref.ptr->Release();
-
-			ref.ptr = p;
-		}
-
-		Ty ToWrapper() const { return Ty{ ref.ptr }; }
-
-		template<class OtherTy>
-			requires std::convertible_to<Ty, OtherTy>
-		operator OtherTy() const& { return OtherTy{ ref.ptr }; }
-
-		interface_type* operator->() { return &ref; }
-		interface_type* operator->() const { return &ref; }
+		InterfaceProxy<Trait>& ToDerived() { return static_cast<InterfaceProxy<Trait>&>(*this); }
+		InnerType<Trait>& Self() { return *ToDerived().InterfaceProxy<Trait>::Get(); }
 	};
 
 	export template<class Ty>
-		using ElementReference = ElementReferenceT<Ty, false>;
+	struct UntaggedTraits;
 
-	export template<class Ty>
-		using ConstElementReference = ElementReferenceT<Ty, true>;
-
-
-
-	export template<class Ty, size_t Extent>
-		requires is_unknown_wrapper<Ty>
-	class Array
+	template<>
+	struct UntaggedTraits<ID3DBlob>
 	{
-	public:
-		using value_type = Ty::pointer;
-		using pointer = Ty::pointer*;
-		using reference = Ty::reference;
-
-	public:
-		template<class Ty2>
-		using traits_template_type = Ty::template traits_template_type<Ty2>;
-		using traits_type = Ty::traits_type;
-
-	public:
-		std::array<value_type, Extent> _values{};
-
-		Array() = default;
-
-		Array(const Array& other) :
-			_values{ other._values }
-		{
-			for (value_type p : _values)
-			{
-				if (p)
-				{
-					auto foo = p->AddRef();
-					int i = 0;
-				}
-			}
-		}
-
-		Array(Array&& other) noexcept
-		{
-			for (size_t i = 0; i < Extent; i++)
-			{
-				std::swap(other._values[i], _values[i]);
-			}
-		}
-
-		template<std::convertible_to<Ty>... Ty2>
-		Array(Ty2... values) :
-			_values{ values.Get()... }
-		{
-			for (value_type p : _values)
-			{
-				if (p)
-				{
-					auto foo = p->AddRef();
-					int i = 0;
-				}
-			}
-		}
-
-		~Array()
-		{
-			for (value_type p : _values)
-			{
-				if (p)
-				{
-					auto foo = p->Release();
-					int i = 0;
-				}
-			}
-		}
-
-		Array& operator=(const Array& other)
-		{
-			Array temp{ other };
-			_values.swap(temp._values);
-			return *this;
-		}
-
-		Array& operator=(Array&& other) noexcept
-		{
-			Array temp{ std::move(other) };
-			_values.swap(temp._values);
-			return *this;
-		}
-
-	public:
-		ElementReference<Ty> operator[](size_t index)
-		{
-			return { _values[index] };
-		}
-
-		ConstElementReference<Ty> operator[](size_t index) const
-		{
-			return { _values[index] };
-		}
-
-		explicit operator std::array<value_type, Extent>() const { return _values; }
-	public:
-		ElementReference<Ty> at(size_t index) { return { _values.at(index) }; }
-		ElementReference<Ty> front() { return { _values.front() }; }
-		ElementReference<Ty> back() { return { _values.back() }; }
-
-		ConstElementReference<Ty> at(size_t index) const { return { _values.at(index) }; }
-		ConstElementReference<Ty> front() const { return { _values.front() }; }
-		ConstElementReference<Ty> back() const { return { _values.back() }; }
-		pointer data() noexcept { return _values.data(); }
-		const pointer data() const noexcept { return _values.data(); }
-		size_t size() const noexcept { return _values.size(); }
-		bool empty() const noexcept { return _values.empty(); }
-		bool max_size() const noexcept { return _values.max_size(); }
-
-		std::array<value_type, Extent> ToUntyped() const { return _values; }
-	};
-
-	export template<class Ty, class Allocator = std::allocator<typename Ty::pointer>>
-		requires is_unknown_wrapper<Ty>
-	class Vector
-	{
-	public:
-		using wrapper_type = Ty;
-		using value_type = Ty::pointer;
-		using pointer = Ty::pointer*;
-		using reference = Ty::reference;
-
-	public:
-		template<class Ty2>
-		using traits_template_type = Ty::template traits_template_type<Ty2>;
-		using traits_type = Ty::traits_type;
-
-	private:
-		std::vector<value_type, Allocator> _values;
-
-	public:
-		Vector() = default;
-		Vector(const Vector& other) :
-			_values{ other._values }
-		{
-			for (Ty v : _values)
-			{
-				if (v)
-					v.Get()->AddRef();
-			}
-		}
-
-		Vector(Vector&& other) noexcept
-		{
-			for (size_t i = 0; i < _values.size(); i++)
-			{
-				std::swap(other._values[i], _values[i]);
-			}
-		}
-
-		Vector(std::initializer_list<Ty> list)
-		{
-			for (Ty v : list)
-			{
-				push_back(v);
-
-				if(v)
-					v.Get()->AddRef();
-			}
-		}
-
-		~Vector()
-		{
-			for (value_type v : _values)
-			{
-				if (v)
-					v->Release();
-			}
-		}
-
-		Vector& operator=(const Vector& other)
-		{
-			Vector temp{ other };
-			_values.swap(temp._values);
-			return *this;
-		}
-
-		Vector& operator=(Vector&& other) noexcept
-		{
-			Vector temp{ std::move(other) };
-			_values.swap(temp._values);
-			return *this;
-		}
-
-	public:
-		ElementReference<Ty> operator[](size_t index)
-		{
-			return { _values[index] };
-		}
-
-		ConstElementReference<Ty> operator[](size_t index) const
-		{
-			return { _values[index] };
-		}
-
-		explicit operator std::vector<value_type, Allocator>() const { return _values; }
-	public:
-		ElementReference<Ty> at(size_t index) { return { _values.at(index) }; }
-		ElementReference<Ty> front() { return { _values.front() }; }
-		ElementReference<Ty> back() { return { _values.back() }; }
-
-		ConstElementReference<Ty> at(size_t index) const { return { _values.at(index) }; }
-		ConstElementReference<Ty> front() const { return { _values.front() }; }
-		ConstElementReference<Ty> back() const { return { _values.back() }; }
-		auto data() noexcept { return _values.data(); }
-		const auto data() const noexcept { return _values.data(); }
-		size_t size() const noexcept { return _values.size(); }
-		bool empty() const noexcept { return _values.empty(); }
-		bool max_size() const noexcept { return _values.max_size(); }
-		void reserve(size_t count) { _values.reserve(count); }
-		size_t capacity() { return _values.capacity(); }
-
-		void push_back(const Ty& value) { _values.push_back(value.Get()); }
-		void push_back(Ty&& value) { _values.push_back(value.Detach()); }
-		void pop_back() { _values.pop_back(); }
-
-		void swap(Vector& other) noexcept { _values.swap(other._values); }
-		void resize(size_t count) noexcept { _values.resize(count); }
-		void resize(size_t count, const Ty& value) noexcept { _values.resize(count, value.Get()); }
-		void clear() { _values.clear(); }
-
-		std::vector<value_type, Allocator> ToUntyped() const { return _values; }
-	};
-
-	export template<class Ty, size_t Extent = std::dynamic_extent>
-		requires is_unknown_wrapper<Ty>
-	class Span
-	{
-
-	public:
-		using value_type = std::conditional_t<std::is_const_v<Ty>, const typename Ty::pointer, typename Ty::pointer>;
-		using pointer = Ty::pointer*;
-		using reference = Ty::reference;
-
-	public:
-		template<class Ty2>
-		using traits_template_type = Ty::template traits_template_type<Ty2>;
-		using traits_type = Ty::traits_type;
-
-	private:
-		std::span<value_type, Extent> m_span;
-
-	public:
-		Span() requires (Extent == std::dynamic_extent) = default;
-
-		template<size_t OtherExtent>
-			requires(OtherExtent == Extent || Extent == std::dynamic_extent)
-		Span(Array<Ty, OtherExtent>& arr) :
-			m_span{ arr.data(), arr.size() }
-		{
-
-		}
-
-		explicit(Extent != std::dynamic_extent)
-			Span(pointer p, size_t count) :
-			m_span{ p, count }
-		{
-
-		}
-		template<class Range>
-		explicit(Extent != std::dynamic_extent)
-		Span(Range&& range) :
-			m_span{ range.data(), range.size() }
-		{
-
-		}
-	public:
-		ElementReference<Ty> operator[](size_t index)
-		{
-			return { m_span[index] };
-		}
-
-		ConstElementReference<Ty> operator[](size_t index) const
-		{
-			return { m_span[index] };
-		}
-
-	public:
-		ElementReference<Ty> front() { return { m_span.front() }; }
-		ElementReference<Ty> back() { return { m_span.back() }; }
-
-		ConstElementReference<Ty> front() const { return { m_span.front() }; }
-		ConstElementReference<Ty> back() const { return { m_span.back() }; }
-		auto data() const noexcept { return m_span.data(); }
-		size_t size() const noexcept { return m_span.size(); }
-
-
-		std::span<pointer, Extent> ToUntyped() const { return m_span; }
-	};
-
-	template<class Ty, size_t Extent>
-	Span(Array<Ty, Extent>&) -> Span<Ty, Extent>;
-
-	template<class Range>
-	Span(Range&&) -> Span<typename Range::wrapper_type>;
-
-	template<class Range>
-	Span(const Range&) -> Span<const typename Range::wrapper_type>;
-
-	export template<class Ty>
-		struct UntaggedTraits
-	{
-		using unknown_type = Ty;
-
 		template<class Derived>
-		using Interface = Ty*;
+		using Interface = ID3DBlob*;
 	};
 
-	//template<std::derived_from<IUnknown> Ty>
-	//struct UntaggedTraits<Ty>
-	//{
-	//	using unknown_type = Ty;
-
-	//	template<class Derived>
-	//	using Interface = Ty*;
-	//};
+	export template<class Ty>
+	struct WrapperMapper;
 
 	export template<class Ty>
-		struct WrapperMapper;
+	struct WrapperViewMapper;
 
-	template<std::derived_from<IUnknown> Ty>
+	export template<std::derived_from<IUnknown> Ty>
 	struct WrapperMapper<Ty>
 	{
-		using type = IUnknownWrapper<Ty, UntaggedTraits>;
+		using type = StrongWrapper<UntaggedTraits<Ty>>;
+	};
+
+	export template<std::derived_from<IUnknown> Ty>
+	struct WrapperViewMapper<Ty>
+	{
+		using type = ReplaceOuterType<typename WrapperMapper<Ty>::type, WeakWrapper>;
 	};
 
 	export template<class Ty>
-		using Wrapper = WrapperMapper<Ty>::type;
+	using Wrapper = WrapperMapper<Ty>::type;
 
-
-
-	template<auto Func>
-	struct GetDescriptionHelper;
-
-	template<class ObjTy, class RetVal, class OutVal, RetVal(ObjTy::* Func)(OutVal)>
-	struct GetDescriptionHelper<Func>
-	{
-		using ret_type = RetVal;
-		using type = std::remove_pointer_t<OutVal>;
-
-		static type GetDescription(ObjTy& obj)
-		{
-			type desc;
-			std::invoke(Func, obj, &desc);
-			return desc;
-		}
-	};
-
-	template<class ObjTy, class RetVal, RetVal(ObjTy::* Func)()>
-	struct GetDescriptionHelper<Func>
-	{
-		using ret_type = RetVal;
-		using type = std::remove_pointer_t<RetVal>;
-
-		static type GetDescription(ObjTy& obj)
-		{
-			return std::invoke(Func, obj);
-		}
-	};
-
-	template<class T>
-	concept HasDesc1 = requires(T v, typename GetDescriptionHelper<&T::GetDesc1>::type d1)
-	{
-		{ v.GetDesc1(&d1) } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc1>::ret_type>;
-	} || requires(T v)
-	{
-		{ v.GetDesc1() } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc1>::ret_type>;
-	};
-
-	template<class T>
-	concept HasDesc2 = requires(T v, typename GetDescriptionHelper<&T::GetDesc2>::type d)
-	{
-		{ v.GetDesc2(&d) } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc2>::ret_type>;
-	} || requires(T v)
-	{
-		{ v.GetDesc2() } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc2>::ret_type>;
-	};
-
-	template<class T>
-	concept HasDesc3 = requires(T v, typename GetDescriptionHelper<&T::GetDesc3>::type d)
-	{
-		{ v.GetDesc3(&d) } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc3>::ret_type>;
-	} || requires(T v)
-	{
-		{ v.GetDesc3() } -> std::same_as<typename GetDescriptionHelper<&T::GetDesc3>::ret_type>;
-	};
-
-	export template<class IDXGIObj>
-		auto GetDescription(IDXGIObj& obj)
-	{
-		if constexpr (HasDesc3<IDXGIObj>)
-			return GetDescriptionHelper<&IDXGIObj::GetDesc3>::GetDescription(obj);
-		else if constexpr (HasDesc2<IDXGIObj>)
-			return GetDescriptionHelper<&IDXGIObj::GetDesc2>::GetDescription(obj);
-		else if constexpr (HasDesc1<IDXGIObj>)
-			return GetDescriptionHelper<&IDXGIObj::GetDesc1>::GetDescription(obj);
-		else
-			return GetDescriptionHelper<&IDXGIObj::GetDesc>::GetDescription(obj);
-	}
+	export template<class Ty>
+	using WrapperView = WrapperViewMapper<Ty>::type;
 }

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -147,6 +147,13 @@ namespace TypedD3D
 		using type = StrongWrapper<Untagged<Ty>>;
 	};
 
+	template<class Ty>
+		requires TypedStructTrait<Untagged<Ty>>
+	struct WrapperMapper<Ty>
+	{
+		using type = TypedStruct<Untagged<Ty>>;
+	};
+
 	export template<std::derived_from<IUnknown> Ty>
 	struct WrapperViewMapper<Ty>
 	{

--- a/TypedD3D/source/Shared.ixx
+++ b/TypedD3D/source/Shared.ixx
@@ -830,7 +830,22 @@ namespace TypedD3D
 	Span(const Range&) -> Span<const typename Range::wrapper_type>;
 
 	export template<class Ty>
-		struct UntaggedTraits;
+		struct UntaggedTraits
+	{
+		using unknown_type = Ty;
+
+		template<class Derived>
+		using Interface = Ty*;
+	};
+
+	//template<std::derived_from<IUnknown> Ty>
+	//struct UntaggedTraits<Ty>
+	//{
+	//	using unknown_type = Ty;
+
+	//	template<class Derived>
+	//	using Interface = Ty*;
+	//};
 
 	export template<class Ty>
 		struct WrapperMapper;

--- a/TypedD3D/source/TypedD3D11.ixx
+++ b/TypedD3D/source/TypedD3D11.ixx
@@ -10,9 +10,3 @@ export import :States;
 export import :Shaders;
 
 export namespace TypedD3D11 = TypedD3D::D3D11;
-
-namespace TypedD3D::D3D11
-{
-	export template<class Ty>
-	using Wrapper = TypedD3D::Wrapper<Ty>;
-}

--- a/TypedD3D/source/TypedD3D12.ixx
+++ b/TypedD3D/source/TypedD3D12.ixx
@@ -12,5 +12,4 @@ export import :D3D12Object;
 
 export namespace TypedD3D12 = TypedD3D::D3D12;
 
-//TODO: Remove inheriting the base traits for CommandLists, CommandAllocators, CommandQueues, DescriptorHeaps in order to reduce the visible names when compiling fails. This will result in more duplication, but it's a price for better debuggability
 //TODO: Finish migrating CommandLists API

--- a/TypedD3D/source/TypedD3D12.ixx
+++ b/TypedD3D/source/TypedD3D12.ixx
@@ -8,5 +8,9 @@ export import :PipelineState;
 export import :Resource;
 export import :Device;
 export import :Wrappers;
+export import :D3D12Object;
 
 export namespace TypedD3D12 = TypedD3D::D3D12;
+
+//TODO: Remove inheriting the base traits for CommandLists, CommandAllocators, CommandQueues, DescriptorHeaps in order to reduce the visible names when compiling fails. This will result in more duplication, but it's a price for better debuggability
+//TODO: Finish migrating CommandLists API

--- a/TypedD3D/source/TypedDXGI.ixx
+++ b/TypedD3D/source/TypedDXGI.ixx
@@ -1,13 +1,8 @@
 export module TypedDXGI;
 export import TypedD3D.Shared;
+export import :DXGIObject;
 export import :Adapter;
 export import :Factory;
 export import :SwapChain;
-
-namespace TypedD3D::DXGI
-{
-	export template<class Ty>
-		using Wrapper = TypedD3D::Wrapper<Ty>;
-}
 
 export namespace TypedDXGI = TypedD3D::DXGI;


### PR DESCRIPTION
- Implementation has been refactored as to remove as much duplication as possible that currently works in MSVC v143 latest, which overall simplifies the implementation, and as a plus side, stuff like `D3D12_COMMAND_LIST_TYPE` will no longer show up as part of the type name when errors occur
- Removed dependance on `ComPtr` internally in favor of implementing my own smart pointers to much more easily get a consistent implementation
- Bugfixed `Array` and `Vector` types, they were not properly incrementing or decrementing ref counts.
- Added a new weak ownership smart pointer `WrapperView`, which does not add or remove ref counts, but still have the wrapped interface available to it
- All unimplemented `IDXGIObject`, `ID3D12Object`, and `ID3D11DeviceChild` interfaces is now compatible with the library's smart pointers and will act like a `ComPtr` in doing so, so they won't have access to any of the wrapper APIs. This is so that you don't have to juggle using different smart pointers depending on whether a type has it implemented or not.
- Removed type aliases like `TypedD3D::D3D11::Device_t` as they're pretty useless and supporting them in various template APIs were just added unneeded complexity.
- Non `IUnknown` type wrappers are now internally implemented as a `TypedStruct` which mirrors the set up of the newly added smart pointers, this is so various type manipulation functions are consistent regardless of what is being wrapped.
- We can now range for loop `Span`, `Array` and `Vector`
- Added an `OutPtr` type so that we don't need to create a `GetAddressOf()` or `operator&` to our smart pointers